### PR TITLE
Move logging commit hash

### DIFF
--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -196,10 +196,16 @@ class Logger(object):  # pylint: disable=too-many-instance-attributes
         :param kwargs: to pass to logger
         """
         cur_thread = threading.currentThread().getName()
-        if sickbeard.CUR_COMMIT_HASH and len(sickbeard.CUR_COMMIT_HASH) > 6 and level in [ERROR, WARNING]:
-            msg += ' [%s]' % sickbeard.CUR_COMMIT_HASH[:7]
+        cur_hash = '[{}] '.format(sickbeard.CUR_COMMIT_HASH[:7]) if all([
+            sickbeard.CUR_COMMIT_HASH,
+            len(sickbeard.CUR_COMMIT_HASH) > 6,
+        ]) else ''
 
-        message = '%s :: %s' % (cur_thread, msg)
+        message = '{thread} :: {hash}{message}'.format(
+            thread = cur_thread,
+            hash = cur_hash,
+            message = msg
+        )
 
         # Change the SSL error to a warning with a link to information about how to fix it.
         # Check for u'error [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:590)'

--- a/tests/scene_helpers_tests.py
+++ b/tests/scene_helpers_tests.py
@@ -92,14 +92,12 @@ class SceneExceptionTestCase(test.SickbeardTestDBCase):
         """
         self.assertEqual(scene_exceptions.get_scene_exceptions(0), [])
 
-    @unittest.skip('Waiting new github page to get exceptions')
     def test_scene_ex_babylon_5(self):
         """
         Test scene exceptions for Babylon 5
         """
         self.assertEqual(sorted(scene_exceptions.get_scene_exceptions(70726)), ['Babylon 5', 'Babylon5'])
 
-    @unittest.skip('Waiting new github page to get exceptions')
     def test_scene_ex_by_name(self):
         """
         Test scene exceptions by name
@@ -109,14 +107,12 @@ class SceneExceptionTestCase(test.SickbeardTestDBCase):
         self.assertEqual(scene_exceptions.get_scene_exception_by_name('babylon 5'), (70726, -1))
         self.assertEqual(scene_exceptions.get_scene_exception_by_name('Carlos 2010'), (164451, -1))
 
-    @unittest.skip('Waiting new github page to get exceptions')
     def test_scene_ex_by_name_empty(self):
         """
         Test scene exceptions by name are empty
         """
         self.assertEqual(scene_exceptions.get_scene_exception_by_name('nothing useful'), (None, None))
 
-    @unittest.skip('Waiting new github page to get exceptions')
     def test_scene_ex_reset_name_cache(self):
         """
         Test scene exceptions reset name cache


### PR DESCRIPTION
Fixes # None

Proposed changes in this pull request:
- Move commit hash to beginning of log message
- Change commit hash to apply to all logs
- Re-enable disabled scene exception tests


- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

Re-enable skipped tests