### PR TITLE
Always write debug/db lines to log file

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -5241,8 +5241,6 @@ class ErrorLogs(WebRoot):
                 if match:
                     level = match.group(7)
                     logName = match.group(8)
-                    if not sickbeard.DEBUG and (level == 'DEBUG' or level == 'DB'):
-                        continue
                     if level not in logger.LOGGING_LEVELS:
                         lastLine = False
                         continue


### PR DESCRIPTION
So when user submit an error, gist will always have DEBUG level even if user don't have sickbeard.DEBUG enabled

too much hassle to ask user to reproduce error again with debug enabled

Setting sickbeard.DEBUG will only prevent from show in the UI.
if user wants to see in UI. just need to enabled. Don't need restart