### PR TITLE
Prevent logging "No results found" message

### DIFF
--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -127,8 +127,12 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
                     continue
 
                 error = data.get("error")
+                error_code = data.get("error_code")
+                # Don't log when {"error":"No results found","error_code":20}
+                # List of errors: https://github.com/rarbg/torrentapi/issues/1#issuecomment-114763312
                 if error:
-                    logger.log(error)
+                    if try_int(error_code) != 20:
+                        logger.log(error)
                     continue
 
                 torrent_results = data.get("torrent_results")


### PR DESCRIPTION
Not an actual error:
{"error":"No results found","error_code":20}

Prevents: https://gist.github.com/fernandog/cd67490ba247380ce4b5