### PR TITLE
Fix double logging

### DIFF
--- a/sickbeard/providers/bitsnoop.py
+++ b/sickbeard/providers/bitsnoop.py
@@ -67,7 +67,7 @@ class BitSnoopProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
 
                     logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                    data = self.get_url(search_url)
+                    data = self.get_url(search_url, echo=False, returns='text')
                     if not data:
                         logger.log(u"No data returned from provider", logger.DEBUG)
                         continue

--- a/sickbeard/providers/cpasbien.py
+++ b/sickbeard/providers/cpasbien.py
@@ -57,7 +57,7 @@ class CpasbienProvider(TorrentProvider):
                     search_url = self.url + '/view_cat.php?categorie=series&trie=date-d'
 
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     continue
 

--- a/sickbeard/providers/danishbits.py
+++ b/sickbeard/providers/danishbits.py
@@ -120,7 +120,7 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                 search_url = "%s?%s" % (self.urls['search'], urlencode(search_params))
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/elitetorrent.py
+++ b/sickbeard/providers/elitetorrent.py
@@ -91,7 +91,7 @@ class elitetorrentProvider(TorrentProvider):
                 search_url = self.urls['search'] + '?' + urllib.parse.urlencode(self.search_params)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url, timeout=30)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     continue
 

--- a/sickbeard/providers/extratorrent.py
+++ b/sickbeard/providers/extratorrent.py
@@ -68,7 +68,7 @@ class ExtraTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url, params=self.search_params)
+                data = self.get_url(search_url, params=self.search_params, echo=False, returns='text')
                 if not data:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/freshontv.py
+++ b/sickbeard/providers/freshontv.py
@@ -121,7 +121,7 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
                 search_url = self.urls['search'] % (freeleech, search_string)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
-                init_html = self.get_url(search_url)
+                init_html = self.get_url(search_url, echo=False, returns='text')
                 max_page_number = 0
 
                 if not init_html:

--- a/sickbeard/providers/gftracker.py
+++ b/sickbeard/providers/gftracker.py
@@ -133,7 +133,7 @@ class GFTrackerProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                 search_url = "%s?%s" % (self.urls['search'], urlencode(search_params))
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/hd4free.py
+++ b/sickbeard/providers/hd4free.py
@@ -80,7 +80,7 @@ class HD4FreeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                 search_url = self.urls['search'] + "?" + urlencode(search_params)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                jdata = self.get_url(search_url, json=True)
+                jdata = self.get_url(search_url, json=True, echo=False)
                 if not jdata:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -88,7 +88,7 @@ class HDBitsProvider(TorrentProvider):
 
         self._check_auth()
 
-        parsedJSON = self.get_url(self.urls['search'], post_data=search_params, json=True)
+        parsedJSON = self.get_url(self.urls['search'], post_data=search_params, json=True, echo=False)
         if not parsedJSON:
             return []
 

--- a/sickbeard/providers/hdspace.py
+++ b/sickbeard/providers/hdspace.py
@@ -105,7 +105,7 @@ class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                     logger.log(u"Search string: {}".format(search_string.decode("utf-8")),
                                logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data or 'please try later' in data:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -103,7 +103,7 @@ class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data or 'please try later' in data:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -106,7 +106,7 @@ class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                 search_url += ';o=seeders' if mode != 'RSS' else ''
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     continue
 

--- a/sickbeard/providers/limetorrents.py
+++ b/sickbeard/providers/limetorrents.py
@@ -69,7 +69,7 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
                     logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                    data = self.get_url(search_url)
+                    data = self.get_url(search_url, echo=False, returns='text')
                     if not data:
                         logger.log(u"No data returned from provider", logger.DEBUG)
                         continue

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -133,7 +133,7 @@ class MoreThanTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                 search_url = "%s?%s" % (self.urls['search'], urlencode(search_params))
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -283,7 +283,7 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
                 logger.log(u"Search URL: {url}".format(url=search_url), logger.DEBUG)
 
                 time.sleep(cpu_presets[sickbeard.CPU_PRESET])
-                data = self.get_url(search_url, echo=False)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     break
 
@@ -301,7 +301,7 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
                             logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
                             time.sleep(cpu_presets[sickbeard.CPU_PRESET])
-                            data = self.get_url(search_url, echo=False)
+                            data = self.get_url(search_url, echo=False, returns='text')
                             if not data:
                                 break
 

--- a/sickbeard/providers/phxbit.py
+++ b/sickbeard/providers/phxbit.py
@@ -119,7 +119,7 @@ class PhxBitProvider(TorrentProvider):  # pylint: disable=too-many-instance-attr
                 search_url = self.urls['search'] + urlencode(search_params)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     continue
 

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -100,7 +100,7 @@ class PretomeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                 search_url = self.urls['search'] % (quote(search_string), self.categories)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     continue
 

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -107,7 +107,7 @@ class SCCProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
 
                 try:
                     logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
-                    data = self.get_url(search_url)
+                    data = self.get_url(search_url, echo=False, returns='text')
                     time.sleep(cpu_presets[sickbeard.CPU_PRESET])
                 except Exception as e:
                     logger.log(u"Unable to fetch data. Error: %s" % repr(e), logger.WARNING)

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -88,7 +88,7 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                 search_url = self.urls['search'] % (quote(search_string), self.categories)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     continue
 

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -129,7 +129,7 @@ class SpeedCDProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                 search_url = "%s?%s" % (self.urls['search'], urlencode(search_params))
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     continue
 

--- a/sickbeard/providers/strike.py
+++ b/sickbeard/providers/strike.py
@@ -49,7 +49,7 @@ class StrikeProvider(TorrentProvider):
 
                 search_url = self.url + "api/v2/torrents/search/?category=TV&phrase=" + search_string
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
-                jdata = self.get_url(search_url, json=True)
+                jdata = self.get_url(search_url, json=True, echo=False)
                 if not jdata:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     return []

--- a/sickbeard/providers/t411.py
+++ b/sickbeard/providers/t411.py
@@ -100,7 +100,7 @@ class T411Provider(TorrentProvider):  # pylint: disable=too-many-instance-attrib
                 search_urlS = ([self.urls['search'] % (search_string, u) for u in self.subcategories], [self.urls['rss']])[mode == 'RSS']
                 for search_url in search_urlS:
                     logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
-                    data = self.get_url(search_url, json=True)
+                    data = self.get_url(search_url, json=True, echo=False)
                     if not data:
                         continue
 

--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -312,7 +312,7 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                                logger.DEBUG)
 
                     logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
-                    data = self.get_url(search_url)
+                    data = self.get_url(search_url, echo=False, returns='text')
                     if not data:
                         logger.log(u"No data returned from provider", logger.DEBUG)
                         continue

--- a/sickbeard/providers/tokyotoshokan.py
+++ b/sickbeard/providers/tokyotoshokan.py
@@ -71,7 +71,7 @@ class TokyoToshokanProvider(TorrentProvider):  # pylint: disable=too-many-instan
                 }
 
                 logger.log(u"Search URL: %s" % self.urls['search'] + '?' + urlencode(search_params), logger.DEBUG)
-                data = self.get_url(self.urls['search'], params=search_params)
+                data = self.get_url(self.urls['search'], params=search_params, echo=False, returns='text')
                 if not data:
                     continue
 

--- a/sickbeard/providers/torrentproject.py
+++ b/sickbeard/providers/torrentproject.py
@@ -71,7 +71,7 @@ class TorrentProjectProvider(TorrentProvider):  # pylint: disable=too-many-insta
                     search_url = posixpath.join(self.custom_url, search_url.split(self.url)[1].lstrip('/'))  # Must use posixpath
 
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
-                torrents = self.get_url(search_url, json=True)
+                torrents = self.get_url(search_url, json=True, echo=False)
                 if not (torrents and "total_found" in torrents and int(torrents["total_found"]) > 0):
                     logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                     continue

--- a/sickbeard/providers/torrentz.py
+++ b/sickbeard/providers/torrentz.py
@@ -81,7 +81,7 @@ class TorrentzProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
 
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/transmitthenet.py
+++ b/sickbeard/providers/transmitthenet.py
@@ -115,7 +115,7 @@ class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-insta
                 search_url = self.urls['search'] + "?" + urlencode(search_params)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(self.urls['search'], params=search_params)
+                data = self.get_url(self.urls['search'], params=search_params, echo=False, returns='text')
                 if not data:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -134,7 +134,7 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
                 search_url = self.urls['search'] + urlencode(search_params)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
-                data = self.get_url(search_url)
+                data = self.get_url(search_url, echo=False, returns='text')
                 if not data:
                     logger.log(u"No data returned from provider", logger.DEBUG)
                     continue


### PR DESCRIPTION
Fixes double logging on providers

Proposed changes in this pull request:
- Add `echo=False` to `get_url` for double-logged providers
- Add `returns` to `get_url` to continue migrating away from deprecated args

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

