### PR TITLE
Manual Search: Sort default by seeders

### DIFF
--- a/gui/slick/views/manualSelect.mako
+++ b/gui/slick/views/manualSelect.mako
@@ -192,28 +192,26 @@
             </tbody>
 
             <tbody aria-live="polite" aria-relevant="all">
-            % for provider in sql_results:
-                % for hItem in sql_results[provider]:
-                    <% provider_img = providers.getProviderClass(GenericProvider.make_id(provider)) %>
-                    <tr id="S${season}E${episode} ${hItem["name"]}" class="skipped season-${season} seasonstyle" role="row">
-                        <td class="tvShow" class="col-name" width="35%">${helpers.remove_non_release_groups(hItem["name"])}</td>
-                        <td align="center">${helpers.remove_non_release_groups(hItem["release_group"])}</td>
-                        <td align="center">
-                            % if provider_img is not None:
-                                <img src="${srRoot}/images/providers/${provider_img.image_name()}" width="16" height="16" style="vertical-align:middle;" alt="${provider}" style="cursor: help;" title="${provider}"/> ${provider}
-                            % else:
-                                <img src="${srRoot}/images/providers/missing.png" width="16" height="16" style="vertical-align:middle;" alt="missing provider" title="missing provider"/> ${provider}
-                            % endif
-                        </td>
-                        <td align="center">${renderQualityPill(int(hItem["quality"]))}</td>
-                        <td align="center">${hItem["seeders"] if hItem["seeders"] > -1 else 'N/A'}</td>
-                        <td align="center">${hItem["leechers"] if hItem["leechers"] > -1 else 'N/A'}</td>
-                        <td align="center">${pretty_file_size(hItem["size"]) if hItem["size"] > -1 else 'N/A'}</td>
-                        <td align="center">${provider_img.provider_type.title()}</td>
-                        <td align="center" class="col-status">Ignored</td>
-                        <td align="center" class="col-search" width="5%"><a class="epManualSearch" id="${str(show.indexerid)}x${season}x${episode}" name="${str(show.indexerid)}x${season}x${episode}" href="manualSnatchSelect?provider=${provider}&amp;rowid=${hItem["rowid"]}&show=${show.indexerid}&amp;season=${season}&amp;episode=${episode}"><img src="${srRoot}/images/download.png" width="16" height="16" alt="search" title="Download selected episode" /></a></td>
-                    </tr>
-                % endfor
+            % for hItem in sql_results:
+                <% provider_img = providers.getProviderClass(GenericProvider.make_id(hItem["provider")) %>
+                <tr id="S${season}E${episode} ${hItem["name"]}" class="skipped season-${season} seasonstyle" role="row">
+                    <td class="tvShow" class="col-name" width="35%">${helpers.remove_non_release_groups(hItem["name"])}</td>
+                    <td align="center">${helpers.remove_non_release_groups(hItem["release_group"])}</td>
+                    <td align="center">
+                        % if provider_img is not None:
+                            <img src="${srRoot}/images/providers/${provider_img.image_name()}" width="16" height="16" style="vertical-align:middle;" alt="{hItem["provider"]}" style="cursor: help;" title="{hItem["provider"]}"/> {hItem["provider"]}
+                        % else:
+                            <img src="${srRoot}/images/providers/missing.png" width="16" height="16" style="vertical-align:middle;" alt="missing provider" title="missing provider"/> {hItem["provider"]}
+                        % endif
+                    </td>
+                    <td align="center">${renderQualityPill(int(hItem["quality"]))}</td>
+                    <td align="center">${hItem["seeders"] if hItem["seeders"] > -1 else 'N/A'}</td>
+                    <td align="center">${hItem["leechers"] if hItem["leechers"] > -1 else 'N/A'}</td>
+                    <td align="center">${pretty_file_size(hItem["size"]) if hItem["size"] > -1 else 'N/A'}</td>
+                    <td align="center">${provider_img.provider_type.title()}</td>
+                    <td align="center" class="col-status">Ignored</td>
+                    <td align="center" class="col-search" width="5%"><a class="epManualSearch" id="${str(show.indexerid)}x${season}x${episode}" name="${str(show.indexerid)}x${season}x${episode}" href="manualSnatchSelect?provider={hItem["provider"]}&amp;rowid=${hItem["rowid"]}&show=${show.indexerid}&amp;season=${season}&amp;episode=${episode}"><img src="${srRoot}/images/download.png" width="16" height="16" alt="search" title="Download selected episode" /></a></td>
+                </tr>
             % endfor
             </tbody>
         </table>


### PR DESCRIPTION
Also changed dict to make the provider name be part of the "item"

So each item will have all previous info plus "provider" key:

### After:
{'seeders': 3, 'name': u'The.Strain.S01E02.The.Box.1080p.WEB-DL.DD5.1.H.264-CtrlHD[rartv]', 'url': u'magnet:?xt=urn:btih:307d92502d6ba9b0dd4bc9ff578408d17879c476', 'season': 1, 'time': 1456440688, 'leechers': 0, 'episodes': u'|2|', 'version': -1, 'rowid': 182, **'provider': u'Rarbg'**, 'indexerid': 276564, 'quality': u'64', 'release_group': u'CtrlHD[rartv]', 'size': 1716910345}

### Before
 {'Usenet-Crawler': [{"seeders": -1, "name": "The.Strain.S02E06.1080p.WEB-DL.DD5.1.H.264-Juggalotus", "url": "https://www.usenet-crawler.com/getnzb/, "season": 2, "leechers": -1, "episodes": "|6|", "version": -1, "rowid": 27, "time": 1456427252, "indexerid": 276564, "quality": "4", "release_group": "KILLERS", "size": 1423058163},{.....}

## Screen shot:

![image](https://cloud.githubusercontent.com/assets/2620870/13337670/8b8b65a6-dbfb-11e5-86a6-dc2db4ac874c.png)
