### PR TITLE
Don't remove non-release words from title, only for "group" column

### DIFF
--- a/gui/slick/views/manualSelect.mako
+++ b/gui/slick/views/manualSelect.mako
@@ -198,7 +198,7 @@
             % for hItem in sql_results:
                 <% provider_img = providers.getProviderClass(GenericProvider.make_id(hItem["provider"])) %>
                 <tr id="S${season}E${episode} ${hItem["name"]}" class="skipped season-${season} seasonstyle" role="row">
-                    <td class="tvShow" class="col-name" width="35%">${helpers.remove_non_release_groups(hItem["name"])}</td>
+                    <td class="tvShow" class="col-name" width="35%">${hItem["name"]}</td>
                     <td align="center">${helpers.remove_non_release_groups(hItem["release_group"])}</td>
                     <td align="center">
                         % if provider_img is not None:


### PR DESCRIPTION
@duramato maye this is the reason we think we have dups

in DB:
How.Its.Made-Dream.Cars.S03E03.Porsche.Panamera.720p.HDTV.x264-W4F[rartv]
How.Its.Made-Dream.Cars.S03E03.Porsche.Panamera.720p.HDTV.x264-W4F

In UI:
How.Its.Made-Dream.Cars.S03E03.Porsche.Panamera.720p.HDTV.x264-W4F
How.Its.Made-Dream.Cars.S03E03.Porsche.Panamera.720p.HDTV.x264-W4F

so user might think its duplicate