### PR TITLE
Make URL column unique in providers table in cache database

### DIFF
--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -39,7 +39,7 @@ class CacheDBConnection(db.DBConnection):
         try:
             if not self.hasTable(providerName):
                 self.action(
-                    "CREATE TABLE [" + providerName + "] (name TEXT, season NUMERIC, episodes TEXT, indexerid NUMERIC, url TEXT, time NUMERIC, quality TEXT, release_group TEXT)")
+                    "CREATE TABLE [" + providerName + "] (name TEXT, season NUMERIC, episodes TEXT, indexerid NUMERIC, url TEXT UNIQUE, time NUMERIC, quality TEXT, release_group TEXT)")
             else:
                 sql_results = self.select("SELECT url, COUNT(url) AS count FROM [" + providerName + "] GROUP BY url HAVING count > 1")
 


### PR DESCRIPTION
Fix dupe items

Need erase cache.db or should do a ALTER TABLE do change existing cache.db to use UNIQUE?

@labrys @p0psicles @medariox @OmgImAlexis this PR fixed issue..... but we already have this in code but it seems its not working!

```python
            # add unique index to prevent further dupes from happening if one does not exist
            self.action("CREATE UNIQUE INDEX IF NOT EXISTS idx_url ON [" + providerName + "] (url)")
```

Seems code already remove dups. but only at boot:
```python
                 for cur_dupe in sql_results:
                     self.action("DELETE FROM [" + providerName + "] WHERE url = ?", [cur_dupe["url"]])
```

I know SQL but not an expert


