### PR TITLE
[Manual Search] Fix TypeError: int() argument must be a string or a number, not 'None…

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1503,7 +1503,7 @@ class Home(WebRoot):
             time.sleep(common.cpu_presets[sickbeard.CPU_PRESET])
         else:
             # Sort the list of found items
-            found_items = sorted(found_items, key=lambda k: (int(k['quality']), int(k['seeders'])), reverse=True)
+            found_items = sorted(found_items, key=lambda k: (try_int(k['quality']), try_int(k['seeders'])), reverse=True)
             # Make unknown qualities at the botton
             found_items = [d for d in found_items if int(d['quality']) < 32768] + [d for d in found_items if int(d['quality']) == 32768]
 


### PR DESCRIPTION
@duramato 

still need to check in cache.db what was None: quality or seeders