### PR TITLE
Added check on expired cookies for tvchaosuk.py

### DIFF
--- a/sickbeard/providers/tvchaosuk.py
+++ b/sickbeard/providers/tvchaosuk.py
@@ -63,7 +63,7 @@ class TVChaosUKProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         raise AuthException('Your authentication credentials for ' + self.name + ' are missing, check your config.')
 
     def login(self):
-        if len(self.session.cookies) >= 4:
+        if (len(self.session.cookies) >= 4 and all([not cookie.is_expired() for cookie in self.session.cookies])):
             return True
 
         login_params = {


### PR DESCRIPTION
Testing if we need this for snatching "old" expired sessions (read cookies), where authentication is required.

If this works, requests auth hook should be used, to create a generic solution.