### PR TITLE
Fixes "Invalid token. Use get_token for a new one!"

### DIFF
--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -121,6 +121,11 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
                                logger.DEBUG)
 
                 time.sleep(cpu_presets[sickbeard.CPU_PRESET])
+
+                # Check if token is still valid before search
+                if not self.login():
+                    continue
+
                 data = self.get_url(self.urls["api"], params=search_params, returns="json")
                 if not isinstance(data, dict):
                     logger.log("No data returned from provider", logger.DEBUG)


### PR DESCRIPTION
Getting tons of this.
If too much queued searches, token can expire in the middle of search-queue

```
2016-03-02 12:34:22 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 12:10:19 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 11:22:18 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 10:34:35 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 09:34:21 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 09:10:15 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 08:22:13 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 07:34:21 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 06:34:19 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 06:10:07 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 05:22:05 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 05:10:04 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 04:34:21 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 02:21:55 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 01:34:12 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
2016-03-02 00:21:51 INFO     SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4d6d66c] Invalid token. Use get_token for a new one!
```