### PR TITLE
Hotfix dateutil error for timezone names on Windows

### DIFF
--- a/sickbeard/network_timezones.py
+++ b/sickbeard/network_timezones.py
@@ -31,7 +31,11 @@ from sickrage.helper.common import try_int
 time_regex = re.compile(r'(?P<hour>\d{1,2})(?:[:.](?P<minute>\d{2})?)? ?(?P<meridiem>[PA]\.? ?M?)?\b', re.I)
 
 network_dict = None
-sb_timezone = tz.tzwinlocal() if tz.tzwinlocal else tz.tzlocal()
+
+try:
+    sb_timezone = tz.tzwinlocal() if tz.tzwinlocal else tz.tzlocal()
+except UnicodeError:
+    sb_timezone = tz.tzlocal()
 
 
 # update the network timezone table


### PR DESCRIPTION
Fixes SickRage/sickrage-issues/issues/1098
possibly related to dateutil/dateutil/issues/197 reported upstream.
