### PR TITLE
Moved the cache queries to the provider.TVcache object

### DIFF
--- a/sickbeard/manual_search.py
+++ b/sickbeard/manual_search.py
@@ -167,7 +167,6 @@ def get_provider_cache_results(indexer, show_all_results=None, perform_search=No
     down_cur_quality = 0
     showObj = Show.find(sickbeard.showList, int(show))
 
-    main_db_con = db.DBConnection('cache.db')
     sql_return = {}
     provider_results = {'last_prov_updates': {}, 'error': {}, 'found_items': []}
     found_items = []
@@ -175,28 +174,9 @@ def get_provider_cache_results(indexer, show_all_results=None, perform_search=No
     providers = [x for x in sickbeard.providers.sortedProviderList(sickbeard.RANDOMIZE_PROVIDERS) if x.is_active() and x.enable_daily]
     for curProvider in providers:
 
-        # Let's check if this provider table already exists
-        table_exists = main_db_con.select("SELECT name FROM sqlite_master WHERE type='table' AND name=?", [curProvider.get_id()])
-        columns = [i[1] for i in main_db_con.select("PRAGMA table_info('%s')" % curProvider.get_id())] if table_exists else []
-        if not table_exists or 'seeders' not in columns or 'leechers' not in columns or 'size' not in columns:
-            continue
-
         # TODO: the implicit sqlite rowid is used, should be replaced with an explicit PK column
-        if not int(show_all_results):
-            sql_return = main_db_con.select("SELECT rowid, ? as 'provider', ? as 'provider_id', name, season, \
-                                            episodes, indexerid, url, time, (select max(time) from '%s') as lastupdate, \
-                                            quality, release_group, version, seeders, leechers, size, time \
-                                            FROM '%s' WHERE episodes LIKE ? AND season = ? AND indexerid = ?"
-                                            % (curProvider.get_id(), curProvider.get_id()),
-                                            [curProvider.name, curProvider.get_id(),
-                                             "%|" + episode + "|%", season, show])
-
-        else:
-            sql_return = main_db_con.select("SELECT rowid, ? as 'provider', ? as 'provider_id', name, season, \
-                                            episodes, indexerid, url, time, (select max(time) from '%s') as lastupdate, \
-                                            quality, release_group, version, seeders, leechers, size, time \
-                                            FROM '%s' WHERE indexerid = ?" % (curProvider.name, curProvider.get_id()),
-                                            [curProvider.get_id(), show])
+        # If table doesn't exist, start a search to create table and new columns seeders, leechers and size
+        sql_return = curProvider.cache.get_cached_items_for_show(show_all_results, **search_show)
 
         if sql_return:
             for item in sql_return:

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -183,6 +183,37 @@ class TVCache(object):
 
         return any(results)
 
+    def get_cached_items_for_show(self, show_all_results=False, **search_show):
+        """ Retrieve cached search results for a specific show, and optionally season and episode """
+
+        cache_db_con = self._getDB()
+        if not int(show_all_results):
+            cache_items = cache_db_con.select("SELECT rowid, ? as 'provider', ? as 'provider_id', name, season, \
+                                              episodes, indexerid, url, time, (select max(time) from '%s') as lastupdate, \
+                                              quality, release_group, version, seeders, leechers, size, time \
+                                              FROM '%s' WHERE episodes LIKE ? AND season = ? AND indexerid = ?"
+                                              % (self.providerID, self.providerID),
+                                              [self.provider.name, self.providerID,
+                                               "%|" + search_show.get('episode') + "|%", search_show.get('season'),
+                                               search_show.get('show')])
+
+        else:
+            cache_items = cache_db_con.select("SELECT rowid, ? as 'provider', ? as 'provider_id', name, season, \
+                                             episodes, indexerid, url, time, (select max(time) from '%s') as lastupdate, \
+                                             quality, release_group, version, seeders, leechers, size, time \
+                                             FROM '%s' WHERE indexerid = ?"
+                                              % (self.providerID, self.providerID),
+                                              [self.provider.name, self.providerID, search_show.get('show')])
+
+        return cache_items
+
+    def get_new_cache_results(self, last_update, **show):
+        cache_db_con = self._getDB()
+        return cache_db_con.select("SELECT * FROM '%s' WHERE episodes LIKE ? AND season = ? AND indexerid = ? \
+                                   AND time > ?"
+                                   % (self.providerID), ["%|" + show.get('episode') + "|%", show.get('season'),
+                                                         show.get('show'), int(last_update)])
+
     def getRSSFeed(self, url, params=None):
         return getFeed(url, params=params, request_hook=self.provider.get_url)
 


### PR DESCRIPTION
When loading the manualSelect.mako or doing the manualSelectCacheCheck ajax calls, the tvcache class is initialized and the provider cache tables are build of they do not exist.

This solves allot of issues, for when searches are done against newly enabled providers that are not giving results.