### PR TITLE
Developers can push branch directly to ORG (feature branches)

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -684,7 +684,10 @@ class GitUpdateManager(UpdateManager):
     def update_remote_origin(self):
         self._run_git(self._git_path, 'config remote.%s.url %s' % (sickbeard.GIT_REMOTE, sickbeard.GIT_REMOTE_URL))
         if sickbeard.GIT_USERNAME:
-            self._run_git(self._git_path, 'config remote.%s.pushurl %s' % (sickbeard.GIT_REMOTE, sickbeard.GIT_REMOTE_URL.replace(sickbeard.GIT_ORG, sickbeard.GIT_USERNAME, 1)))
+            if sickbeard.DEVELOPER:
+                self._run_git(self._git_path, 'config remote.%s.pushurl %s' % (sickbeard.GIT_REMOTE, sickbeard.GIT_REMOTE_URL))
+            else:
+                self._run_git(self._git_path, 'config remote.%s.pushurl %s' % (sickbeard.GIT_REMOTE, sickbeard.GIT_REMOTE_URL.replace(sickbeard.GIT_ORG, sickbeard.GIT_USERNAME, 1)))
 
 
 class SourceUpdateManager(UpdateManager):


### PR DESCRIPTION
@pymedusa/developers need to enable the hidden config `developer` in config.ini

this setting also hide the warning about not using master branch