### PR TITLE
Run git 'remote prune' and remove untracked local branches after remote branch gets deleted

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -524,6 +524,10 @@ class GitUpdateManager(UpdateManager):
         self._num_commits_behind = 0
         self._num_commits_ahead = 0
 
+        # Remove local branches that doesn't exist anymore in remote
+        logger.log("Checkinng local branches to be removed")
+        self.prune()
+
         # update remote origin url
         self.update_remote_origin()
 
@@ -621,9 +625,6 @@ class GitUpdateManager(UpdateManager):
 
         # update remote origin url
         self.update_remote_origin()
-        
-        # Remove local branches that doesn't exist anymore in remote
-        self.prune()
 
         # remove untracked files and performs a hard reset on git branch to avoid update issues
         if sickbeard.GIT_RESET:
@@ -667,10 +668,18 @@ class GitUpdateManager(UpdateManager):
     def prune(self):
         """
         Calls git remote prune to delete all local branches that doesn't exist in remote anymore
+        all local branches that were removed from remote have status 'gone'
         """
         _, _, exit_status = self._run_git(self._git_path, 'remote prune {}'.format(sickbeard.GIT_REMOTE))
         if exit_status == 0:
-            return True
+            branches, _, exit_status = self._run_git(self._git_path, 'branch -vv')
+            if exit_status == 0:
+                for branch in branches.splitlines():
+                    if branch and ': gone]' in branch:
+                        logger.log("Branch: {}".format(branch))
+                        remaining_branch = re.match('(?P<branch>.*)(?P<hash>[a-z0-9]{7}) (?P<remote>\[.*\])(?P<commit>.*)', branch).group('branch').strip()
+                        logger.log("Removing local branch after remote branch being deleted: {}".format(remaining_branch))
+                        self._run_git(self._git_path, 'branch -D {}'.format(remaining_branch))
 
     def reset(self):
         """
@@ -685,7 +694,6 @@ class GitUpdateManager(UpdateManager):
         # update remote origin url
         self.update_remote_origin()
         sickbeard.BRANCH = self._find_installed_branch()
-
         branches, _, exit_status = self._run_git(self._git_path, 'ls-remote --heads %s' % sickbeard.GIT_REMOTE)  # @UnusedVariable
         if exit_status == 0 and branches:
             if branches:

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -621,6 +621,9 @@ class GitUpdateManager(UpdateManager):
 
         # update remote origin url
         self.update_remote_origin()
+        
+        # Remove local branches that doesn't exist anymore in remote
+        self.prune()
 
         # remove untracked files and performs a hard reset on git branch to avoid update issues
         if sickbeard.GIT_RESET:
@@ -658,6 +661,14 @@ class GitUpdateManager(UpdateManager):
         on the call's success.
         """
         _, _, exit_status = self._run_git(self._git_path, 'clean -df ""')  # @UnusedVariable
+        if exit_status == 0:
+            return True
+
+    def prune(self):
+        """
+        Calls git remote prune to delete all local branches that doesn't exist in remote anymore
+        """
+        _, _, exit_status = self._run_git(self._git_path, 'remote prune {}'.format(sickbeard.GIT_REMOTE))
         if exit_status == 0:
             return True
 


### PR DESCRIPTION
@labrys 
Prune all unreachable objects from the object database
https://git-scm.com/docs/git-prune

```
Pruning origin
URL: https://github.com/pymedusa/SickRage.git
 * [pruned] origin/dont_skip_providers
 * [pruned] origin/fix-manual-search
 * [pruned] origin/manual-search-fix-srroot
 * [pruned] origin/manual-search-moved-sql-to-tvcache
 * [pruned] origin/manual-search-rebase
 * [pruned] origin/merge-sr
 * [pruned] origin/transmission_fix
```

git branch -D {branch}
```
Deleted branch dont_skip_providers (was 59ec3c6).
Deleted branch transmission_fix (was fcf92b4).
```


Logs:
```
2016-03-18 08:37:47 DEBUG    CHECKVERSION :: [cde4813] git branch -D manual-search : returned successful
2016-03-18 08:37:47 DEBUG    CHECKVERSION :: [cde4813] Executing git branch -D manual-search with your shell in /home/osmc/SickRage
2016-03-18 08:37:47 INFO     CHECKVERSION :: [cde4813] Removing local branch after remote branch being deleted: manual-search
2016-03-18 08:37:47 INFO     CHECKVERSION :: [cde4813] Branch:   manual-search 8d60b9e [origin/manual-search: gone] Added disabling manual-snatch icons when one is clicked, making sure the user can't start a second before it's redirected.
2016-03-18 08:37:47 DEBUG    CHECKVERSION :: [cde4813] git branch -vv : returned successful
2016-03-18 08:37:47 DEBUG    CHECKVERSION :: [cde4813] Executing git branch -vv with your shell in /home/osmc/SickRage
2016-03-18 08:37:47 DEBUG    CHECKVERSION :: [cde4813] git remote prune origin : returned successful
2016-03-18 08:37:46 DEBUG    CHECKVERSION :: [cde4813] Executing git remote prune origin with your shell in /home/osmc/SickRage
2016-03-18 08:37:46 INFO     CHECKVERSION :: [cde4813] Checkinng local branches to be removed
```