### PR TITLE
Fixed manual searching for scene named anime shows.

### DIFF
--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -164,7 +164,7 @@ class TVCache(object):
         except Exception as e:
             logger.log(u"Error while searching " + self.provider.name + ", skipping: " + repr(e), logger.DEBUG)
 
-    def update_cache_manual_search(self, manual_data = None):
+    def update_cache_manual_search(self, manual_data=None):
 
         try:
             cl = []

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -131,6 +131,7 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
 
                     continue
 
+            # NOTE: searched_scene_season is always None?
             if len(episodes) > 1 and search_mode == 'sponly' and searched_scene_season == episode.scene_season:
                 continue
 


### PR DESCRIPTION
Somehow results = curProvider.cache.update_cache_manual_search(searchResults[curEp]) was always running with curEp= -1. As it should run the function with the episode number as a param.

With this fix it was getting all results for show Fairy Tails S2, for providers nyaatorrent and tokyotosho. As before it only found results from nzb providers.

We'll need to thoroughly test this will all different kinds of shows. I can also image that for some shows, you will get allot more results now.
@fernandog @labrys @duramato 