### PR TITLE
Fix bs4 find_all

### DIFF
--- a/sickbeard/providers/abnormal.py
+++ b/sickbeard/providers/abnormal.py
@@ -113,7 +113,7 @@ class ABNormalProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
 
                 with BS4Parser(data, 'html5lib') as html:
                     torrent_table = html.find(class_='torrent_table')
-                    torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                    torrent_rows = torrent_table('tr') if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
@@ -121,11 +121,11 @@ class ABNormalProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
                         continue
 
                     # Catégorie, Release, Date, DL, Size, C, S, L
-                    labels = [label.get_text(strip=True) for label in torrent_rows[0].find_all('td')]
+                    labels = [label.get_text(strip=True) for label in torrent_rows[0]('td')]
 
                     # Skip column headers
                     for result in torrent_rows[1:]:
-                        cells = result.find_all('td')
+                        cells = result('td')
                         if len(cells) < len(labels):
                             continue
 

--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -126,7 +126,7 @@ class AlphaRatioProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
                 with BS4Parser(data, "html5lib") as html:
                     torrent_table = html.find("table", id="torrent_table")
-                    torrent_rows = torrent_table.find_all("tr") if torrent_table else []
+                    torrent_rows = torrent_table("tr") if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
@@ -134,11 +134,11 @@ class AlphaRatioProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                         continue
 
                     # "", "", "Name /Year", "Files", "Time", "Size", "Snatches", "Seeders", "Leechers"
-                    labels = [process_column_header(label) for label in torrent_rows[0].find_all("td")]
+                    labels = [process_column_header(label) for label in torrent_rows[0]("td")]
 
                     # Skip column headers
                     for result in torrent_rows[1:]:
-                        cells = result.find_all("td")
+                        cells = result("td")
                         if len(cells) < len(labels):
                             continue
 

--- a/sickbeard/providers/bitsnoop.py
+++ b/sickbeard/providers/bitsnoop.py
@@ -74,7 +74,7 @@ class BitSnoopProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
                         continue
 
                     data = BeautifulSoup(data, 'html5lib')
-                    for item in data.findAll('item'):
+                    for item in data('item'):
                         try:
                             if not item.category.text.endswith(('TV', 'Anime')):
                                 continue

--- a/sickbeard/providers/bitsoup.py
+++ b/sickbeard/providers/bitsoup.py
@@ -105,7 +105,7 @@ class BitSoupProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                 try:
                     with BS4Parser(data, "html.parser") as html:
                         torrent_table = html.find('table', attrs={'class': 'koptekst'})
-                        torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                        torrent_rows = torrent_table('tr') if torrent_table else []
 
                         # Continue only if one Release is found
                         if len(torrent_rows) < 2:
@@ -113,7 +113,7 @@ class BitSoupProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                             continue
 
                         for result in torrent_rows[1:]:
-                            cells = result.find_all('td')
+                            cells = result('td')
 
                             link = cells[1].find('a')
                             download_url = self.urls['download'] % cells[2].find('a')['href']

--- a/sickbeard/providers/bluetigers.py
+++ b/sickbeard/providers/bluetigers.py
@@ -101,7 +101,7 @@ class BlueTigersProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
                 try:
                     with BS4Parser(data, 'html5lib') as html:
-                        result_linkz = html.findAll('a', href=re.compile("torrents-details"))
+                        result_linkz = html('a', href=re.compile("torrents-details"))
 
                         if not result_linkz:
                             logger.log(u"Data returned from provider do not contains any torrent", logger.DEBUG)

--- a/sickbeard/providers/cpasbien.py
+++ b/sickbeard/providers/cpasbien.py
@@ -60,7 +60,7 @@ class CpasbienProvider(TorrentProvider):
                     continue
 
                 with BS4Parser(data, 'html5lib') as html:
-                    torrent_rows = html.find_all(class_=re.compile('ligne[01]'))
+                    torrent_rows = html(class_=re.compile('ligne[01]'))
                     for result in torrent_rows:
                         try:
                             title = result.find(class_="titre").get_text(strip=True).replace("HDTV", "HDTV x264-CPasBien")

--- a/sickbeard/providers/danishbits.py
+++ b/sickbeard/providers/danishbits.py
@@ -122,7 +122,7 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
                 with BS4Parser(data, 'html5lib') as html:
                     torrent_table = html.find('table', id='torrent_table')
-                    torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                    torrent_rows = torrent_table('tr') if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
@@ -131,7 +131,7 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
                     # Literal:     Navn, Størrelse, Kommentarer, Tilføjet, Snatches, Seeders, Leechers
                     # Translation: Name, Size,      Comments,    Added,    Snatches, Seeders, Leechers
-                    labels = [process_column_header(label) for label in torrent_rows[0].find_all('td')]
+                    labels = [process_column_header(label) for label in torrent_rows[0]('td')]
 
                     # Skip column headers
                     for result in torrent_rows[1:]:
@@ -142,7 +142,7 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                             if not all([title, download_url]):
                                 continue
 
-                            cells = result.find_all('td')
+                            cells = result('td')
 
                             seeders = try_int(cells[labels.index('Seeders')].get_text(strip=True))
                             leechers = try_int(cells[labels.index('Leechers')].get_text(strip=True))

--- a/sickbeard/providers/elitetorrent.py
+++ b/sickbeard/providers/elitetorrent.py
@@ -94,7 +94,7 @@ class elitetorrentProvider(TorrentProvider):
                 try:
                     with BS4Parser(data, 'html5lib') as html:
                         torrent_table = html.find('table', class_='fichas-listado')
-                        torrent_rows = torrent_table.find_ll('tr') if torrent_table else []
+                        torrent_rows = torrent_table('tr') if torrent_table else []
 
                         if len(torrent_rows) < 2:
                             logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)

--- a/sickbeard/providers/extratorrent.py
+++ b/sickbeard/providers/extratorrent.py
@@ -75,7 +75,7 @@ class ExtraTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                     continue
 
                 with BS4Parser(data, 'html5lib') as parser:
-                    for item in parser.findAll('item'):
+                    for item in parser('item'):
                         try:
                             title = re.sub(r'^<!\[CDATA\[|\]\]>$', '', item.find('title').get_text(strip=True))
                             seeders = try_int(item.find('seeders').get_text(strip=True))

--- a/sickbeard/providers/freshontv.py
+++ b/sickbeard/providers/freshontv.py
@@ -134,7 +134,7 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                         # Check to see if there is more than 1 page of results
                         pager = init_soup.find('div', {'class': 'pager'})
                         if pager:
-                            page_links = pager.find_all('a', href=True)
+                            page_links = pager('a', href=True)
                         else:
                             page_links = []
 
@@ -178,7 +178,7 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
                         with BS4Parser(data_response, 'html5lib') as html:
 
-                            torrent_rows = html.findAll("tr", {"class": re.compile('torrent_[0-9]*')})
+                            torrent_rows = html("tr", {"class": re.compile('torrent_[0-9]*')})
 
                             # Continue only if a Release is found
                             if not torrent_rows:

--- a/sickbeard/providers/gftracker.py
+++ b/sickbeard/providers/gftracker.py
@@ -135,20 +135,20 @@ class GFTrackerProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
                 with BS4Parser(data, 'html5lib') as html:
                     torrent_table = html.find('div', id='torrentBrowse')
-                    torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                    torrent_rows = torrent_table('tr') if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
                         logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    labels = [process_column_header(label) for label in torrent_rows[0].find_all('td')]
+                    labels = [process_column_header(label) for label in torrent_rows[0]('td')]
 
                     # Skip column headers
                     for result in torrent_rows[1:]:
 
                         try:
-                            cells = result.find_all('td')
+                            cells = result('td')
 
                             title = cells[labels.index('Name')].find('a').find_next('a')['title'] or cells[labels.index('Name')].find('a')['title']
                             download_url = self.url + cells[labels.index('DL')].find('a')['href']

--- a/sickbeard/providers/hdspace.py
+++ b/sickbeard/providers/hdspace.py
@@ -123,7 +123,7 @@ class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                     logger.log(u"No html data parsed from provider", logger.DEBUG)
                     continue
 
-                torrents = html.findAll('tr')
+                torrents = html('tr')
                 if not torrents:
                     continue
 

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -128,14 +128,14 @@ class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                     torrent_rows = []
                     torrent_table = html.find('table', class_='mainblockcontenttt')
                     if torrent_table:
-                        torrent_rows = torrent_table.find_all('tr')
+                        torrent_rows = torrent_table('tr')
 
                     if not torrent_rows:
                         logger.log(u"Could not find results in returned data", logger.DEBUG)
                         continue
 
                     # Cat., Active, Filename, Dl, Wl, Added, Size, Uploader, S, L, C
-                    labels = [label.a.get_text(strip=True) if label.a else label.get_text(strip=True) for label in torrent_rows[0].find_all('td')]
+                    labels = [label.a.get_text(strip=True) if label.a else label.get_text(strip=True) for label in torrent_rows[0]('td')]
 
                     # Skip column headers
                     for result in torrent_rows[1:]:

--- a/sickbeard/providers/hounddawgs.py
+++ b/sickbeard/providers/hounddawgs.py
@@ -134,11 +134,11 @@ class HoundDawgsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
                         for result in entries[1:]:
 
-                            torrent = result.find_all('td')
+                            torrent = result('td')
                             if len(torrent) <= 1:
                                 break
 
-                            allAs = (torrent[1]).find_all('a')
+                            allAs = (torrent[1])('a')
 
                             try:
                                 notinternal = result.find('img', src='/static//common/user_upload.png')
@@ -153,8 +153,8 @@ class HoundDawgsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                                 torrent_size = result.find("td", class_="nobr").find_next_sibling("td").string
                                 if torrent_size:
                                     size = convert_size(torrent_size) or -1
-                                seeders = try_int((result.findAll('td')[6]).text)
-                                leechers = try_int((result.findAll('td')[7]).text)
+                                seeders = try_int((result('td')[6]).text)
+                                leechers = try_int((result('td')[7]).text)
 
                             except (AttributeError, TypeError):
                                 continue

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -120,7 +120,7 @@ class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                             continue
 
                         torrent_table = html.find('table', attrs={'class': 'torrents'})
-                        torrents = torrent_table.find_all('tr') if torrent_table else []
+                        torrents = torrent_table('tr') if torrent_table else []
 
                         # Continue only if one Release is found
                         if len(torrents) < 2:
@@ -129,11 +129,11 @@ class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
                         for result in torrents[1:]:
                             try:
-                                title = result.find_all('td')[1].find('a').text
-                                download_url = self.urls['base_url'] + result.find_all('td')[3].find('a')['href']
+                                title = result('td')[1].find('a').text
+                                download_url = self.urls['base_url'] + result('td')[3].find('a')['href']
                                 seeders = int(result.find('td', attrs={'class': 'ac t_seeders'}).text)
                                 leechers = int(result.find('td', attrs={'class': 'ac t_leechers'}).text)
-                                torrent_size = result.find_all('td')[5].text
+                                torrent_size = result('td')[5].text
                                 size = convert_size(torrent_size) or -1
                             except (AttributeError, TypeError, KeyError):
                                 continue

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -89,7 +89,7 @@ class KatProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
                     continue
 
                 with BS4Parser(data, "html5lib") as html:
-                    for item in html.find_all("item"):
+                    for item in html("item"):
                         try:
                             title = item.title.get_text(strip=True)
                             # Use the torcache link kat provides,

--- a/sickbeard/providers/limetorrents.py
+++ b/sickbeard/providers/limetorrents.py
@@ -77,7 +77,7 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
                     data = BeautifulSoup(data, 'html5lib')
 
-                    entries = data.findAll('item')
+                    entries = data('item')
                     if not entries:
                         logger.log(u'Returned xml contained no results', logger.INFO)
                         continue
@@ -105,8 +105,8 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                                 # Category: <a href="http://www.limetorrents.cc/browse-torrents/TV-shows/">TV shows</a><br /> Seeds: 1<br />Leechers: 0<br />Size: 7.71 GB<br /><br /><a href="http://www.limetorrents.cc/Owen-Hart-of-Gold-Djon91-torrent-7180661.html">More @ limetorrents.cc</a><br />
                                 # ]]>
                                 description = item.find('description')
-                                seeders = try_int(description.find_all('br')[0].next_sibling.strip().lstrip('Seeds: '))
-                                leechers = try_int(description.find_all('br')[1].next_sibling.strip().lstrip('Leechers: '))
+                                seeders = try_int(description('br')[0].next_sibling.strip().lstrip('Seeds: '))
+                                leechers = try_int(description('br')[1].next_sibling.strip().lstrip('Leechers: '))
                             else:
                                 # <description>Seeds: 6982 , Leechers 734</description>
                                 description = item.find('description').text.partition(',')

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -136,14 +136,14 @@ class MoreThanTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
                 with BS4Parser(data, 'html5lib') as html:
                     torrent_table = html.find('table', class_='torrent_table')
-                    torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                    torrent_rows = torrent_table('tr') if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
                         logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    labels = [process_column_header(label) for label in torrent_rows[0].find_all('td')]
+                    labels = [process_column_header(label) for label in torrent_rows[0]('td')]
 
                     # Skip column headers
                     for result in torrent_rows[1:]:
@@ -157,7 +157,7 @@ class MoreThanTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                             if not all([title, download_url]):
                                 continue
 
-                            cells = result.find_all('td')
+                            cells = result('td')
                             seeders = try_int(cells[labels.index('Seeders')].get_text(strip=True))
                             leechers = try_int(cells[labels.index('Leechers')].get_text(strip=True))
 

--- a/sickbeard/providers/newpct.py
+++ b/sickbeard/providers/newpct.py
@@ -91,7 +91,7 @@ class newpctProvider(TorrentProvider):
 
                 with BS4Parser(data, 'html5lib') as html:
                     torrent_table = html.find('table', id='categoryTable')
-                    torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                    torrent_rows = torrent_table('tr') if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 3:  # Headers + 1 Torrent + Pagination
@@ -100,10 +100,10 @@ class newpctProvider(TorrentProvider):
 
                     # 'Fecha', 'Título', 'Tamaño', ''
                     # Date, Title, Size
-                    labels = [label.get_text(strip=True) for label in torrent_rows[0].find_all('th')]
+                    labels = [label.get_text(strip=True) for label in torrent_rows[0]('th')]
                     for row in torrent_rows[1:-1]:
                         try:
-                            cells = row.find_all('td')
+                            cells = row('td')
 
                             torrent_row = row.find('a')
                             title = self._processTitle(torrent_row.get('title', ''))

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -176,10 +176,10 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
             if just_caps:
                 return
 
-            for category in html.find_all('category'):
+            for category in html('category'):
                 if 'TV' in category.get('name', '') and category.get('id', ''):
                     return_categories.append({'id': category['id'], 'name': category['name']})
-                    for subcat in category.find_all('subcat'):
+                    for subcat in category('subcat'):
                         if subcat.get('name', '') and subcat.get('id', ''):
                             return_categories.append({'id': subcat['id'], 'name': subcat['name']})
 
@@ -214,7 +214,7 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
         Checks that the returned data is valid
         Returns: _check_auth if valid otherwise False if there is an error
         """
-        if data.find_all('categories') + data.find_all('item'):
+        if data('categories') + data('item'):
             return self._check_auth()
 
         try:
@@ -329,7 +329,7 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
                     except AttributeError:
                         torznab = False
 
-                    for item in html.find_all('item'):
+                    for item in html('item'):
                         try:
                             title = item.title.get_text(strip=True)
                             download_url = None
@@ -352,7 +352,7 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
                                 item_size = size_regex.group() if size_regex else -1
                             else:
                                 item_size = item.size.get_text(strip=True) if item.size else -1
-                                for attr in item.find_all('newznab:attr') + item.find_all('torznab:attr'):
+                                for attr in item('newznab:attr') + item('torznab:attr'):
                                     item_size = attr['value'] if attr['name'] == 'size' else item_size
                                     seeders = try_int(attr['value']) if attr['name'] == 'seeders' else seeders
                                     peers = try_int(attr['value']) if attr['name'] == 'peers' else None

--- a/sickbeard/providers/phxbit.py
+++ b/sickbeard/providers/phxbit.py
@@ -121,7 +121,7 @@ class PhxBitProvider(TorrentProvider):  # pylint: disable=too-many-instance-attr
 
                 with BS4Parser(data, 'html5lib') as html:
                     torrent_table = html.find("table")
-                    torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                    torrent_rows = torrent_table('tr') if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
@@ -129,11 +129,11 @@ class PhxBitProvider(TorrentProvider):  # pylint: disable=too-many-instance-attr
                         continue
 
                     # Catégorie, Nom,  DL, Com, Taille, C, Seed, Leech,	Share
-                    labels = [process_column_header(label) for label in torrent_rows[0].find_all('td')]
+                    labels = [process_column_header(label) for label in torrent_rows[0]('td')]
 
                     # Skip column headers
                     for result in torrent_rows[1:]:
-                        cells = result.find_all('td')
+                        cells = result('td')
                         if len(cells) < len(labels):
                             continue
 

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -115,10 +115,10 @@ class PretomeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                             logger.log(u"Could not find table of torrents", logger.ERROR)
                             continue
 
-                        torrent_rows = torrent_table.find_all('tr', attrs={'class': 'browse'})
+                        torrent_rows = torrent_table('tr', attrs={'class': 'browse'})
 
                         for result in torrent_rows:
-                            cells = result.find_all('td')
+                            cells = result('td')
                             size = None
                             link = cells[1].find('a', attrs={'style': 'font-size: 1.25em; font-weight: bold;'})
 

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -116,14 +116,14 @@ class SCCProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
 
                 with BS4Parser(data, 'html5lib') as html:
                     torrent_table = html.find('table', attrs={'id': 'torrents-table'})
-                    torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                    torrent_rows = torrent_table('tr') if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
                         logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    for result in torrent_table.find_all('tr')[1:]:
+                    for result in torrent_table('tr')[1:]:
 
                         try:
                             link = result.find('td', attrs={'class': 'ttr_name'}).find('a')

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -104,11 +104,11 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                     # Scenetime apparently uses different number of cells in #torrenttable based
                     # on who you are. This works around that by extracting labels from the first
                     # <tr> and using their index to find the correct download/seeders/leechers td.
-                    labels = [label.get_text(strip=True) for label in torrent_rows[0].find_all('td')]
+                    labels = [label.get_text(strip=True) for label in torrent_rows[0]('td')]
 
                     for result in torrent_rows[1:]:
                         try:
-                            cells = result.find_all('td')
+                            cells = result('td')
 
                             link = cells[labels.index('Name')].find('a')
                             torrent_id = link['href'].replace('details.php?id=', '').split("&")[0]

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -131,19 +131,19 @@ class SpeedCDProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
                 with BS4Parser(data, 'html5lib') as html:
                     torrent_table = html.find('div', class_='boxContent').find('table')
-                    torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                    torrent_rows = torrent_table('tr') if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
                         logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    labels = [process_column_header(label) for label in torrent_rows[0].find_all('th')]
+                    labels = [process_column_header(label) for label in torrent_rows[0]('th')]
 
                     # Skip column headers
                     for result in torrent_rows[1:]:
                         try:
-                            cells = result.find_all('td')
+                            cells = result('td')
 
                             title = cells[labels.index('Title')].find('a', class_='torrent').get_text()
                             download_url = urljoin(self.url, cells[labels.index('Download')].find(title='Download').parent['href'])

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -111,19 +111,19 @@ class ThePirateBayProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
                 with BS4Parser(data, "html5lib") as html:
                     torrent_table = html.find("table", id="searchResult")
-                    torrent_rows = torrent_table.find_all("tr") if torrent_table else []
+                    torrent_rows = torrent_table("tr") if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
                         logger.log("Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    labels = [process_column_header(label) for label in torrent_rows[0].find_all("th")]
+                    labels = [process_column_header(label) for label in torrent_rows[0]("th")]
 
                     # Skip column headers
                     for result in torrent_rows[1:]:
                         try:
-                            cells = result.find_all("td")
+                            cells = result("td")
 
                             title = result.find(class_="detName").get_text(strip=True)
                             download_url = result.find(title="Download this torrent using magnet")["href"] + self._custom_trackers

--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -175,7 +175,7 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         """
         file_quality = ''
 
-        img_all = (torrent_rows.find_all('td'))[1].find_all('img')
+        img_all = (torrent_rows('td'))[1]('img')
 
         if img_all:
             for img_type in img_all:
@@ -185,7 +185,7 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                     logger.log(u"Failed parsing quality. Traceback: %s" % traceback.format_exc(), logger.ERROR)
 
         else:
-            file_quality = (torrent_rows.find_all('td'))[1].get_text()
+            file_quality = (torrent_rows('td'))[1].get_text()
             logger.log(u"Episode quality: %s" % file_quality, logger.DEBUG)
 
         def checkName(options, func):
@@ -198,7 +198,7 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         fullHD = checkName(["1080p", "fullHD"], any)
 
         if img_all:
-            file_quality = (torrent_rows.find_all('td'))[1].get_text()
+            file_quality = (torrent_rows('td'))[1].get_text()
 
         webdl = checkName(["webdl", "webmux", "webrip", "dl-webmux", "web-dlmux", "webdl-mux", "web-dl", "webdlmux", "dlmux"], any)
 
@@ -223,7 +223,7 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def _is_italian(self, torrent_rows):
 
-        name = str(torrent_rows.find_all('td')[1].find('b').find('span'))
+        name = str(torrent_rows('td')[1].find('b').find('span'))
         if not name or name == 'None':
             return False
 
@@ -248,7 +248,7 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
     @staticmethod
     def _is_english(torrent_rows):
 
-        name = str(torrent_rows.find_all('td')[1].find('b').find('span'))
+        name = str(torrent_rows('td')[1].find('b').find('span'))
         if not name or name == 'None':
             return False
 
@@ -319,7 +319,7 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                     try:
                         with BS4Parser(data, 'html5lib') as html:
                             torrent_table = html.find('table', attrs={'class': 'copyright'})
-                            torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                            torrent_rows = torrent_table('tr') if torrent_table else []
 
                             # Continue only if one Release is found
                             if len(torrent_rows) < 3:
@@ -330,17 +330,17 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                             if len(torrent_rows) < 42:
                                 last_page = 1
 
-                            for result in torrent_table.find_all('tr')[2:]:
+                            for result in torrent_table('tr')[2:]:
 
                                 try:
                                     link = result.find('td').find('a')
                                     title = link.string
-                                    download_url = self.urls['download'] % result.find_all('td')[8].find('a')['href'][-8:]
-                                    leechers = result.find_all('td')[3].find_all('td')[1].text
+                                    download_url = self.urls['download'] % result('td')[8].find('a')['href'][-8:]
+                                    leechers = result('td')[3]('td')[1].text
                                     leechers = int(leechers.strip('[]'))
-                                    seeders = result.find_all('td')[3].find_all('td')[2].text
+                                    seeders = result('td')[3]('td')[2].text
                                     seeders = int(seeders.strip('[]'))
-                                    torrent_size = result.find_all('td')[3].find_all('td')[3].text.strip('[]') + " GB"
+                                    torrent_size = result('td')[3]('td')[3].text.strip('[]') + " GB"
                                     size = convert_size(torrent_size) or -1
                                 except (AttributeError, TypeError):
                                     continue

--- a/sickbeard/providers/tokyotoshokan.py
+++ b/sickbeard/providers/tokyotoshokan.py
@@ -71,14 +71,14 @@ class TokyoToshokanProvider(TorrentProvider):  # pylint: disable=too-many-instan
 
                 with BS4Parser(data, 'html5lib') as soup:
                     torrent_table = soup.find('table', class_='listing')
-                    torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                    torrent_rows = torrent_table('tr') if torrent_table else []
 
                     # Continue only if one Release is found
                     if len(torrent_rows) < 2:
                         logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    a = 1 if len(torrent_rows[0].find_all('td')) < 2 else 0
+                    a = 1 if len(torrent_rows[0]('td')) < 2 else 0
 
                     for top, bot in zip(torrent_rows[a::2], torrent_rows[a + 1::2]):
                         try:

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -105,7 +105,7 @@ class TorrentBytesProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
                 with BS4Parser(data, "html5lib") as html:
                     torrent_table = html.find("table", border="1")
-                    torrent_rows = torrent_table.find_all("tr") if torrent_table else []
+                    torrent_rows = torrent_table("tr") if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
@@ -113,11 +113,11 @@ class TorrentBytesProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                         continue
 
                     # "Type", "Name", Files", "Comm.", "Added", "TTL", "Size", "Snatched", "Seeders", "Leechers"
-                    labels = [label.get_text(strip=True) for label in torrent_rows[0].find_all("td")]
+                    labels = [label.get_text(strip=True) for label in torrent_rows[0]("td")]
 
                     for result in torrent_rows[1:]:
                         try:
-                            cells = result.find_all("td")
+                            cells = result("td")
 
                             download_url = urljoin(self.url, cells[labels.index("Name")].find("a", href=re.compile(r"download.php\?id="))["href"])
                             title_element = cells[labels.index("Name")].find("a", href=re.compile(r"details.php\?id="))

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -129,14 +129,14 @@ class TorrentLeechProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
                 with BS4Parser(data, "html5lib") as html:
                     torrent_table = html.find("table", id="torrenttable")
-                    torrent_rows = torrent_table.find_all("tr") if torrent_table else []
+                    torrent_rows = torrent_table("tr") if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
                         logger.log("Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    labels = [process_column_header(label) for label in torrent_rows[0].find_all("th")]
+                    labels = [process_column_header(label) for label in torrent_rows[0]("th")]
 
                     # Skip column headers
                     for result in torrent_rows[1:]:
@@ -157,7 +157,7 @@ class TorrentLeechProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                                                (title, seeders, leechers), logger.DEBUG)
                                 continue
 
-                            torrent_size = result.find_all("td")[labels.index("Size")].get_text()
+                            torrent_size = result("td")[labels.index("Size")].get_text()
                             size = convert_size(torrent_size, units=units) or -1
 
                             item = {'title': title, 'link': download_url, 'size': size, 'seeders': seeders, 'leechers': leechers, 'hash': None}

--- a/sickbeard/providers/torrentz.py
+++ b/sickbeard/providers/torrentz.py
@@ -86,7 +86,7 @@ class TorrentzProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
 
                 try:
                     with BS4Parser(data, 'html5lib') as parser:
-                        for item in parser.findAll('item'):
+                        for item in parser('item'):
                             if item.category and 'tv' not in item.category.get_text(strip=True):
                                 continue
 

--- a/sickbeard/providers/transmitthenet.py
+++ b/sickbeard/providers/transmitthenet.py
@@ -122,7 +122,7 @@ class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-insta
                             logger.log(u"Data returned from %s does not contain any torrents" % self.name, logger.DEBUG)
                             continue
 
-                        torrent_rows = torrent_table.findAll('tr', {'class': 'torrent'})
+                        torrent_rows = torrent_table('tr', {'class': 'torrent'})
 
                         # Continue only if one Release is found
                         if not torrent_rows:
@@ -161,7 +161,7 @@ class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-insta
                                                (title, seeders, leechers), logger.DEBUG)
                                 continue
 
-                            cells = torrent_row.find_all('td')
+                            cells = torrent_row('td')
                             torrent_size = cells[5].text.strip()
                             size = convert_size(torrent_size) or -1
 

--- a/sickbeard/providers/tvchaosuk.py
+++ b/sickbeard/providers/tvchaosuk.py
@@ -115,14 +115,14 @@ class TVChaosUKProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
                 with BS4Parser(data, 'html5lib') as html:
                     torrent_table = html.find(id='sortabletable')
-                    torrent_rows = torrent_table.find_all("tr") if torrent_table else []
+                    torrent_rows = torrent_table("tr") if torrent_table else []
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
                         logger.log("Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    labels = [label.img['title'] if label.img else label.get_text(strip=True) for label in torrent_rows[0].find_all('td')]
+                    labels = [label.img['title'] if label.img else label.get_text(strip=True) for label in torrent_rows[0]('td')]
                     for torrent in torrent_rows[1:]:
                         try:
                             if self.freeleech and not torrent.find('img', alt=re.compile('Free Torrent')):
@@ -158,7 +158,7 @@ class TVChaosUKProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                             title = re.sub(ur'(.*)[\. ]?\(\d{4}\)', ur'\1', title)
                             title = re.sub(ur'\s+', ur' ', title)
 
-                            torrent_size = torrent.find_all('td')[labels.index('Size')].get_text(strip=True)
+                            torrent_size = torrent('td')[labels.index('Size')].get_text(strip=True)
                             size = convert_size(torrent_size, units=units) or -1
 
                             if mode != 'RSS':

--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -139,7 +139,7 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
                     torrent_table = html.find("table", class_="table2 table-bordered2")
                     torrent_rows = []
                     if torrent_table:
-                        torrent_rows = torrent_table.find_all("tr")
+                        torrent_rows = torrent_table("tr")
 
                     # Continue only if at least one Release is found
                     if len(torrent_rows) < 2:
@@ -147,11 +147,11 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
                         continue
 
                     # Catégorie, Nom du Torrent, (Download), (Bookmark), Com., Taille, Compl�t�, Seeders, Leechers
-                    labels = [process_column_header(label) for label in torrent_rows[0].find_all('td')]
+                    labels = [process_column_header(label) for label in torrent_rows[0]('td')]
 
                     # Skip column headers
                     for row in torrent_rows[1:]:
-                        cells = row.find_all('td')
+                        cells = row('td')
                         if len(cells) < len(labels):
                             continue
 


### PR DESCRIPTION
Fix upstream typo in `beautifulsoup.find_all()` and convert all `find_all()` to the simplified form.
