### PR TITLE
Using release name when searching for subtitles

### DIFF
--- a/sickbeard/refiners/__init__.py
+++ b/sickbeard/refiners/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/sickbeard/refiners/release.py
+++ b/sickbeard/refiners/release.py
@@ -39,15 +39,15 @@ def refine(video, release_name=None, release_file=None, extension='release', **k
     :param str extension: the release file extension.
 
     """
-    logger.log(u'Starting release refiner [extension={}, release_name={}, release_file={}]'.format
+    logger.log(u'Starting release refiner [extension={0}, release_name={1}, release_file={2}]'.format
                (extension, release_name, release_file), logger.DEBUG)
     dirpath, filename = os.path.split(video.name)
     dirpath = dirpath or '.'
     fileroot, fileext = os.path.splitext(filename)
-    release_file = release_file if release_file else get_release_file(dirpath, extension, fileroot)
+    release_file = release_file if release_file else get_release_file(dirpath, fileroot, extension)
     release_name = release_name if release_name else get_release_name(release_file)
 
-    release_path = os.path.join(dirpath, '%s%s' % (release_name, fileext))
+    release_path = os.path.join(dirpath, release_name + fileext)
     logger.log(u'Guessing using {}'.format(release_path), logger.DEBUG)
 
     guess = guessit(release_path)
@@ -58,11 +58,22 @@ def refine(video, release_name=None, release_file=None, extension='release', **k
 
         if new_value and old_value != new_value:
             setattr(video, key, new_value)
-            logger.log(u'Attribute {} changed from {} to {}'.format(key, old_value, new_value), logger.DEBUG)
+            logger.log(u'Attribute {0} changed from {1} to {2}'.format(key, old_value, new_value), logger.DEBUG)
 
 
-def get_release_file(dirpath, extension, fileroot):
-    release_file = os.path.join(dirpath, '%s.%s' % (fileroot, extension))
+def get_release_file(dirpath, filename, extension):
+    """
+    Given a `dirpath`, `filename` and `extension`, it returns the release file that should contain the original
+    release name.
+
+    Args:
+        dirpath: the file base folder
+        filename: the file name without extension
+        extension: the file extension
+
+    Returns: the release file if the file exists
+    """
+    release_file = os.path.join(dirpath, filename + extension)
 
     # skip if info file doesn't exist
     if os.path.isfile(release_file):
@@ -71,6 +82,14 @@ def get_release_file(dirpath, extension, fileroot):
 
 
 def get_release_name(release_file):
+    """
+    Given a `release_file` it will return the release name
+
+    Args:
+        release_file: the text file that contains the release name
+
+    Returns: the release name
+    """
     with open(release_file, 'r') as f:
         release_name = f.read().strip()
 

--- a/sickbeard/refiners/release.py
+++ b/sickbeard/refiners/release.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+import os
+
+from guessit import guessit
+from sickbeard import logger
+
+
+MOVIE_ATTRIBUTES = {'title': 'title', 'year': 'year', 'format': 'format', 'release_group': 'release_group',
+                    'resolution': 'screen_size',  'video_codec': 'video_codec', 'audio_codec': 'audio_codec'}
+EPISODE_ATTRIBUTES = {'series': 'title', 'season': 'season', 'episode': 'episode', 'title': 'episode_title',
+                      'year': 'year', 'format': 'format', 'release_group': 'release_group', 'resolution': 'screen_size',
+                      'video_codec': 'video_codec', 'audio_codec': 'audio_codec'}
+
+
+def refine(video, release_name=None, release_file=None, extension='release', **kwargs):
+    """Refine a video by using the original release name.
+    The refiner will first try to use the release_name passed as an argument;
+    If no release name, then it will read release_file;
+    If no release file, then it will read the file video_name.<extension> seeking for a release name.
+
+    When a release name is found, the video object will be enhanced using the guessit properties extracted from it.
+
+    Several :class:`~subliminal.video.Video` attributes can be found:
+
+      * :attr:`~subliminal.video.Video.title`
+      * :attr:`~subliminal.video.Video.series`
+      * :attr:`~subliminal.video.Video.season`
+      * :attr:`~subliminal.video.Video.episode`
+      * :attr:`~subliminal.video.Video.year`
+      * :attr:`~subliminal.video.Video.format`
+      * :attr:`~subliminal.video.Video.release_group`
+      * :attr:`~subliminal.video.Video.resolution`
+      * :attr:`~subliminal.video.Video.video_codec`
+      * :attr:`~subliminal.video.Video.audio_codec`
+
+    :param video: the video to refine.
+    :param str release_name: the release name to be used.
+    :param str release_file: the release file to be used
+    :param str extension: the release file extension.
+
+    """
+    logger.log(u'Starting release refiner [extension={}, release_name={}, release_file={}]'.format
+               (extension, release_name, release_file), logger.DEBUG)
+    dirpath, filename = os.path.split(video.name)
+    dirpath = dirpath or '.'
+    fileroot, fileext = os.path.splitext(filename)
+    release_file = release_file if release_file else get_release_file(dirpath, extension, fileroot)
+    release_name = release_name if release_name else get_release_name(release_file)
+
+    release_path = os.path.join(dirpath, '%s%s' % (release_name, fileext))
+    logger.log(u'Guessing using {}'.format(release_path), logger.DEBUG)
+
+    guess = guessit(release_path)
+    attributes = MOVIE_ATTRIBUTES if guess.get('type') == 'movie' else EPISODE_ATTRIBUTES
+    for key, value in attributes.items():
+        old_value = getattr(video, key)
+        new_value = guess.get(value)
+
+        if new_value and old_value != new_value:
+            setattr(video, key, new_value)
+            logger.log(u'Attribute {} changed from {} to {}'.format(key, old_value, new_value), logger.DEBUG)
+
+
+def get_release_file(dirpath, extension, fileroot):
+    release_file = os.path.join(dirpath, '%s.%s' % (fileroot, extension))
+
+    # skip if info file doesn't exist
+    if os.path.isfile(release_file):
+        logger.log(u'Found release file {}'.format(release_file), logger.DEBUG)
+        return release_file
+
+
+def get_release_name(release_file):
+    with open(release_file, 'r') as f:
+        release_name = f.read().strip()
+
+    # skip if no release name was found
+    if not release_name:
+        logger.log(u'Release file {} does not contain a release name'.format(release_file), logger.WARNING)
+
+    return release_name

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1415,7 +1415,8 @@ class TVEpisode(object):  # pylint: disable=too-many-instance-attributes, too-ma
 
         subtitles_info = {'location': self.location, 'subtitles': self.subtitles, 'season': self.season,
                           'episode': self.episode, 'name': self.name, 'show_name': self.show.name,
-                          'show_indexerid': self.show.indexerid, 'status': self.status}
+                          'show_indexerid': self.show.indexerid, 'status': self.status,
+                          'release_name': self.release_name}
 
         self.subtitles, new_subtitles = subtitles.download_subtitles(subtitles_info)
 


### PR DESCRIPTION
This will add a new subliminal refiner that will make use of the original release name to "enrich" the video object information before searching for subtitles. That will allow users to choose whatever "renaming rules" they want without worrying about downloading the correct subtitles. It should increase the subtitle search success ratio as well, since the original release name might contain more info then the renamed video file.

I tested this on my local installation. Please, let me know if anything needs to be changed or someone wants to try it first.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

