### PR TITLE
snatchSelection page: Removed scene exception message and H1 anchor underscore

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -922,6 +922,10 @@ h1.title {
     border-bottom: 1px solid #888;
 }
 
+h1.title a {
+    text-decoration: none;
+}
+
 .displayspecials {
     position: relative;
     top: -24px;

--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -15,7 +15,6 @@
 <%block name="scripts">
 <script type="text/javascript" src="${srRoot}/js/lib/jquery.bookmarkscroll.js?${sbPID}"></script>
 <script type="text/javascript" src="${srRoot}/js/plotTooltip.js?${sbPID}"></script>
-<script type="text/javascript" src="${srRoot}/js/sceneExceptionsTooltip.js?${sbPID}"></script>
 <script type="text/javascript" src="${srRoot}/js/ratingTooltip.js?${sbPID}"></script>
 <script type="text/javascript" src="${srRoot}/js/ajaxEpSearch.js?${sbPID}"></script>
 <script type="text/javascript" src="${srRoot}/js/ajaxEpSubtitles.js?${sbPID}"></script>

--- a/gui/slick/views/snatchSelection.mako
+++ b/gui/slick/views/snatchSelection.mako
@@ -18,7 +18,6 @@
 <%block name="scripts">
 <script type="text/javascript" src="${srRoot}/js/lib/jquery.bookmarkscroll.js?${sbPID}"></script>
 <script type="text/javascript" src="${srRoot}/js/plotTooltip.js?${sbPID}"></script>
-<script type="text/javascript" src="${srRoot}/js/sceneExceptionsTooltip.js?${sbPID}"></script>
 <script type="text/javascript" src="${srRoot}/js/ratingTooltip.js?${sbPID}"></script>
 <script type="text/javascript" src="${srRoot}/js/ajaxEpSubtitles.js?${sbPID}"></script>
 </%block>


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

Main reason for this UI change is the underscore. It's ugly.
![image](https://cloud.githubusercontent.com/assets/1331394/13980427/d22101fe-f0de-11e5-8cf6-312f96e5d09a.png)

Then I noticed the sceneExceptionsTooltip.js is included for displayShow.mako and snatchSelection.mako. But it's triggered on $('.title a'). And because the anchor has been removed for the displayShow.mako page, it's of no use. To keep things consistent i've also removed it from snatchSelection.

The text-decoration: none, is set for all 'h1/a'. I've checked but there are no other H1 tags with an anchor, so we're save there.

* Removed sceneExceptionsTooltip.js for displayShow and snatchSelection.mako as it's no longer used for displayShow, I assume there also is no use for it in snatchSelection.mako to keep things consistent.

I've left the id scene_exception_$show.indexerid.. on the a tag, if we want to bring it back some day.

As this is a gui change, i'm sure if can merge this. @OmgImAlexis will need to give a go on this.