### PR TITLE
Changing parameters precedence in release refiner

### DIFF
--- a/sickbeard/refiners/release.py
+++ b/sickbeard/refiners/release.py
@@ -44,8 +44,8 @@ def refine(video, release_name=None, release_file=None, extension='release', **k
     dirpath, filename = os.path.split(video.name)
     dirpath = dirpath or '.'
     fileroot, fileext = os.path.splitext(filename)
-    release_file = release_file if release_file else get_release_file(dirpath, fileroot, extension)
-    release_name = release_name if release_name else get_release_name(release_file)
+    release_file = get_release_file(dirpath, fileroot, extension) or release_file
+    release_name = get_release_name(release_file) or release_name
 
     release_path = os.path.join(dirpath, release_name + fileext)
     logger.log(u'Guessing using {}'.format(release_path), logger.DEBUG)
@@ -90,6 +90,9 @@ def get_release_name(release_file):
 
     Returns: the release name
     """
+    if not release_file:
+        return
+
     with open(release_file, 'r') as f:
         release_name = f.read().strip()
 


### PR DESCRIPTION
This change is
- to give the user the possibility to override the release name by just creating a .release file. 
- minor fix when no release_name and no release_file are defined. 

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)