### PR TITLE
[Manual Search] Add provider setting 'Enable provider for Manual Searches'

### DIFF
--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -168,6 +168,18 @@ $('#config-components').tabs();
                         </div>
                         % endif
 
+                        % if hasattr(curNewznabProvider, 'enable_manualsearch'):
+                        <div class="field-pair">
+                            <label for="${curNewznabProvider.get_id()}_enable_manualsearch">
+                                <span class="component-title">Enable provider for manual searches</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" name="${curNewznabProvider.get_id()}_enable_manualsearch" id="${curNewznabProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curNewznabProvider.enable_manualsearch)]}/>
+                                    <p>enable provider to use in manual searches.</p>
+                                </span>
+                            </label>
+                        </div>
+                        % endif
+
                         % if hasattr(curNewznabProvider, 'enable_backlog'):
                         <div class="field-pair${(' hidden', '')[curNewznabProvider.supports_backlog]}">
                             <label for="${curNewznabProvider.get_id()}_enable_backlog">
@@ -254,6 +266,19 @@ $('#config-components').tabs();
                             </label>
                         </div>
                         % endif
+
+                        % if hasattr(curNzbProvider, 'enable_manualsearch'):
+                        <div class="field-pair">
+                            <label for="${curNzbProvider.get_id()}_enable_manualsearch">
+                                <span class="component-title">Enable provider for manual searches</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" name="${curNzbProvider.get_id()}_enable_manualsearch" id="${curNzbProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curNzbProvider.enable_manualsearch)]}/>
+                                    <p>enable provider to use in manual searches.</p>
+                                </span>
+                            </label>
+                        </div>
+                        % endif
+
 
                         % if hasattr(curNzbProvider, 'enable_backlog'):
                         <div class="field-pair${(' hidden', '')[curNzbProvider.supports_backlog]}">
@@ -523,6 +548,18 @@ $('#config-components').tabs();
                                 <span class="component-desc">
                                     <input type="checkbox" name="${curTorrentProvider.get_id()}_enable_daily" id="${curTorrentProvider.get_id()}_enable_daily" ${('', 'checked="checked"')[bool(curTorrentProvider.enable_daily)]}/>
                                     <p>enable provider to perform daily searches.</p>
+                                </span>
+                            </label>
+                        </div>
+                        % endif
+
+                        % if hasattr(curTorrentProvider, 'enable_manualsearch'):
+                        <div class="field-pair">
+                            <label for="${curTorrentProvider.get_id()}_enable_manualsearch">
+                                <span class="component-title">Enable provider for manual searches</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" name="${curTorrentProvider.get_id()}_enable_manualsearch" id="${curTorrentProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curTorrentProvider.enable_manualsearch)]}/>
+                                    <p>enable provider to use in manual searches.</p>
                                 </span>
                             </label>
                         </div>

--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -169,12 +169,12 @@ $('#config-components').tabs();
                         % endif
 
                         % if hasattr(curNewznabProvider, 'enable_manualsearch'):
-                        <div class="field-pair">
+                        <div class="field-pair${(' hidden', '')[curNewznabProvider.supports_backlog]}">
                             <label for="${curNewznabProvider.get_id()}_enable_manualsearch">
-                                <span class="component-title">Enable provider for manual searches</span>
+                                <span class="component-title">Enable manual searches</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curNewznabProvider.get_id()}_enable_manualsearch" id="${curNewznabProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curNewznabProvider.enable_manualsearch)]}/>
-                                    <p>enable provider to use in manual searches.</p>
+                                    <input type="checkbox" name="${curNewznabProvider.get_id()}_enable_manualsearch" id="${curNewznabProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curNewznabProvider.enable_manualsearch  and curNewznabProvider.supports_backlog)]}/>
+                                    <p>enable provider to perform manual searches.</p>
                                 </span>
                             </label>
                         </div>
@@ -268,12 +268,12 @@ $('#config-components').tabs();
                         % endif
 
                         % if hasattr(curNzbProvider, 'enable_manualsearch'):
-                        <div class="field-pair">
+                        <div class="field-pair${(' hidden', '')[curNzbProvider.supports_backlog]}">
                             <label for="${curNzbProvider.get_id()}_enable_manualsearch">
-                                <span class="component-title">Enable provider for manual searches</span>
+                                <span class="component-title">Enable manual searches</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curNzbProvider.get_id()}_enable_manualsearch" id="${curNzbProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curNzbProvider.enable_manualsearch)]}/>
-                                    <p>enable provider to use in manual searches.</p>
+                                    <input type="checkbox" name="${curNzbProvider.get_id()}_enable_manualsearch" id="${curNzbProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curNzbProvider.enable_manualsearch and curNzbProvider.supports_backlog)]}/>
+                                    <p>enable provider to perform manual searches.</p>
                                 </span>
                             </label>
                         </div>
@@ -554,12 +554,12 @@ $('#config-components').tabs();
                         % endif
 
                         % if hasattr(curTorrentProvider, 'enable_manualsearch'):
-                        <div class="field-pair">
+                        <div class="field-pair${(' hidden', '')[curTorrentProvider.supports_backlog]}">
                             <label for="${curTorrentProvider.get_id()}_enable_manualsearch">
-                                <span class="component-title">Enable provider for manual searches</span>
+                                <span class="component-title">Enable manual searches</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.get_id()}_enable_manualsearch" id="${curTorrentProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curTorrentProvider.enable_manualsearch)]}/>
-                                    <p>enable provider to use in manual searches.</p>
+                                    <input type="checkbox" name="${curTorrentProvider.get_id()}_enable_manualsearch" id="${curTorrentProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curTorrentProvider.enable_manualsearch and curTorrentProvider.supports_backlog)]}/>
+                                    <p>enable provider to perform manual searches.</p>
                                 </span>
                             </label>
                         </div>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -75,7 +75,7 @@ CFG = None
 CONFIG_FILE = None
 
 # This is the version of the config we EXPECT to find
-CONFIG_VERSION = 8
+CONFIG_VERSION = 9
 
 # Default encryption version (0 for None)
 ENCRYPTION_VERSION = 0

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1361,6 +1361,11 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
                                                                            curTorrentProvider.get_id() + '_enable_backlog',
                                                                            curTorrentProvider.supports_backlog))
 
+            if hasattr(curTorrentProvider, 'enable_manualsearch'):
+                curTorrentProvider.enable_manualsearch = bool(check_setting_int(CFG, curTorrentProvider.get_id().upper(),
+                                                                           curTorrentProvider.get_id() + '_enable_manualsearch',
+                                                                           1))
+
             if hasattr(curTorrentProvider, 'cat'):
                 curTorrentProvider.cat = check_setting_int(CFG, curTorrentProvider.get_id().upper(),
                                                            curTorrentProvider.get_id() + '_cat', 0)
@@ -1395,6 +1400,11 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
                 curNzbProvider.enable_backlog = bool(check_setting_int(CFG, curNzbProvider.get_id().upper(),
                                                                        curNzbProvider.get_id() + '_enable_backlog',
                                                                        curNzbProvider.supports_backlog))
+
+            if hasattr(curNzbProvider, 'enable_manualsearch'):
+                curNzbProvider.enable_manualsearch = bool(check_setting_int(CFG, curNzbProvider.get_id().upper(),
+                                                                     curNzbProvider.get_id() + '_enable_manualsearch',
+                                                                     1))
 
         if not ek(os.path.isfile, CONFIG_FILE):
             logger.log(u"Unable to find '" + CONFIG_FILE + "', all settings will be default!", logger.DEBUG)
@@ -1856,6 +1866,9 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
         if hasattr(curTorrentProvider, 'enable_backlog'):
             new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_enable_backlog'] = int(
                 curTorrentProvider.enable_backlog)
+        if hasattr(curTorrentProvider, 'enable_manualsearch'):
+            new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_enable_manualsearch'] = int(
+                curTorrentProvider.enable_manualsearch)
         if hasattr(curTorrentProvider, 'cat'):
             new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_cat'] = int(
                 curTorrentProvider.cat)
@@ -1886,6 +1899,9 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
         if hasattr(curNzbProvider, 'enable_backlog'):
             new_config[curNzbProvider.get_id().upper()][curNzbProvider.get_id() + '_enable_backlog'] = int(
                 curNzbProvider.enable_backlog)
+        if hasattr(curNzbProvider, 'enable_manualsearch'):
+            new_config[curNzbProvider.get_id().upper()][curNzbProvider.get_id() + '_enable_manualsearch'] = int(
+                curNzbProvider.enable_manualsearch)
 
     new_config['NZBs'] = {}
     new_config['NZBs']['nzbs'] = int(NZBS)

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -915,3 +915,10 @@ class ConfigMigrator(object):
         sickbeard.PLEX_SERVER_USERNAME = check_setting_str(self.config_obj, 'Plex', 'plex_username', '', censor_log=True)
         sickbeard.PLEX_SERVER_PASSWORD = check_setting_str(self.config_obj, 'Plex', 'plex_password', '', censor_log=True)
         sickbeard.USE_PLEX_SERVER = bool(check_setting_int(self.config_obj, 'Plex', 'use_plex', 0))
+
+    def _migrate_v9(self):
+        """
+        Migrate to config version 9
+        """
+        # Added setting "enable_manualsearch" for providers (dynamic setting)
+        pass

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -82,7 +82,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
 
         # for each provider get a list of the
         origThreadName = threading.currentThread().name
-        providers = [x for x in sickbeard.providers.sortedProviderList(sickbeard.RANDOMIZE_PROVIDERS) if x.is_active()]
+        providers = [x for x in sickbeard.providers.sortedProviderList(sickbeard.RANDOMIZE_PROVIDERS) if x.is_active() and x.enable_backlog]
         for curProvider in providers:
             threading.currentThread().name = origThreadName + " :: [" + curProvider.name + "]"
 

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -487,8 +487,14 @@ def searchProviders(show, episodes, manualSearch=False, downCurQuality=False, ma
 
     origThreadName = threading.currentThread().name
 
-    providers = [x for x in sickbeard.providers.sortedProviderList(sickbeard.RANDOMIZE_PROVIDERS)
-                 if x.is_active() and x.enable_backlog]
+    if manual_snatch:
+        logger.log("Using manual search providers")
+        providers = [x for x in sickbeard.providers.sortedProviderList(sickbeard.RANDOMIZE_PROVIDERS)
+                    if x.is_active() and x.enable_manualsearch]
+    else:
+        providers = [x for x in sickbeard.providers.sortedProviderList(sickbeard.RANDOMIZE_PROVIDERS)
+                    if x.is_active() and x.enable_backlog]
+
     if not manualSearch:
         for curProvider in providers:
             threading.currentThread().name = origThreadName + " :: [" + curProvider.name + "]"

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -155,8 +155,8 @@ class TVCache(object):
                     if ci is not None:
                         cl.append(ci)
 
+                cache_db_con = self._getDB()
                 if cl:
-                    cache_db_con = self._getDB()
                     cache_db_con.mass_action(cl)
 
         except AuthException as e:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4749,6 +4749,12 @@ class ConfigProviders(Config):
                         newznabProviderDict[cur_id].enable_daily = 0
 
                     try:
+                        newznabProviderDict[cur_id].enable_manualsearch = config.checkbox_to_value(
+                            kwargs[cur_id + '_enable_manualsearch'])
+                    except Exception:
+                        newznabProviderDict[cur_id].enable_manualsearch = 1
+
+                    try:
                         newznabProviderDict[cur_id].enable_backlog = config.checkbox_to_value(
                             kwargs[cur_id + '_enable_backlog'])
                     except Exception:
@@ -4951,6 +4957,13 @@ class ConfigProviders(Config):
                 except Exception:
                     curTorrentProvider.enable_daily = 0  # these exceptions are actually catching unselected checkboxes
 
+            if hasattr(curTorrentProvider, 'enable_manualsearch'):
+                try:
+                    curTorrentProvider.enable_manualsearch = config.checkbox_to_value(
+                        kwargs[curTorrentProvider.get_id() + '_enable_manualsearch'])
+                except Exception:
+                    curTorrentProvider.enable_manualsearch = 1  # these exceptions are actually catching unselected checkboxes
+
             if hasattr(curTorrentProvider, 'enable_backlog'):
                 try:
                     curTorrentProvider.enable_backlog = config.checkbox_to_value(
@@ -5005,6 +5018,13 @@ class ConfigProviders(Config):
                         kwargs[curNzbProvider.get_id() + '_enable_daily'])
                 except Exception:
                     curNzbProvider.enable_daily = 0  # these exceptions are actually catching unselected checkboxes
+
+            if hasattr(curNzbProvider, 'enable_manualsearch'):
+                try:
+                    curNzbProvider.enable_manualsearch = config.checkbox_to_value(
+                        kwargs[curNzbProvider.get_id() + '_enable_manualsearch'])
+                except Exception:
+                    curNzbProvider.enable_manualsearch = 1  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curNzbProvider, 'enable_backlog'):
                 try:

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -56,6 +56,7 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
         ]
         self.cache = TVCache(self)
         self.enable_backlog = False
+        self.enable_manualsearch = False
         self.enable_daily = False
         self.enabled = False
         self.headers = {'User-Agent': UA_POOL.random}


### PR DESCRIPTION
It will only use "manual search" providers when you use "Force results" button. Because this providers don't get updated in DailySearcher as they are manual search only

So its a mix of @duramato and mine (fallback)

- Fixes thread name while doing forced search
Before:
 [c352080] Performing episode search for 
After:
[MoreThanTV] :: [c352080] Performing episode search for 

- Fixed "forced search when no results" using backlog enabled providers (in manual_snatch.py we used to use daily). Now we use "enable_manualsearch"

- Fixed: search for propers only in backlog enabled providers

- Initialize provider even if no query to execute

This changes UI but nothing that will break angular @OmgImAlexis 
