### PR TITLE
[Manual Search] Add provider setting 'Enable manual searches'

### DIFF
--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -168,6 +168,18 @@ $('#config-components').tabs();
                         </div>
                         % endif
 
+                        % if hasattr(curNewznabProvider, 'enable_manualsearch'):
+                        <div class="field-pair${(' hidden', '')[curNewznabProvider.supports_backlog]}">
+                            <label for="${curNewznabProvider.get_id()}_enable_manualsearch">
+                                <span class="component-title">Enable manual searches</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" name="${curNewznabProvider.get_id()}_enable_manualsearch" id="${curNewznabProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curNewznabProvider.enable_manualsearch  and curNewznabProvider.supports_backlog)]}/>
+                                    <p>enable provider to perform manual searches.</p>
+                                </span>
+                            </label>
+                        </div>
+                        % endif
+
                         % if hasattr(curNewznabProvider, 'enable_backlog'):
                         <div class="field-pair${(' hidden', '')[curNewznabProvider.supports_backlog]}">
                             <label for="${curNewznabProvider.get_id()}_enable_backlog">
@@ -254,6 +266,19 @@ $('#config-components').tabs();
                             </label>
                         </div>
                         % endif
+
+                        % if hasattr(curNzbProvider, 'enable_manualsearch'):
+                        <div class="field-pair${(' hidden', '')[curNzbProvider.supports_backlog]}">
+                            <label for="${curNzbProvider.get_id()}_enable_manualsearch">
+                                <span class="component-title">Enable manual searches</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" name="${curNzbProvider.get_id()}_enable_manualsearch" id="${curNzbProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curNzbProvider.enable_manualsearch and curNzbProvider.supports_backlog)]}/>
+                                    <p>enable provider to perform manual searches.</p>
+                                </span>
+                            </label>
+                        </div>
+                        % endif
+
 
                         % if hasattr(curNzbProvider, 'enable_backlog'):
                         <div class="field-pair${(' hidden', '')[curNzbProvider.supports_backlog]}">
@@ -523,6 +548,18 @@ $('#config-components').tabs();
                                 <span class="component-desc">
                                     <input type="checkbox" name="${curTorrentProvider.get_id()}_enable_daily" id="${curTorrentProvider.get_id()}_enable_daily" ${('', 'checked="checked"')[bool(curTorrentProvider.enable_daily)]}/>
                                     <p>enable provider to perform daily searches.</p>
+                                </span>
+                            </label>
+                        </div>
+                        % endif
+
+                        % if hasattr(curTorrentProvider, 'enable_manualsearch'):
+                        <div class="field-pair${(' hidden', '')[curTorrentProvider.supports_backlog]}">
+                            <label for="${curTorrentProvider.get_id()}_enable_manualsearch">
+                                <span class="component-title">Enable manual searches</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" name="${curTorrentProvider.get_id()}_enable_manualsearch" id="${curTorrentProvider.get_id()}_enable_manualsearch" ${('', 'checked="checked"')[bool(curTorrentProvider.enable_manualsearch and curTorrentProvider.supports_backlog)]}/>
+                                    <p>enable provider to perform manual searches.</p>
                                 </span>
                             </label>
                         </div>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -75,7 +75,7 @@ CFG = None
 CONFIG_FILE = None
 
 # This is the version of the config we EXPECT to find
-CONFIG_VERSION = 8
+CONFIG_VERSION = 9
 
 # Default encryption version (0 for None)
 ENCRYPTION_VERSION = 0
@@ -1361,6 +1361,11 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
                                                                            curTorrentProvider.get_id() + '_enable_backlog',
                                                                            curTorrentProvider.supports_backlog))
 
+            if hasattr(curTorrentProvider, 'enable_manualsearch'):
+                curTorrentProvider.enable_manualsearch = bool(check_setting_int(CFG, curTorrentProvider.get_id().upper(),
+                                                                           curTorrentProvider.get_id() + '_enable_manualsearch',
+                                                                           1))
+
             if hasattr(curTorrentProvider, 'cat'):
                 curTorrentProvider.cat = check_setting_int(CFG, curTorrentProvider.get_id().upper(),
                                                            curTorrentProvider.get_id() + '_cat', 0)
@@ -1395,6 +1400,11 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
                 curNzbProvider.enable_backlog = bool(check_setting_int(CFG, curNzbProvider.get_id().upper(),
                                                                        curNzbProvider.get_id() + '_enable_backlog',
                                                                        curNzbProvider.supports_backlog))
+
+            if hasattr(curNzbProvider, 'enable_manualsearch'):
+                curNzbProvider.enable_manualsearch = bool(check_setting_int(CFG, curNzbProvider.get_id().upper(),
+                                                                     curNzbProvider.get_id() + '_enable_manualsearch',
+                                                                     1))
 
         if not ek(os.path.isfile, CONFIG_FILE):
             logger.log(u"Unable to find '" + CONFIG_FILE + "', all settings will be default!", logger.DEBUG)
@@ -1856,6 +1866,9 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
         if hasattr(curTorrentProvider, 'enable_backlog'):
             new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_enable_backlog'] = int(
                 curTorrentProvider.enable_backlog)
+        if hasattr(curTorrentProvider, 'enable_manualsearch'):
+            new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_enable_manualsearch'] = int(
+                curTorrentProvider.enable_manualsearch)
         if hasattr(curTorrentProvider, 'cat'):
             new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_cat'] = int(
                 curTorrentProvider.cat)
@@ -1886,6 +1899,9 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
         if hasattr(curNzbProvider, 'enable_backlog'):
             new_config[curNzbProvider.get_id().upper()][curNzbProvider.get_id() + '_enable_backlog'] = int(
                 curNzbProvider.enable_backlog)
+        if hasattr(curNzbProvider, 'enable_manualsearch'):
+            new_config[curNzbProvider.get_id().upper()][curNzbProvider.get_id() + '_enable_manualsearch'] = int(
+                curNzbProvider.enable_manualsearch)
 
     new_config['NZBs'] = {}
     new_config['NZBs']['nzbs'] = int(NZBS)

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -915,3 +915,10 @@ class ConfigMigrator(object):
         sickbeard.PLEX_SERVER_USERNAME = check_setting_str(self.config_obj, 'Plex', 'plex_username', '', censor_log=True)
         sickbeard.PLEX_SERVER_PASSWORD = check_setting_str(self.config_obj, 'Plex', 'plex_password', '', censor_log=True)
         sickbeard.USE_PLEX_SERVER = bool(check_setting_int(self.config_obj, 'Plex', 'use_plex', 0))
+
+    def _migrate_v9(self):
+        """
+        Migrate to config version 9
+        """
+        # Added setting "enable_manualsearch" for providers (dynamic setting)
+        pass

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -155,8 +155,8 @@ class TVCache(object):
                     if ci is not None:
                         cl.append(ci)
 
+                cache_db_con = self._getDB()
                 if cl:
-                    cache_db_con = self._getDB()
                     cache_db_con.mass_action(cl)
 
         except AuthException as e:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4691,32 +4691,32 @@ class ConfigProviders(Config):
 
                     try:
                         newznabProviderDict[cur_id].search_mode = str(kwargs[cur_id + '_search_mode']).strip()
-                    except Exception:
-                        pass
+                    except (AttributeError, KeyError):
+                        pass  # these exceptions are actually catching unselected checkboxes
 
                     try:
                         newznabProviderDict[cur_id].search_fallback = config.checkbox_to_value(
                             kwargs[cur_id + '_search_fallback'])
-                    except Exception:
-                        newznabProviderDict[cur_id].search_fallback = 0
+                    except (AttributeError, KeyError):
+                        newznabProviderDict[cur_id].search_fallback = 0  # these exceptions are actually catching unselected checkboxes
 
                     try:
                         newznabProviderDict[cur_id].enable_daily = config.checkbox_to_value(
                             kwargs[cur_id + '_enable_daily'])
-                    except Exception:
-                        newznabProviderDict[cur_id].enable_daily = 0
+                    except (AttributeError, KeyError):
+                        newznabProviderDict[cur_id].enable_daily = 0  # these exceptions are actually catching unselected checkboxes
 
                     try:
                         newznabProviderDict[cur_id].enable_manualsearch = config.checkbox_to_value(
                             kwargs[cur_id + '_enable_manualsearch'])
-                    except Exception:
-                        newznabProviderDict[cur_id].enable_manualsearch = 0
+                    except (AttributeError, KeyError):
+                        newznabProviderDict[cur_id].enable_manualsearch = 0  # these exceptions are actually catching unselected checkboxes
 
                     try:
                         newznabProviderDict[cur_id].enable_backlog = config.checkbox_to_value(
                             kwargs[cur_id + '_enable_backlog'])
-                    except Exception:
-                        newznabProviderDict[cur_id].enable_backlog = 0
+                    except (AttributeError, KeyError):
+                        newznabProviderDict[cur_id].enable_backlog = 0  # these exceptions are actually catching unselected checkboxes
                 else:
                     sickbeard.newznabProviderList.append(newProvider)
 
@@ -4790,157 +4790,158 @@ class ConfigProviders(Config):
             if hasattr(curTorrentProvider, 'custom_url'):
                 try:
                     curTorrentProvider.custom_url = str(kwargs[curTorrentProvider.get_id() + '_custom_url']).strip()
-                except Exception:
-                    curTorrentProvider.custom_url = None
+                except (AttributeError, KeyError):
+                    curTorrentProvider.custom_url = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'minseed'):
                 try:
                     curTorrentProvider.minseed = int(str(kwargs[curTorrentProvider.get_id() + '_minseed']).strip())
-                except Exception:
-                    curTorrentProvider.minseed = 0
+                except (AttributeError, KeyError):
+                    curTorrentProvider.minseed = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'minleech'):
                 try:
                     curTorrentProvider.minleech = int(str(kwargs[curTorrentProvider.get_id() + '_minleech']).strip())
-                except Exception:
-                    curTorrentProvider.minleech = 0
+                except (AttributeError, KeyError):
+                    curTorrentProvider.minleech = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'ratio'):
                 try:
                     ratio = float(str(kwargs[curTorrentProvider.get_id() + '_ratio']).strip())
                     curTorrentProvider.ratio = (ratio, -1)[ratio < 0]
-                except Exception:
-                    curTorrentProvider.ratio = None
+                except (AttributeError, KeyError):
+                    curTorrentProvider.ratio = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'digest'):
                 try:
                     curTorrentProvider.digest = str(kwargs[curTorrentProvider.get_id() + '_digest']).strip()
-                except Exception:
-                    curTorrentProvider.digest = None
+                except (AttributeError, KeyError):
+                    curTorrentProvider.digest = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'hash'):
                 try:
                     curTorrentProvider.hash = str(kwargs[curTorrentProvider.get_id() + '_hash']).strip()
-                except Exception:
-                    curTorrentProvider.hash = None
+                except (AttributeError, KeyError):
+                    curTorrentProvider.hash = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'api_key'):
                 try:
                     curTorrentProvider.api_key = str(kwargs[curTorrentProvider.get_id() + '_api_key']).strip()
-                except Exception:
-                    curTorrentProvider.api_key = None
+                except (AttributeError, KeyError):
+                    curTorrentProvider.api_key = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'username'):
                 try:
                     curTorrentProvider.username = str(kwargs[curTorrentProvider.get_id() + '_username']).strip()
-                except Exception:
-                    curTorrentProvider.username = None
+                except (AttributeError, KeyError):
+                    curTorrentProvider.username = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'password'):
                 try:
                     curTorrentProvider.password = str(kwargs[curTorrentProvider.get_id() + '_password']).strip()
-                except Exception:
-                    curTorrentProvider.password = None
+                except (AttributeError, KeyError):
+                    curTorrentProvider.password = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'passkey'):
                 try:
                     curTorrentProvider.passkey = str(kwargs[curTorrentProvider.get_id() + '_passkey']).strip()
-                except Exception:
-                    curTorrentProvider.passkey = None
+                except (AttributeError, KeyError):
+                    curTorrentProvider.passkey = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'pin'):
                 try:
                     curTorrentProvider.pin = str(kwargs[curTorrentProvider.get_id() + '_pin']).strip()
-                except Exception:
-                    curTorrentProvider.pin = None
+                except (AttributeError, KeyError):
+                    curTorrentProvider.pin = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'confirmed'):
                 try:
                     curTorrentProvider.confirmed = config.checkbox_to_value(
                         kwargs[curTorrentProvider.get_id() + '_confirmed'])
-                except Exception:
-                    curTorrentProvider.confirmed = 0
+                except (AttributeError, KeyError):
+                    curTorrentProvider.confirmed = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'ranked'):
                 try:
                     curTorrentProvider.ranked = config.checkbox_to_value(
                         kwargs[curTorrentProvider.get_id() + '_ranked'])
-                except Exception:
-                    curTorrentProvider.ranked = 0
+                except (AttributeError, KeyError):
+                    curTorrentProvider.ranked = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'engrelease'):
                 try:
                     curTorrentProvider.engrelease = config.checkbox_to_value(
                         kwargs[curTorrentProvider.get_id() + '_engrelease'])
-                except Exception:
-                    curTorrentProvider.engrelease = 0
+                except (AttributeError, KeyError):
+                    curTorrentProvider.engrelease = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'onlyspasearch'):
                 try:
                     curTorrentProvider.onlyspasearch = config.checkbox_to_value(
                         kwargs[curTorrentProvider.get_id() + '_onlyspasearch'])
-                except Exception:
-                    curTorrentProvider.onlyspasearch = 0
+                except (AttributeError, KeyError):
+                    curTorrentProvider.onlyspasearch = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'sorting'):
                 try:
                     curTorrentProvider.sorting = str(kwargs[curTorrentProvider.get_id() + '_sorting']).strip()
-                except Exception:
-                    curTorrentProvider.sorting = 'seeders'
+                except (AttributeError, KeyError):
+                    curTorrentProvider.sorting = 'seeders'  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'freeleech'):
                 try:
                     curTorrentProvider.freeleech = config.checkbox_to_value(
                         kwargs[curTorrentProvider.get_id() + '_freeleech'])
-                except Exception:
-                    curTorrentProvider.freeleech = 0
+                except (AttributeError, KeyError):
+                    curTorrentProvider.freeleech = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'search_mode'):
                 try:
                     curTorrentProvider.search_mode = str(kwargs[curTorrentProvider.get_id() + '_search_mode']).strip()
-                except Exception:
-                    curTorrentProvider.search_mode = 'eponly'
+                except (AttributeError, KeyError):
+                    curTorrentProvider.search_mode = 'eponly'  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'search_fallback'):
                 try:
                     curTorrentProvider.search_fallback = config.checkbox_to_value(
                         kwargs[curTorrentProvider.get_id() + '_search_fallback'])
-                except Exception:
+                except (AttributeError, KeyError):
                     curTorrentProvider.search_fallback = 0  # these exceptions are catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'enable_daily'):
                 try:
                     curTorrentProvider.enable_daily = config.checkbox_to_value(
                         kwargs[curTorrentProvider.get_id() + '_enable_daily'])
-                except Exception:
+                except (AttributeError, KeyError):
                     curTorrentProvider.enable_daily = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'enable_manualsearch'):
                 try:
                     curTorrentProvider.enable_manualsearch = config.checkbox_to_value(
                         kwargs[curTorrentProvider.get_id() + '_enable_manualsearch'])
-                except Exception:
+                except (AttributeError, KeyError):
                     curTorrentProvider.enable_manualsearch = 0  # these exceptions are actually catching unselected checkboxes
+                    raise
 
             if hasattr(curTorrentProvider, 'enable_backlog'):
                 try:
                     curTorrentProvider.enable_backlog = config.checkbox_to_value(
                         kwargs[curTorrentProvider.get_id() + '_enable_backlog'])
-                except Exception:
+                except (AttributeError, KeyError):
                     curTorrentProvider.enable_backlog = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'cat'):
                 try:
                     curTorrentProvider.cat = int(str(kwargs[curTorrentProvider.get_id() + '_cat']).strip())
-                except Exception:
-                    curTorrentProvider.cat = 0
+                except (AttributeError, KeyError):
+                    curTorrentProvider.cat = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curTorrentProvider, 'subtitle'):
                 try:
                     curTorrentProvider.subtitle = config.checkbox_to_value(
                         kwargs[curTorrentProvider.get_id() + '_subtitle'])
-                except Exception:
-                    curTorrentProvider.subtitle = 0
+                except (AttributeError, KeyError):
+                    curTorrentProvider.subtitle = 0  # these exceptions are actually catching unselected checkboxes
 
         for curNzbProvider in [prov for prov in sickbeard.providers.sortedProviderList() if
                                prov.provider_type == GenericProvider.NZB]:
@@ -4948,47 +4949,47 @@ class ConfigProviders(Config):
             if hasattr(curNzbProvider, 'api_key'):
                 try:
                     curNzbProvider.api_key = str(kwargs[curNzbProvider.get_id() + '_api_key']).strip()
-                except Exception:
-                    curNzbProvider.api_key = None
+                except (AttributeError, KeyError):
+                    curNzbProvider.api_key = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curNzbProvider, 'username'):
                 try:
                     curNzbProvider.username = str(kwargs[curNzbProvider.get_id() + '_username']).strip()
-                except Exception:
-                    curNzbProvider.username = None
+                except (AttributeError, KeyError):
+                    curNzbProvider.username = None  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curNzbProvider, 'search_mode'):
                 try:
                     curNzbProvider.search_mode = str(kwargs[curNzbProvider.get_id() + '_search_mode']).strip()
-                except Exception:
-                    curNzbProvider.search_mode = 'eponly'
+                except (AttributeError, KeyError):
+                    curNzbProvider.search_mode = 'eponly'  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curNzbProvider, 'search_fallback'):
                 try:
                     curNzbProvider.search_fallback = config.checkbox_to_value(
                         kwargs[curNzbProvider.get_id() + '_search_fallback'])
-                except Exception:
+                except (AttributeError, KeyError):
                     curNzbProvider.search_fallback = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curNzbProvider, 'enable_daily'):
                 try:
                     curNzbProvider.enable_daily = config.checkbox_to_value(
                         kwargs[curNzbProvider.get_id() + '_enable_daily'])
-                except Exception:
+                except (AttributeError, KeyError):
                     curNzbProvider.enable_daily = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curNzbProvider, 'enable_manualsearch'):
                try:
                    curNzbProvider.enable_manualsearch = config.checkbox_to_value(
                        kwargs[curNzbProvider.get_id() + '_enable_manualsearch'])
-               except Exception:
+               except (AttributeError, KeyError):
                    curNzbProvider.enable_manualsearch = 0  # these exceptions are actually catching unselected checkboxes
 
             if hasattr(curNzbProvider, 'enable_backlog'):
                 try:
                     curNzbProvider.enable_backlog = config.checkbox_to_value(
                         kwargs[curNzbProvider.get_id() + '_enable_backlog'])
-                except Exception:
+                except (AttributeError, KeyError):
                     curNzbProvider.enable_backlog = 0  # these exceptions are actually catching unselected checkboxes
 
         sickbeard.NEWZNAB_DATA = '!!!'.join([x.configStr() for x in sickbeard.newznabProviderList])

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -319,3 +319,12 @@ def episode_num(season=None, episode=None, **kwargs):
     elif numbering == 'absolute':
         if not (season and episode) and (season or episode):
             return '{0:0>3}'.format(season or episode)
+
+def enabled_providers(search_type):
+    """ 
+    Return providers based on search type: daily, backlog and manualsearch
+    """
+    return [x for x in sickbeard.providers.sortedProviderList(sickbeard.RANDOMIZE_PROVIDERS)
+        if x.is_active() and
+        hasattr(x, 'enable_{}'.format(search_type)) and
+        getattr(x, 'enable_{}'.format(search_type))]

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -56,6 +56,7 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
         ]
         self.cache = TVCache(self)
         self.enable_backlog = False
+        self.enable_manualsearch = False
         self.enable_daily = False
         self.enabled = False
         self.headers = {'User-Agent': UA_POOL.random}


### PR DESCRIPTION
It will only use "manual search" providers when you use "Force results" button. Because this providers don't get updated in DailySearcher as they are manual search only

So its a mix of @duramato and mine (fallback)

- Fixes thread name while doing forced search
Before:
 [c352080] Performing episode search for 
After:
[MoreThanTV] :: [c352080] Performing episode search for 

- Fixed "forced search when no results" using backlog enabled providers (in manual_snatch.py we used to use daily). Now we use "enable_manualsearch"

- Fixed: search for propers only in backlog enabled providers

- Initialize provider even if no query to execute

This changes UI but nothing that will break angular @OmgImAlexis 
