### PR TITLE
Fix compact history results so that all actions for a release are shown

### DIFF
--- a/gui/slick/views/history.mako
+++ b/gui/slick/views/history.mako
@@ -2,12 +2,12 @@
 <%!
     import sickbeard
     import os.path
-    import datetime
+    from datetime import datetime
     import re
     import time
 
     from sickbeard import providers
-    from sickbeard import sbdatetime
+    from sickbeard.sbdatetime import sbdatetime
 
     from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, FAILED, DOWNLOADED, SUBTITLED
     from sickbeard.common import Quality, statusStrings, Overview
@@ -49,11 +49,11 @@
     <table id="historyTable" class="sickbeardTable tablesorter" cellspacing="1" border="0" cellpadding="0">
         <thead>
             <tr>
-                <th class="nowrap">Time</th>
-                <th>Episode</th>
+                <th class="nowrap" width="15%">Time</th>
+                <th width="35%">Episode</th>
                 <th>Action</th>
                 <th>Provider</th>
-                <th>Quality</th>
+                <th width="14%">Quality</th>
             </tr>
         </thead>
 
@@ -65,44 +65,44 @@
 
         <tbody>
         % for hItem in historyResults:
-            <% curStatus, curQuality = Quality.splitCompositeStatus(int(hItem["action"])) %>
+            <% composite = Quality.splitCompositeStatus(int(hItem.action)) %>
             <tr>
                 <td align="center">
-                    <% airDate = sbdatetime.sbdatetime.sbfdatetime(datetime.datetime.strptime(str(hItem["date"]), History.date_format), show_seconds=True) %>
-                    <% isoDate = datetime.datetime.strptime(str(hItem["date"]), History.date_format).isoformat('T') %>
+                    <% airDate = sbdatetime.sbfdatetime(datetime.strptime(str(hItem.date), History.date_format), show_seconds=True) %>
+                    <% isoDate = datetime.strptime(str(hItem.date), History.date_format).isoformat('T') %>
                     <time datetime="${isoDate}" class="date">${airDate}</time>
                 </td>
-                <td class="tvShow" width="35%"><a href="${srRoot}/home/displayShow?show=${hItem["show_id"]}#S${hItem["season"]}E${hItem["episode"]}">${hItem["show_name"]} - ${"S%02i" % int(hItem["season"])}${"E%02i" % int(hItem["episode"])} ${('', '<span class="quality Proper">Proper</span>')["proper" in hItem["resource"].lower() or "repack" in hItem["resource"].lower()]}</a></td>
-                <td align="center" ${('', 'class="subtitles_column"')[curStatus == SUBTITLED]}>
-                % if curStatus == SUBTITLED:
-                    <img width="16" height="11" style="vertical-align:middle;" src="${srRoot}/images/subtitles/flags/${hItem['resource']}.png" onError="this.onerror=null;this.src='${srRoot}/images/flags/unknown.png';">
+                <td class="tvShow"><a href="${srRoot}/home/displayShow?show=${hItem.show_id}#S${hItem.season}E${hItem.episode}">${hItem.show_name} - ${"S%02i" % int(hItem.season)}${"E%02i" % int(hItem.episode)} ${('', '<span class="quality Proper">Proper</span>')["proper" in hItem.resource.lower() or "repack" in hItem.resource.lower()]}</a></td>
+                <td align="center" ${('', 'class="subtitles_column"')[composite.status == SUBTITLED]}>
+                % if composite.status == SUBTITLED:
+                    <img width="16" height="11" style="vertical-align:middle;" src="${srRoot}/images/subtitles/flags/${hItem.resource}.png" onError="this.onerror=null;this.src='${srRoot}/images/flags/unknown.png';">
                 % endif
-                    <span style="cursor: help; vertical-align:middle;" title="${ek(os.path.basename, hItem['resource'])}">${statusStrings[curStatus]}</span>
+                    <span style="cursor: help; vertical-align:middle;" title="${ek(os.path.basename, hItem.resource)}">${statusStrings[composite.status]}</span>
                 </td>
                 <td align="center">
-                % if curStatus in [DOWNLOADED, ARCHIVED]:
-                    % if hItem["provider"] != "-1":
-                        <span style="vertical-align:middle;"><i>${hItem["provider"]}</i></span>
+                % if composite.status in [DOWNLOADED, ARCHIVED]:
+                    % if hItem.provider != "-1":
+                        <span style="vertical-align:middle;"><i>${hItem.provider}</i></span>
                     % else:
                         <span style="vertical-align:middle;"><i>Unknown</i></span>
                     % endif
                 % else:
-                    % if hItem["provider"] > 0:
-                        % if curStatus in [SNATCHED, FAILED]:
-                            <% provider = providers.getProviderClass(GenericProvider.make_id(hItem["provider"])) %>
+                    % if hItem.provider > 0:
+                        % if composite.status in [SNATCHED, FAILED]:
+                            <% provider = providers.getProviderClass(GenericProvider.make_id(hItem.provider)) %>
                             % if provider is not None:
                                 <img src="${srRoot}/images/providers/${provider.image_name()}" width="16" height="16" style="vertical-align:middle;" /> <span style="vertical-align:middle;">${provider.name}</span>
                             % else:
                                 <img src="${srRoot}/images/providers/missing.png" width="16" height="16" style="vertical-align:middle;" title="missing provider"/> <span style="vertical-align:middle;">Missing Provider</span>
                             % endif
                         % else:
-                                <img src="${srRoot}/images/subtitles/${hItem['provider']}.png" width="16" height="16" style="vertical-align:middle;" /> <span style="vertical-align:middle;">${hItem["provider"].capitalize()}</span>
+                                <img src="${srRoot}/images/subtitles/${hItem.provider}.png" width="16" height="16" style="vertical-align:middle;" /> <span style="vertical-align:middle;">${hItem.provider.capitalize()}</span>
                         % endif
                     % endif
                 % endif
                 </td>
-                <span style="display: none;">${curQuality}</span>
-                <td align="center">${renderQualityPill(curQuality)}</td>
+                <span style="display: none;">${composite.quality}</span>
+                <td align="center">${renderQualityPill(composite.quality)}</td>
             </tr>
         % endfor
         </tbody>
@@ -112,14 +112,14 @@
     <table id="historyTable" class="sickbeardTable tablesorter" cellspacing="1" border="0" cellpadding="0">
         <thead>
             <tr>
-                <th class="nowrap">Time</th>
-                <th>Episode</th>
+                <th class="nowrap" width="15%">Time</th>
+                <th width="25%">Episode</th>
                 <th>Snatched</th>
                 <th>Downloaded</th>
                 % if sickbeard.USE_SUBTITLES:
                 <th>Subtitled</th>
                 % endif
-                <th>Quality</th>
+                <th width="14%">Quality</th>
             </tr>
         </thead>
 
@@ -133,20 +133,20 @@
         % for hItem in compactResults:
             <tr>
                 <td align="center">
-                    <% airDate = sbdatetime.sbdatetime.sbfdatetime(datetime.datetime.strptime(str(hItem["actions"][0]["time"]), History.date_format), show_seconds=True) %>
-                    <% isoDate = datetime.datetime.strptime(str(hItem["actions"][0]["time"]), History.date_format).isoformat('T') %>
+                    <% airDate = sbdatetime.sbfdatetime(datetime.strptime(str(hItem.actions[0].date), History.date_format), show_seconds=True) %>
+                    <% isoDate = datetime.strptime(str(hItem.actions[0].date), History.date_format).isoformat('T') %>
                     <time datetime="${isoDate}" class="date">${airDate}</time>
                 </td>
-                <td class="tvShow" width="25%">
-                    <span><a href="${srRoot}/home/displayShow?show=${hItem["show_id"]}#season-${hItem["season"]}">${hItem["show_name"]} - ${"S%02i" % int(hItem["season"])}${"E%02i" % int(hItem["episode"])}${('', ' <span class="quality Proper">Proper</span>')['proper' in hItem["resource"].lower() or 'repack' in hItem["resource"].lower()]}</a></span>
+                <td class="tvShow">
+                    <span><a href="${srRoot}/home/displayShow?show=${hItem.index.show_id}#season-${hItem.index.season}">${hItem.show_name} - ${"S%02i" % int(hItem.index.season)}${"E%02i" % int(hItem.index.episode)}${('', ' <span class="quality Proper">Proper</span>')['proper' in hItem.actions[0].resource.lower() or 'repack' in hItem.actions[0].resource.lower()]}</a></span>
                 </td>
-                <td align="center" provider="${str(sorted(hItem["actions"])[0]["provider"])}">
-                    % for action in sorted(hItem["actions"]):
-                        <% curStatus, curQuality = Quality.splitCompositeStatus(int(action["action"])) %>
-                        % if curStatus in [SNATCHED, FAILED]:
-                            <% provider = providers.getProviderClass(GenericProvider.make_id(action["provider"])) %>
+                <td align="center" provider="${str(sorted(hItem.actions)[0].provider)}">
+                    % for cur_action in sorted(hItem.actions):
+                        <% composite = Quality.splitCompositeStatus(int(cur_action.action)) %>
+                        % if composite.status in [SNATCHED, FAILED]:
+                            <% provider = providers.getProviderClass(GenericProvider.make_id(cur_action.provider)) %>
                             % if provider is not None:
-                                <img src="${srRoot}/images/providers/${provider.image_name()}" width="16" height="16" style="vertical-align:middle;" alt="${provider.name}" style="cursor: help;" title="${provider.name}: ${ek(os.path.basename, action["resource"])}"/>
+                                <img src="${srRoot}/images/providers/${provider.image_name()}" width="16" height="16" style="vertical-align:middle;" alt="${provider.name}" style="cursor: help;" title="${provider.name}: ${ek(os.path.basename, cur_action.resource)}"/>
                             % else:
                                 <img src="${srRoot}/images/providers/missing.png" width="16" height="16" style="vertical-align:middle;" alt="missing provider" title="missing provider"/>
                             % endif
@@ -154,31 +154,31 @@
                     % endfor
                 </td>
                 <td align="center">
-                    % for action in sorted(hItem["actions"]):
-                        <% curStatus, curQuality = Quality.splitCompositeStatus(int(action["action"])) %>
-                        % if curStatus in [DOWNLOADED, ARCHIVED]:
-                            % if action["provider"] != "-1":
-                                <span style="cursor: help;" title="${ek(os.path.basename, action["resource"])}"><i>${action["provider"]}</i></span>
+                    % for cur_action in sorted(hItem.actions):
+                        <% composite = Quality.splitCompositeStatus(int(cur_action.action)) %>
+                        % if composite.status in [DOWNLOADED, ARCHIVED]:
+                            % if cur_action.provider != "-1":
+                                <span style="cursor: help;" title="${ek(os.path.basename, cur_action.resource)}"><i>${cur_action.provider}</i></span>
                             % else:
-                                <span style="cursor: help;" title="${ek(os.path.basename, action["resource"])}"><i>Unknown</i></span>
+                                <span style="cursor: help;" title="${ek(os.path.basename, cur_action.resource)}"><i>Unknown</i></span>
                             % endif
                         % endif
                     % endfor
                 </td>
                 % if sickbeard.USE_SUBTITLES:
                 <td align="center">
-                    % for action in sorted(hItem["actions"]):
-                        <% curStatus, curQuality = Quality.splitCompositeStatus(int(action["action"])) %>
-                        % if curStatus == SUBTITLED:
-                            <img src="${srRoot}/images/subtitles/${action['provider']}.png" width="16" height="16" style="vertical-align:middle;" alt="${action["provider"]}" title="${action["provider"].capitalize()}: ${ek(os.path.basename, action["resource"])}"/>
+                    % for cur_action in sorted(hItem.actions):
+                        <% composite = Quality.splitCompositeStatus(int(cur_action.action)) %>
+                        % if composite.status == SUBTITLED:
+                            <img src="${srRoot}/images/subtitles/${cur_action.provider}.png" width="16" height="16" style="vertical-align:middle;" alt="${cur_action.provider}" title="${cur_action.provider.capitalize()}: ${ek(os.path.basename, cur_action.resource)}"/>
                             <span style="vertical-align:middle;"> / </span>
-                            <img width="16" height="11" style="vertical-align:middle;" src="${srRoot}/images/subtitles/flags/${action['resource']}.png" onError="this.onerror=null;this.src='${srRoot}/images/flags/unknown.png';" style="vertical-align: middle !important;">
+                            <img width="16" height="11" style="vertical-align:middle;" src="${srRoot}/images/subtitles/flags/${cur_action.resource}.png" onError="this.onerror=null;this.src='${srRoot}/images/flags/unknown.png';" style="vertical-align: middle !important;">
                             &nbsp;
                         % endif
                     % endfor
                 </td>
                 % endif
-                <td align="center" width="14%" quality="${curQuality}">${renderQualityPill(curQuality)}</td>
+                <td align="center" quality="${composite.quality}">${renderQualityPill(composite.quality)}</td>
             </tr>
         % endfor
         </tbody>

--- a/tests/sickrage_tests/show/history_tests.py
+++ b/tests/sickrage_tests/show/history_tests.py
@@ -65,38 +65,6 @@ class HistoryTests(unittest.TestCase):
             for (action, result) in tests.iteritems():
                 self.assertEqual(History._get_actions(action), result)  # pylint: disable=protected-access
 
-    def test_get_limit(self):
-        """
-        Test get limit
-        """
-        test_cases = {
-            None: 0,
-            '': 0,
-            '0': 0,
-            '5': 5,
-            '-5': 0,
-            '1.5': 0,
-            '-1.5': 0,
-            5: 5,
-            -5: 0,
-            1.5: 1,
-            -1.5: 0,
-        }
-
-        unicode_test_cases = {
-            u'': 0,
-            u'0': 0,
-            u'5': 5,
-            u'-5': 0,
-            u'1.5': 0,
-            u'-1.5': 0,
-        }
-
-        for tests in test_cases, unicode_test_cases:
-            for (action, result) in tests.iteritems():
-                self.assertEqual(History._get_limit(action), result)  # pylint: disable=protected-access
-
-
 if __name__ == '__main__':
     print('=====> Testing %s' % __file__)
 


### PR DESCRIPTION
...and limit it by number of releases, not number of actions
based on #171 by @fernandog

##### common.py
* Change splitCompositeStatus to return a namedtuple(status, quality)
* Optimize imports
* Minor clean-up

##### webapi.py
* Change to use the named tuples in history
* Optimize imports
* Remove unused variables
* Clean up todo items

##### webserve.py
* Move compact history subroutine from webserve.py sickrage\show\History
* Optimize imports
* Remove unused variables
* Remove redundant parentheses
* Clean up todo items

##### sickrage/show/History.py
* Rewrite compact history subroutine
  * Update show.history to use namedtuple instead of dict
  * return namedtuple instead of tuple
  * limit releases by number of releases and not number of actions
* Optimize imports
* Add todo and docs
