### PR TITLE
Strip() in pre-script result

### DIFF
--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -884,7 +884,7 @@ def run_subs_scripts(scripts, script_args):
             process = subprocess.Popen(inner_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                        stderr=subprocess.STDOUT, cwd=sickbeard.PROG_DIR)
             out, _ = process.communicate()  # @UnusedVariable
-            logger.log(u'Script result: {0}'.format(out), logger.DEBUG)
+            logger.log(u'Script result: {0}'.format(out.rstrip()), logger.DEBUG)
 
         except Exception as error:
             logger.log(u'Unable to run subtitles script: {0}'.format(ex(error)))


### PR DESCRIPTION
Log with AA (empty line):

```
2016-03-29 18:47:53 DEBUG    FINDSUBTITLES :: [fcb0d34] Could not search in legendastv provider. Discarding for now
AA
2016-03-29 18:47:53 DEBUG    FINDSUBTITLES :: [fcb0d34] Script result: Nothing to rename
2016-03-29 18:47:53 INFO     FINDSUBTITLES :: [fcb0d34] Executing command: ['python', '/home/osmc/scripts/rename_releases.py', '/media/SAMSUNG/media/downloaded/series/Show.S07E18.1080p.HDTV.X264-DIMENSION.mkv']
2016-03-29 18:47:53 INFO     FINDSUBTITLES :: [fcb0d34] Running subtitle pre-script: python /home/osmc/scripts/rename_releases.py
```

```
>>> import subprocess
>>> inner_cmd = ['python', '/home/osmc/scripts/rename_releases.py', '/media/SAMSUNG/media/downloaded/series/Show.S04E04.1080p.HDTV.x264-BRISK.mkv']
>>> process = subprocess.Popen(inner_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
...                                        stderr=subprocess.STDOUT)
>>> out, _ = process.communicate()
>>> print out
Nothing to rename

>>> print out.strip()
Nothing to rename
>>>
```

My pre-script:
```
# coding=utf-8
#!/usr/bin/python

import os
import sys

filename = sys.argv[1]
if filename.rpartition('.')[2] in ('mkv', 'mp4', 'avi'):
    new_filename = filename.replace('VietHD', 'RARBG').replace('DRACULA','RARBG')
    if new_filename != filename:
        print("Renaming: {} para {}".format(filename, new_filename))
        os.rename(filename, new_filename)
    else:
        print("Nothing to rename")

```