### PR TITLE
[Manual Search] Avoid Daily searcher run together with Manual Search

### DIFF
--- a/sickbeard/generic_queue.py
+++ b/sickbeard/generic_queue.py
@@ -66,6 +66,18 @@ class GenericQueue(object):
 
             return item
 
+    def remove_item(self, item):
+        """
+        Removes an item to this queue
+
+        :param item: Queue object to remove
+        :return: item
+        """
+        with self.lock:
+            self.queue = [queue_item for queue_item in self.queue if queue_item != item]
+
+            return item
+
     def run(self, force=False):
         """
         Process items in this queue

--- a/sickbeard/manual_search.py
+++ b/sickbeard/manual_search.py
@@ -217,6 +217,9 @@ def get_provider_cache_results(indexer, show_all_results=None, perform_search=No
         # make a queue item for it and put it on the queue
         ep_queue_item = search_queue.ForcedSearchQueueItem(ep_obj.show, ep_obj, bool(int(down_cur_quality)), True)  # pylint: disable=maybe-no-member
 
+        # Remove item from DailySearcher/BacklogSearcher before adding item to manual search queue
+        # sickbeard.searchQueueScheduler.action.remove_item(???)
+
         sickbeard.searchQueueScheduler.action.add_item(ep_queue_item)
 
         # give the CPU a break and some time to start the queue

--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -78,8 +78,8 @@ class SearchQueue(generic_queue.GenericQueue):
         self.min_priority = 0
 
     def is_backlog_paused(self):
-        # backlog priorities are NORMAL, this should be done properly somewhere
-        return self.min_priority >= generic_queue.QueuePriorities.NORMAL
+        # backlog priorities are LOW, this should be done properly somewhere
+        return self.min_priority >= generic_queue.QueuePriorities.LOW
 
     def is_manualsearch_in_progress(self):
         # Only referenced in webserve.py, only current running manualsearch or failedsearch is needed!!
@@ -126,6 +126,13 @@ class SearchQueue(generic_queue.GenericQueue):
             generic_queue.GenericQueue.add_item(self, item)
         else:
             logger.log(u"Not adding item, it's already in the queue", logger.DEBUG)
+
+    def remove_item(self, item):
+        """
+        Removes a item from generic queue
+        """
+
+        generic_queue.GenericQueue.remove_item(self, item)
 
 
 class DailySearchQueueItem(generic_queue.QueueItem):


### PR DESCRIPTION
Solution 1:
- [ ] Block snatchEpisode from daily/backlog/proper if that episode is being manually searched (snatchSelection page is open)

Solution 2:
- [ ] Remove show/ep from dailysearcher/backlog queue if its already running before user hit "manual search"


as discussed in IRC a few weeks ago.
when Manual search is running together with DailySearcher, it may find a result and auto snatch. But also user may snatch so it snatches twice (I had this issue, also @duramato)

@p0psicles @medariox @labrys need help to continue

this is labrys  idea to remove from queue (I would remove entire show from queue because use may select a multi-episode release)

maybe we can check "is_dailysearch_in_progress" and "is_backlog_in_progress" and then remove
but if the daily/backlog are about to start (like in 2min or 30s) how do we proceed? In generic_queue we have "pause", so if they are not running we can pause (or postpone threads)
maybe polling snatchSelection page and send a manualsearch_open" = True
