### PR TITLE
Don't run daily/backlog/propers searcher when manualsearch is searching

### DIFF
--- a/sickbeard/dailysearcher.py
+++ b/sickbeard/dailysearcher.py
@@ -43,7 +43,13 @@ class DailySearcher(object):  # pylint:disable=too-few-public-methods
         :param force: Force search
         """
         if self.amActive:
+            logger.log(u"Daily search is still running, not starting it again", logger.DEBUG)
             return
+
+        if sickbeard.searchQueueScheduler.action.is_manualsearch_in_progress():
+            logger.log(u"Manual search is running. Can't start Daily search", logger.WARNING)
+            return
+
 
         self.amActive = True
         _ = force

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -51,6 +51,14 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
         :param force: Start even if already running (currently not used, defaults to False)
         """
         logger.log(u"Beginning the search for new propers")
+        
+        if self.amActive:
+            logger.log(u"Find propers is still running, not starting it again", logger.DEBUG)
+            return
+
+        if sickbeard.searchQueueScheduler.action.is_manualsearch_in_progress():
+            logger.log(u"Manual search is running. Can't start Find propers", logger.WARNING)
+            return
 
         self.amActive = True
 

--- a/sickbeard/searchBacklog.py
+++ b/sickbeard/searchBacklog.py
@@ -73,6 +73,10 @@ class BacklogSearcher(object):
         if self.amActive:
             logger.log(u"Backlog is still running, not starting it again", logger.DEBUG)
             return
+        
+        if sickbeard.searchQueueScheduler.action.is_manualsearch_in_progress():
+            logger.log(u"Manual search is running. Can't start Backlog Search", logger.WARNING)
+            return
 
         self.amActive = True
         self.amPaused = False


### PR DESCRIPTION
It doesn't start other threads when manual search is actually running:

```
SEARCHQUEUE-FORCEDSEARCH-295515 :: [ThePirateBay] :: [1eb2e79] Performing episode search for Quantico
SEARCHQUEUE-FORCEDSEARCH-295515 :: [Speedcd] :: [1eb2e79] Performing episode search for Quantico
SEARCHQUEUE-FORCEDSEARCH-295515 :: [HDTorrents] :: [1eb2e79] Performing episode search for Quantico
SEARCHQUEUE-FORCEDSEARCH-295515 :: [TorrentDay] :: [1eb2e79] Performing episode search for Quantico
SEARCHQUEUE-FORCEDSEARCH-295515 :: [AlphaRatio] :: [1eb2e79] Performing episode search for Quantico
DAILYSEARCHER :: [1eb2e79] Manual search is running. Can't start Daily search
Thread-16 :: [1eb2e79] Daily search forced
SEARCHQUEUE-FORCEDSEARCH-295515 :: [Rarbg] :: [1eb2e79] Performing episode search for Quantico
SEARCHQUEUE-FORCEDSEARCH-295515 :: [MoreThanTV] :: [1eb2e79] Performing episode search for Quantico
SEARCHQUEUE-FORCEDSEARCH-295515 :: [1eb2e79] Using manual search providers
SEARCHQUEUE-FORCEDSEARCH-295515 :: [1eb2e79] Beginning forced search for: [Quantico - S01E16 - Clue]
```