### PR TITLE
Logging improvements

### DIFF
--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -154,6 +154,7 @@ class Logger(object):  # pylint: disable=too-many-instance-attributes
             if logger is not self.logger:
                 logger.root = self.logger
                 logger.parent = self.logger
+                logger.propagate = False
 
         log_level = DB if self.database_logging else DEBUG if self.debug_logging else INFO
 

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -233,7 +233,7 @@ class Logger(object):  # pylint: disable=too-many-instance-attributes
             r'error \[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE\] sslv3 alert handshake failure \(_ssl\.c:\d+\)',
         ]
         for ssl_error in ssl_errors:
-            check = re.sub(ssl_error, 'See: http://git.io/vuU5V', message)
+            check = re.sub(ssl_error, 'See: https://git.io/vVaIj', message)
             if check != message:
                 message = check
                 level = WARNING


### PR DESCRIPTION
- Fixing duplicate logging message (when enabling subliminal logging)
- Moving threadName and 'current commit hash' to the logger formatter in order to have the same message pattern for modules other than sickbeard.

Here's a preview:

```
2016-04-05 21:40:15 INFO     Thread-16 :: [6bb3888] No subtitles found for /library/series/Real Humans/Season 02/Real Humans - S02E10 - Episode 10.mkv
2016-04-05 21:40:15 INFO     Thread-16 :: [6bb3888] Searching candidates using the keyword real humans
2016-04-05 21:40:14 INFO     Thread-16 :: [6bb3888] Logging in
2016-04-05 21:40:14 INFO     Thread-16 :: [6bb3888] Initializing provider legendastv
2016-04-05 21:40:14 INFO     Thread-16 :: [6bb3888] Listing subtitles with provider 'legendastv' and languages set([])
2016-04-05 21:40:14 INFO     Thread-16 :: [6bb3888] Refining video with omdb
2016-04-05 21:40:13 INFO     Thread-16 :: [6bb3888] Getting series episode 2x10
2016-04-05 21:40:12 INFO     Thread-16 :: [6bb3888] Searching series 'Real Humans'
2016-04-05 21:40:12 INFO     Thread-16 :: [6bb3888] Refining video with tvdb
2016-04-05 21:40:12 INFO     Thread-16 :: [6bb3888] Refining video with release
2016-04-05 21:40:12 INFO     Thread-16 :: [6bb3888] Refining video with metadata
2016-04-05 21:40:12 INFO     Thread-16 :: [6bb3888] Scanning video 'Real Humans - S02E10 - Episode 10.mkv' in '/library/series/Real Humans/Season 02'
2016-04-05 21:39:38 INFO     TORNADO :: [6bb3888] Starting Medusa on http://0.0.0.0:8081/
```

Additional configuration could be later added to enable/disable certain modules to be logged.

### I'm still testing to see if everything is working as expected.