### PR TITLE
Check if search threads like forceSearch, backLogsearch are running when manual snatching

### DIFF
--- a/gui/slick/js/core.js
+++ b/gui/slick/js/core.js
@@ -2528,6 +2528,12 @@ var SICKRAGE = {
                     } else {
                         $(link).children('img').attr('src', srRoot + '/images/no16.png');
                     }
+                    if (data.message != '') {
+                        $('#manual-select-warning').removeClass('hidden');
+                        $('#manual-select-warning span').text(data.message);
+                    } else {
+                        $('#manual-select-warning').addClass('hidden');
+                    }
                 });
             });
 

--- a/gui/slick/views/snatchSelection.mako
+++ b/gui/slick/views/snatchSelection.mako
@@ -183,9 +183,15 @@
             </div>
         </div>
     
-    <input class="btn manualSearchButton" type="button" id="reloadResults" value="Reload Results" data-force-search="0" />
-    <input class="btn manualSearchButton" type="button" id="reloadResultsForceSearch" value="Force Search" data-force-search="1" />
+    <div id="manual-search-navigation">
+        <input class="btn manualSearchButton" type="button" id="reloadResults" value="Reload Results" data-force-search="0" />
+        <input class="btn manualSearchButton" type="button" id="reloadResultsForceSearch" value="Force Search" data-force-search="1" />
+    </div>
     <div id="searchNotification"></div>
+    <div id="manual-select-warning" class="alert alert-danger hidden-print hidden" role="alert">
+            <span></span>
+    </div>
+        
     
     <div class="clearfix"></div>
     <div id="wrapper">

--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -89,13 +89,19 @@ class SearchQueue(generic_queue.GenericQueue):
 
     def is_backlog_in_progress(self):
         for cur_item in self.queue + [self.currentItem]:
-            if isinstance(cur_item, BacklogQueueItem):
+            if isinstance(cur_item, (BacklogQueueItem, FailedQueueItem)):
                 return True
         return False
 
     def is_dailysearch_in_progress(self):
         for cur_item in self.queue + [self.currentItem]:
             if isinstance(cur_item, DailySearchQueueItem):
+                return True
+        return False
+
+    def is_forced_search_in_progress(self):
+        for cur_item in self.queue + [self.currentItem]:
+            if isinstance(cur_item, ForcedSearchQueueItem):
                 return True
         return False
 


### PR DESCRIPTION
…ailySearch, properSearch, when snatching an episode using manual search. If a search is running, this is shown to the user, using an alert-danger.

Please don't merge this yet. I've done this in a rush, with minimal testing.
This is more to discuss the solution. And this can be used as a POC.

Note! Manual Search snatches are always queued behind backlog searches.