### PR TITLE
Fix when the only existing subs is deleted and DB wasnt updated

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1401,14 +1401,15 @@ class TVEpisode(object):  # pylint: disable=too-many-instance-attributes, too-ma
     def refreshSubtitles(self):
         """Look for subtitles files and refresh the subtitles property."""
         current_subtitles = subtitles.get_current_subtitles(self.location)
-        if current_subtitles:
-            if self.subtitles == current_subtitles:
-                ep_num = episode_num(self.season, self.episode) or \
-                         episode_num(self.season, self.episode, numbering='absolute')
-                logger.log(u'No changed subtitles for {0} {1}'.format(self.show.name, ep_num), logger.DEBUG)
-            else:
-                self.subtitles = current_subtitles
-                self.saveToDB()
+        ep_num = episode_num(self.season, self.episode) or \
+                 episode_num(self.season, self.episode, numbering='absolute')
+        if self.subtitles == current_subtitles:
+            logger.log(u'No changed subtitles for {0} {1}. Current subtitles: {2}'.format(self.show.name, ep_num, current_subtitles), logger.DEBUG)
+        else:
+            logger.log(u'Subtitle changes detected for this show {0} {1}. Current subtitles: {2}'.format(self.show.name, ep_num, current_subtitles), logger.DEBUG)
+            self.subtitles = current_subtitles
+            self.saveToDB()
+
 
     def download_subtitles(self, force=False):
         if not ek(os.path.isfile, self.location):


### PR DESCRIPTION
1) Erase one subtitle file for a show in library
2) Refresh files. 
3) CC icon appears
4) Re-add subtitle again
5) CC icon disappears

@ratoaq2 problem is that information is cached and need to wait cache expires to detect properly

can we override cache information when forced refresh?

```
11:22:06 DEBUG::SHOWQUEUE-REFRESH :: [1fc2460] Using cached parse result for: The.Americans.S04E04.1080p.WEB-DL.DD5.1.h.264-NTb
11:22:06 DEBUG::SHOWQUEUE-REFRESH :: [1fc2460] Name The.Americans.S04E04.1080p.WEB-DL.DD5.1.h.264-NTb gave release group of NTb, seems valid
11:22:06 DEBUG::SHOWQUEUE-REFRESH :: [1fc2460] Found cached video information under key sickbeard.subtitles:video|/media/SAMSUNG/media/series/The Americans (2013)/Season 4/The.Americans.S04E04.1080p.WEB-DL.DD5.1.h.264-NTb.mkv|None|True|None|None
11:22:06 DEBUG::SHOWQUEUE-REFRESH :: [1fc2460] No changed subtitles for The Americans (2013) S04E04
```