### PR TITLE
[Manual Search] Added a manualSnatchScheduler to handle SnatchQueue items

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -106,10 +106,12 @@ showUpdateScheduler = None
 versionCheckScheduler = None
 showQueueScheduler = None
 searchQueueScheduler = None
+manualSnatchScheduler = None
 properFinderScheduler = None
 autoPostProcesserScheduler = None
 subtitlesFinderScheduler = None
 traktCheckerScheduler = None
+
 
 showList = []
 
@@ -628,7 +630,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             USE_PUSHBULLET, PUSHBULLET_NOTIFY_ONSNATCH, PUSHBULLET_NOTIFY_ONDOWNLOAD, PUSHBULLET_NOTIFY_ONSUBTITLEDOWNLOAD, PUSHBULLET_API, PUSHBULLET_DEVICE, \
             versionCheckScheduler, VERSION_NOTIFY, AUTO_UPDATE, NOTIFY_ON_UPDATE, PROCESS_AUTOMATICALLY, NO_DELETE, UNPACK, CPU_PRESET, \
             KEEP_PROCESSED_DIR, PROCESS_METHOD, DELRARCONTENTS, TV_DOWNLOAD_DIR, UPDATE_FREQUENCY, \
-            showQueueScheduler, searchQueueScheduler, ROOT_DIRS, CACHE_DIR, ACTUAL_CACHE_DIR, TIMEZONE_DISPLAY, \
+            showQueueScheduler, searchQueueScheduler, manualSnatchScheduler, ROOT_DIRS, CACHE_DIR, ACTUAL_CACHE_DIR, TIMEZONE_DISPLAY, \
             NAMING_PATTERN, NAMING_MULTI_EP, NAMING_ANIME_MULTI_EP, NAMING_FORCE_FOLDERS, NAMING_ABD_PATTERN, NAMING_CUSTOM_ABD, NAMING_SPORTS_PATTERN, NAMING_CUSTOM_SPORTS, NAMING_ANIME_PATTERN, NAMING_CUSTOM_ANIME, NAMING_STRIP_YEAR, \
             RENAME_EPISODES, AIRDATE_EPISODES, FILE_TIMESTAMP_TIMEZONE, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
             providerList, newznabProviderList, torrentRssProviderList, \
@@ -1467,6 +1469,10 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
                                                   threadName="SHOWUPDATER",
                                                   start_time=datetime.time(hour=SHOWUPDATE_HOUR, minute=random.randint(0, 59)))
 
+        # snatcher used for manual search, manual picked results
+        manualSnatchScheduler = scheduler.Scheduler(search_queue.SnatchQueue(),
+                                                    cycleTime=datetime.timedelta(seconds=3),
+                                                    threadName="MANUALSNATCHQUEUE")
         # searchers
         searchQueueScheduler = scheduler.Scheduler(search_queue.SearchQueue(),
                                                    cycleTime=datetime.timedelta(seconds=3),
@@ -1556,6 +1562,10 @@ def start():
             searchQueueScheduler.enable = True
             searchQueueScheduler.start()
 
+            # start the search queue checker
+            manualSnatchScheduler.enable = True
+            manualSnatchScheduler.start()
+
             # start the proper finder
             if DOWNLOAD_PROPERS:
                 properFinderScheduler.silent = False
@@ -1611,6 +1621,7 @@ def halt():
                 versionCheckScheduler,
                 showQueueScheduler,
                 searchQueueScheduler,
+                manualSnatchScheduler,
                 autoPostProcesserScheduler,
                 traktCheckerScheduler,
                 properFinderScheduler,

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -503,10 +503,10 @@ def searchProviders(show, episodes, forced_search=False, downCurQuality=False, m
     if manual_search:
         logger.log("Using manual search providers")
         providers = [x for x in sickbeard.providers.sortedProviderList(sickbeard.RANDOMIZE_PROVIDERS)
-                    if x.is_active() and x.enable_manualsearch]
+                     if x.is_active() and x.enable_manualsearch]
     else:
         providers = [x for x in sickbeard.providers.sortedProviderList(sickbeard.RANDOMIZE_PROVIDERS)
-                    if x.is_active() and x.enable_backlog]
+                     if x.is_active() and x.enable_backlog]
 
     if not forced_search:
         for cur_provider in providers:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1455,10 +1455,10 @@ class Home(WebRoot):
                 ep_objs.append(TVEpisode(show_obj, int(cached_result['season']), int(episode)))
 
         # Create the queue item
-        snatch_queue_item = search_queue.ManualSearchQueueItem(show_obj, ep_objs, provider, cached_result)
+        snatch_queue_item = search_queue.ManualSnatchQueueItem(show_obj, ep_objs, provider, cached_result)
 
         # Add the queue item to the queue
-        sickbeard.searchQueueScheduler.action.add_item(snatch_queue_item)
+        sickbeard.manualSnatchScheduler.action.add_item(snatch_queue_item)
 
         while snatch_queue_item.success is not False:
             if snatch_queue_item.started and snatch_queue_item.success:


### PR DESCRIPTION
Snatches found from the manual search are now handled by a dedicated scheduler.

Before they where queued in the searchScheduler thread.

* Fixed the queue_length reporting on manual searches. These are now reported correctly and separate from forced searches.