### PR TITLE
[Manual Search] Move show_words and use new function to filter words

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,3 @@ cache:
 after_failure:
   - cat ./Logs/sickrage.log
 
-notifications:
-  irc: "irc.freenode.net#pymedusa"
-  email:
-    on_success: change
-    on_failure: change

--- a/gui/slick/views/snatchSelection.mako
+++ b/gui/slick/views/snatchSelection.mako
@@ -5,7 +5,7 @@
     import ntpath
     import os.path
     import sickbeard
-    from sickbeard import subtitles, sbdatetime, network_timezones, helpers
+    from sickbeard import subtitles, sbdatetime, network_timezones, helpers, show_name_helpers
     import sickbeard.helpers
 
     from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, FAILED, DOWNLOADED
@@ -222,6 +222,8 @@
                 if hItem["name"] and require_words and any([i for i in require_words.split(',') if i.lower() in hItem["name"].lower()]):
                     name_require = True
                 if hItem["name"] and ignore_words and any([i for i in ignore_words.split(',') if i.lower() in hItem["name"].lower()]):
+                    name_ignore = True
+                if hItem["name"] and not show_name_helpers.filterBadReleases(hItem["name"]):
                     name_ignore = True
 
 

--- a/gui/slick/views/snatchSelection.mako
+++ b/gui/slick/views/snatchSelection.mako
@@ -123,16 +123,16 @@
                 % endif
 
                 % if require_words:
-                    <tr><td class="showLegend" style="vertical-align: top;">Required Words: </td><td><span class="break-word">${require_words}</span></td></tr>
+                    <tr><td class="showLegend" style="vertical-align: top;">Required Words: </td><td><span class="break-word"><font color="green">${require_words}</font></span></td></tr>
                 % endif
                 % if ignore_words:
-                    <tr><td class="showLegend" style="vertical-align: top;">Ignored Words: </td><td><span class="break-word">${ignore_words}</span></td></tr>
+                    <tr><td class="showLegend" style="vertical-align: top;">Ignored Words: </td><td><span class="break-word"><font color="red">${ignore_words}</font></span></td></tr>
                 % endif
                 % if preferred_words:
-                    <tr><td class="showLegend" style="vertical-align: top;">Preferred Words: </td><td><span class="break-word">${preferred_words}</span></td></tr>
+                    <tr><td class="showLegend" style="vertical-align: top;">Preferred Words: </td><td><span class="break-word"><font color="blue">${preferred_words}</font></span></td></tr>
                 % endif
                 % if undesired_words:
-                    <tr><td class="showLegend" style="vertical-align: top;">Undesired Words: </td><td><span class="break-word">${undesired_words}</span></td></tr>
+                    <tr><td class="showLegend" style="vertical-align: top;">Undesired Words: </td><td><span class="break-word"><font color="orange">${undesired_words}</font></span></td></tr>
                 % endif
                 % if bwl and bwl.whitelist:
                     <tr>
@@ -210,14 +210,22 @@
                 <%
                 release_group_ignore = False
                 release_group_require = False
+                release_group_preferred = False
+                release_group_undesired = False
                 name_ignore = False
                 name_require = False
+                name_undesired = False
+                name_preferred = False
                 
                 release_group = helpers.remove_non_release_groups(hItem["release_group"])
                 if release_group and ignore_words and release_group.lower() in ignore_words.lower().split(','):
                     release_group_ignore = True
                 elif release_group and require_words and release_group.lower() in require_words.lower().split(','):
                     release_group_require = True
+                elif release_group and preferred_words and release_group.lower() in preferred_words.lower().split(','):
+                    release_group_preferred = True
+                elif release_group and undesired_words and release_group.lower() in undesired_words.lower().split(','):
+                    release_group_undesired = True
 
                 if hItem["name"] and require_words and any([i for i in require_words.split(',') if i.lower() in hItem["name"].lower()]):
                     name_require = True
@@ -225,7 +233,10 @@
                     name_ignore = True
                 if hItem["name"] and not show_name_helpers.filterBadReleases(hItem["name"]):
                     name_ignore = True
-
+                if hItem["name"] and undesired_words and any([i for i in undesired_words.split(',') if i.lower() in hItem["name"].lower()]):
+                    name_undesired = True
+                if hItem["name"] and preferred_words and any([i for i in preferred_words.split(',') if i.lower() in hItem["name"].lower()]):
+                    name_preferred = True
 
                 %>
 
@@ -234,6 +245,10 @@
                         <td class="tvShow"><span class="break-word"><font color="red">${hItem["name"]}</font></span></td>
                     % elif name_require:
                         <td class="tvShow"><span class="break-word"><font color="green">${hItem["name"]}</font></span></td>
+                    % elif name_undesired:
+                        <td class="tvShow"><span class="break-word"><font color="orange">${hItem["name"]}</font></span></td>
+                    % elif name_preferred:
+                        <td class="tvShow"><span class="break-word"><font color="blue">${hItem["name"]}</font></span></td>
                     % else:
                         <td class="tvShow"><span class="break-word">${hItem["name"]}</span></td>
                     % endif
@@ -241,6 +256,10 @@
                         <td class="col-group"><span class="break-word"><font color="red">${release_group}</font></span></td>
                     % elif release_group_require:
                         <td class="col-group"><span class="break-word"><font color="green">${release_group}</font></span></td>
+                    % elif release_group_preferred:
+                        <td class="col-group"><span class="break-word"><font color="blue">${release_group}</font></span></td>
+                    % elif release_group_undesired:
+                        <td class="col-group"><span class="break-word"><font color="orange">${release_group}</font></span></td>
                     % else:
                         <td class="col-group"><span class="break-word">${release_group}</span></td>
                     % endif

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -234,20 +234,24 @@ def pickBestResult(results, show):  # pylint: disable=too-many-branches
         if cur_result.quality not in anyQualities + bestQualities:
             logger.log(cur_result.name + " is a quality we know we don't want, rejecting it", logger.DEBUG)
             continue
-
-        if show.rls_ignore_words and show_name_helpers.containsAtLeastOneWord(cur_result.name, cur_result.show.rls_ignore_words):
-            logger.log(u"Ignoring " + cur_result.name + " based on ignored words filter: " + show.rls_ignore_words,
-                       logger.INFO)
+        
+        show_words = show_name_helpers.show_words(cur_result.show)
+        ignore_words = show_words.ignore_words
+        require_words = show_words.require_words
+        found_ignore_word = show_name_helpers.containsAtLeastOneWord(cur_result.name, ignore_words)
+        found_require_word = show_name_helpers.containsAtLeastOneWord(cur_result.name, require_words)        
+        
+        if ignore_words and found_ignore_word:
+            logger.log(u"Ignoring " + cur_result.name + " based on ignored words filter: " + found_ignore_word,
+                       logger.WARNING)
             continue
 
-        if show.rls_require_words and not show_name_helpers.containsAtLeastOneWord(cur_result.name, cur_result.show.rls_require_words):
-            logger.log(u"Ignoring " + cur_result.name + " based on required words filter: " + show.rls_require_words,
-                       logger.INFO)
+        if require_words and not found_require_word:
+            logger.log(u"Ignoring " + cur_result.name + " based on required words filter: " + require_words,
+                       logger.WARNING)
             continue
 
-        if not show_name_helpers.filterBadReleases(cur_result.name, parse=False, show=show):
-            logger.log(u"Ignoring " + cur_result.name + " because its not a valid scene release that we want, ignoring it",
-                       logger.INFO)
+        if not show_name_helpers.filterBadReleases(cur_result.name, parse=False):
             continue
 
         if hasattr(cur_result, 'size'):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -51,7 +51,7 @@ import sickbeard
 from sickbeard import (
     classes, clients, config, db, helpers, logger, naming,
     network_timezones, notifiers, processTV, sab, search_queue,
-    subtitles, ui,
+    subtitles, ui, show_name_helpers
 )
 from sickbeard.blackandwhitelist import BlackAndWhiteList, short_group_names
 from sickbeard.browser import foldersAtPath
@@ -1387,6 +1387,8 @@ class Home(WebRoot):
             'name': showObj.name,
         })
 
+        show_words = show_name_helpers.show_words(showObj)
+
         return t.render(
             submenu=submenu, showLoc=showLoc, show_message=show_message,
             show=showObj, sql_results=sql_results, seasonResults=seasonResults,
@@ -1399,10 +1401,10 @@ class Home(WebRoot):
             title=showObj.name,
             controller="home",
             action="displayShow",
-            preferred_words=self.show_words(showObj)[0],
-            undesired_words=self.show_words(showObj)[1],
-            ignore_words=self.show_words(showObj)[2],
-            require_words=self.show_words(showObj)[3]
+            preferred_words=show_words.preferred_words,
+            undesired_words=show_words.undesired_words,
+            ignore_words=show_words.ignore_words,
+            require_words=show_words.require_words
         )
 
     def pickManualSearch(self, provider=None, rowid=None):
@@ -1615,6 +1617,8 @@ class Home(WebRoot):
             'name': showObj.name,
         })
 
+        show_words = show_name_helpers.show_words(showObj)
+
         return t.render(
             submenu=submenu, showLoc=showLoc, show_message=show_message,
             show=showObj, provider_results=provider_results, episode=episode,
@@ -1627,30 +1631,12 @@ class Home(WebRoot):
             title=showObj.name,
             controller="home",
             action="snatchSelection",
-            preferred_words=self.show_words(showObj)[0],
-            undesired_words=self.show_words(showObj)[1],
-            ignore_words=self.show_words(showObj)[2],
-            require_words=self.show_words(showObj)[3]
+            preferred_words=show_words.preferred_words,
+            undesired_words=show_words.undesired_words,
+            ignore_words=show_words.ignore_words,
+            require_words=show_words.require_words
         )
 
-    @staticmethod
-    def show_words(showObj):
-        preferred_words = ", ".join(sickbeard.PREFERRED_WORDS.split(',')) if sickbeard.PREFERRED_WORDS.split(',') else ''
-        undesired_words = ", ".join(sickbeard.UNDESIRED_WORDS.split(',')) if sickbeard.UNDESIRED_WORDS.split(',') else ''
-
-        global_ignore = sickbeard.IGNORE_WORDS.split(',') if sickbeard.IGNORE_WORDS else []
-        show_ignore = showObj.rls_ignore_words.split(',') if showObj.rls_ignore_words else []
-        show_require = showObj.rls_require_words.split(',') if showObj.rls_require_words else []
-        final_ignore = show_ignore + [i for i in global_ignore if i.lower() not in [r.lower() for r in show_require]]
-        ignore_words = ", ".join(final_ignore)
-        
-        global_require = sickbeard.REQUIRE_WORDS.split(',') if sickbeard.REQUIRE_WORDS else []
-        show_require = showObj.rls_require_words.split(',') if showObj.rls_require_words else []
-        show_ignore = showObj.rls_ignore_words.split(',') if showObj.rls_ignore_words else []
-        final_require = show_require + [i for i in global_require if i.lower() not in [r.lower() for r in show_ignore]]
-        require_words = ", ".join(final_require)
-        
-        return [preferred_words, undesired_words, ignore_words, require_words]
 
     @staticmethod
     def plotDetails(show, season, episode):

--- a/tests/scene_helpers_tests.py
+++ b/tests/scene_helpers_tests.py
@@ -68,11 +68,10 @@ class SceneTests(test.SickbeardTestDBCase):
         """
         Test filtering of bad releases
         """
-        self._test_filter_bad_releases('Show.S02.German.Stuff-Grp', False)
-        self._test_filter_bad_releases('Show.S02.Some.Stuff-Core2HD', False)
-        self._test_filter_bad_releases('Show.S02.Some.German.Stuff-Grp', False)
-        # self._test_filter_bad_releases('German.Show.S02.Some.Stuff-Grp', True)
-        self._test_filter_bad_releases('Show.S02.This.Is.German', False)
+        self._test_filter_bad_releases('Show.S02.SUBBED', False)
+        self._test_filter_bad_releases('Show.S02.DUBBED', False)
+        self._test_filter_bad_releases('Show.S02', True)
+        self._test_filter_bad_releases('Show.S02.DVDEXTRAS', False)
 
 
 class SceneExceptionTestCase(test.SickbeardTestDBCase):


### PR DESCRIPTION
Use the new function "show_words" that display global+show ignored/required words in displayShow and snatchSelection (also to "paint" those words in the results) to filter results in dailysearcher/backlogsearcher

Next step from PR https://github.com/pymedusa/SickRage/pull/370

TODO:
- [x] Use namedtuples
- [x] Use filterbadreleases  in snatchSelection