### PR TITLE
[Manual Search] Filter min seeds and leechers in pickBestResult

### DIFF
--- a/gui/slick/views/snatchSelection.mako
+++ b/gui/slick/views/snatchSelection.mako
@@ -216,6 +216,8 @@
                 name_require = False
                 name_undesired = False
                 name_preferred = False
+                below_minseed = False
+                below_minleech = False
                 
                 release_group = helpers.remove_non_release_groups(hItem["release_group"])
                 if release_group and ignore_words and release_group.lower() in ignore_words.lower().split(','):
@@ -231,12 +233,17 @@
                     name_require = True
                 if hItem["name"] and ignore_words and any([i for i in ignore_words.split(',') if i.lower() in hItem["name"].lower()]):
                     name_ignore = True
-                if hItem["name"] and not show_name_helpers.filterBadReleases(hItem["name"]):
+                if hItem["name"] and not show_name_helpers.filterBadReleases(hItem["name"], False):
                     name_ignore = True
                 if hItem["name"] and undesired_words and any([i for i in undesired_words.split(',') if i.lower() in hItem["name"].lower()]):
                     name_undesired = True
                 if hItem["name"] and preferred_words and any([i for i in preferred_words.split(',') if i.lower() in hItem["name"].lower()]):
                     name_preferred = True
+                
+                if hItem["provider_minseed"] and hItem["seeders"] and hItem["seeders"] > -1 and int(hItem["seeders"]) < hItem["provider_minseed"]:
+                    below_minseed = True
+                if hItem["provider_minleech"] and hItem["leechers"] and hItem["leechers"] > -1 and int(hItem["leechers"]) < hItem["provider_minleech"]:
+                    below_minleech = True
 
                 %>
 
@@ -271,8 +278,16 @@
                         % endif
                     </td>
                     <td align="center">${renderQualityPill(int(hItem["quality"]))}</td>
-                    <td align="center">${hItem["seeders"] if hItem["seeders"] > -1 else '-'}</td>
-                    <td align="center">${hItem["leechers"] if hItem["leechers"] > -1 else '-'}</td>
+                    % if below_minseed:
+                        <td align="center"><font color="red">${hItem["seeders"] if hItem["seeders"] > -1 else '-'}</font></td>
+                    % else:
+                        <td align="center">${hItem["seeders"] if hItem["seeders"] > -1 else '-'}</td>               
+                    % endif
+                    % if below_minleech:
+                        <td align="center"><font color="red">${hItem["leechers"] if hItem["leechers"] > -1 else '-'}</font></td>
+                    % else:
+                        <td align="center">${hItem["leechers"] if hItem["leechers"] > -1 else '-'}</td>               
+                    % endif
                     <td class="col-size">${pretty_file_size(hItem["size"]) if hItem["size"] > -1 else 'N/A'}</td>
                     <td align="center">${hItem["provider_type"]}</td>
                     <td class="col-date">${datetime.datetime.fromtimestamp(hItem["time"]).strftime(sickbeard.DATE_PRESET+" "+sickbeard.TIME_PRESET)}</td>

--- a/sickbeard/providers/abnormal.py
+++ b/sickbeard/providers/abnormal.py
@@ -139,7 +139,7 @@ class ABNormalProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
                             leechers = try_int(cells[labels.index('L')].get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log('Discarding torrent because it doesn\'t meet the minimum seeders or leechers: {} (S:{} L:{})'.format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -152,7 +152,7 @@ class AlphaRatioProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                             leechers = try_int(cells[labels.index("Leechers")].get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != "RSS":
                                     logger.log("Discarding torrent because it doesn't meet the"
                                                " minimum seeders or leechers: {} (S:{} L:{})".format

--- a/sickbeard/providers/bitcannon.py
+++ b/sickbeard/providers/bitcannon.py
@@ -93,7 +93,7 @@ class BitCannonProvider(TorrentProvider):
                         else:
                             seeders = leechers = 0
 
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != "RSS":
                                 logger.log("Discarding torrent because it doesn't meet the "
                                            "minimum seeders or leechers: {} (S:{} L:{})".format

--- a/sickbeard/providers/bitsnoop.py
+++ b/sickbeard/providers/bitsnoop.py
@@ -103,7 +103,7 @@ class BitSnoopProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
                             continue
 
                             # Filter unseeded torrent
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                            (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/bitsoup.py
+++ b/sickbeard/providers/bitsoup.py
@@ -131,7 +131,7 @@ class BitSoupProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                                 continue
 
                                 # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/bluetigers.py
+++ b/sickbeard/providers/bluetigers.py
@@ -121,7 +121,7 @@ class BlueTigersProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                                     continue
 
                                 # Filter unseeded torrent
-                                # if seeders < self.minseed or leechers < self.minleech:
+                                # if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 #    if mode != 'RSS':
                                 #        logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                 #                   (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/cpasbien.py
+++ b/sickbeard/providers/cpasbien.py
@@ -72,7 +72,7 @@ class CpasbienProvider(TorrentProvider):
 
                             seeders = try_int(result.find(class_="up").get_text(strip=True))
                             leechers = try_int(result.find(class_="down").get_text(strip=True))
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/danishbits.py
+++ b/sickbeard/providers/danishbits.py
@@ -148,7 +148,7 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                             leechers = try_int(cells[labels.index('Leechers')].get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the"
                                                u" minimum seeders or leechers: {} (S:{} L:{})".format

--- a/sickbeard/providers/elitetorrent.py
+++ b/sickbeard/providers/elitetorrent.py
@@ -117,7 +117,7 @@ class elitetorrentProvider(TorrentProvider):
                                 continue
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/extratorrent.py
+++ b/sickbeard/providers/extratorrent.py
@@ -98,7 +98,7 @@ class ExtraTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                             continue
 
                             # Filter unseeded torrent
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                            (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/freshontv.py
+++ b/sickbeard/providers/freshontv.py
@@ -212,7 +212,7 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                                     continue
 
                                 # Filter unseeded torrent
-                                if seeders < self.minseed or leechers < self.minleech:
+                                if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                     if mode != 'RSS':
                                         logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                    (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/gftracker.py
+++ b/sickbeard/providers/gftracker.py
@@ -160,7 +160,7 @@ class GFTrackerProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                             leechers = try_int(peers[1])
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the"
                                                u" minimum seeders or leechers: {} (S:{} L:{})".format

--- a/sickbeard/providers/hd4free.py
+++ b/sickbeard/providers/hd4free.py
@@ -105,7 +105,7 @@ class HD4FreeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
                         seeders = jdata[i]["seeders"]
                         leechers = jdata[i]["leechers"]
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                            (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/hdspace.py
+++ b/sickbeard/providers/hdspace.py
@@ -146,7 +146,7 @@ class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                             continue
 
                         # Filter unseeded torrent
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                            (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -158,7 +158,7 @@ class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                             continue
 
                         # Filter unseeded torrent
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                            (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/hounddawgs.py
+++ b/sickbeard/providers/hounddawgs.py
@@ -163,7 +163,7 @@ class HoundDawgsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                                 continue
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/ilovetorrents.py
+++ b/sickbeard/providers/ilovetorrents.py
@@ -140,7 +140,7 @@ class ILoveTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instan
                                 continue
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -142,7 +142,7 @@ class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                                 continue
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -107,7 +107,7 @@ class KatProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
                             leechers = try_int(item.find("torrent:peers").get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != "RSS":
                                     logger.log("Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/limetorrents.py
+++ b/sickbeard/providers/limetorrents.py
@@ -121,7 +121,7 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                             continue
 
                             # Filter unseeded torrent
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                            (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -162,7 +162,7 @@ class MoreThanTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                             leechers = try_int(cells[labels.index('Leechers')].get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the"
                                                u" minimum seeders or leechers: {} (S:{} L:{})".format

--- a/sickbeard/providers/norbits.py
+++ b/sickbeard/providers/norbits.py
@@ -116,7 +116,7 @@ class NorbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                         seeders = try_int(item.pop('seeders', 0))
                         leechers = try_int(item.pop('leechers', 0))
 
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             logger.log('Discarding torrent because it does not meet '
                                        'the minimum seeders or leechers: {} (S:{} L:{})'.format
                                        (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/nyaatorrents.py
+++ b/sickbeard/providers/nyaatorrents.py
@@ -92,7 +92,7 @@ class NyaaProvider(TorrentProvider):  # pylint: disable=too-many-instance-attrib
                         seeders = try_int(seeders)
                         leechers = try_int(leechers)
 
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log('Discarding torrent because it doesn\'t meet the'
                                            ' minimum seeders or leechers: {} (S:{} L:{})'.format

--- a/sickbeard/providers/phxbit.py
+++ b/sickbeard/providers/phxbit.py
@@ -147,7 +147,7 @@ class PhxBitProvider(TorrentProvider):  # pylint: disable=too-many-instance-attr
                             leechers = try_int(cells[labels.index('Leech')].get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format(title, seeders, leechers), logger.DEBUG)
                                 continue

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -146,7 +146,7 @@ class PretomeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                                 continue
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -154,7 +154,7 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
 
                         seeders = item.pop("seeders")
                         leechers = item.pop("leechers")
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != "RSS":
                                 logger.log("Discarding torrent because it doesn't meet the"
                                            " minimum seeders or leechers: {} (S:{} L:{})".format

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -148,7 +148,7 @@ class SCCProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
                             continue
 
                         # Filter unseeded torrent
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format(title, seeders, leechers), logger.DEBUG)
                             continue

--- a/sickbeard/providers/sceneelite.py
+++ b/sickbeard/providers/sceneelite.py
@@ -126,7 +126,7 @@ class SceneEliteProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                             continue
                         size = try_int(torrent.pop("size", ""), 0)
                         download_url = self.urls["download"] + id
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log(u"Torrent doesn't meet minimum seeds & leechers not selecting : {0}".format(title), logger.DEBUG)
                             continue

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -129,7 +129,7 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                             continue
 
                         # Filter unseeded torrent
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                            (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -154,7 +154,7 @@ class SpeedCDProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                             leechers = try_int(cells[labels.index('Leechers')].get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format(title, seeders, leechers), logger.DEBUG)
                                 continue

--- a/sickbeard/providers/strike.py
+++ b/sickbeard/providers/strike.py
@@ -67,7 +67,7 @@ class StrikeProvider(TorrentProvider):
                         continue
 
                     # Filter unseeded torrent
-                    if seeders < self.minseed or leechers < self.minleech:
+                    if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                         if mode != 'RSS':
                             logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                        (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/t411.py
+++ b/sickbeard/providers/t411.py
@@ -130,7 +130,7 @@ class T411Provider(TorrentProvider):  # pylint: disable=too-many-instance-attrib
                                 torrent_size = torrent['size']
 
                                 # Filter unseeded torrent
-                                if seeders < self.minseed or leechers < self.minleech:
+                                if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                     if mode != 'RSS':
                                         logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format(title, seeders, leechers), logger.DEBUG)
                                     continue

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -137,7 +137,7 @@ class ThePirateBayProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                             leechers = try_int(cells[labels.index("LE")].get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != "RSS":
                                     logger.log("Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -380,7 +380,7 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                                     title = re.sub(r'([Ee][\d{1,2}\-?]+)', '', title)
 
                                 # Filter unseeded torrent
-                                if seeders < self.minseed or leechers < self.minleech:
+                                if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                     if mode != 'RSS':
                                         logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                    (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/tokyotoshokan.py
+++ b/sickbeard/providers/tokyotoshokan.py
@@ -100,7 +100,7 @@ class TokyoToshokanProvider(TorrentProvider):  # pylint: disable=too-many-instan
                             continue
 
                         # Filter unseeded torrent
-                        if seeders < self.minseed or leechers < self.minleech:
+                        if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                             if mode != 'RSS':
                                 logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                            (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -135,7 +135,7 @@ class TorrentBytesProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                             leechers = try_int(cells[labels.index("Leechers")].get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != "RSS":
                                     logger.log("Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -143,7 +143,7 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                     leechers = int(torrent['leech']) if torrent['leech'] else 0
 
                     # Filter unseeded torrent
-                    if seeders < self.minseed or leechers < self.minleech:
+                    if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                         if mode != 'RSS':
                             logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format(title, seeders, leechers), logger.DEBUG)
                         continue

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -150,7 +150,7 @@ class TorrentLeechProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                             leechers = try_int(result.find("td", class_="leechers").get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != "RSS":
                                     logger.log("Discarding torrent because it doesn't meet the"
                                                " minimum seeders or leechers: {} (S:{} L:{})".format

--- a/sickbeard/providers/torrentproject.py
+++ b/sickbeard/providers/torrentproject.py
@@ -94,7 +94,7 @@ class TorrentProjectProvider(TorrentProvider):  # pylint: disable=too-many-insta
                     title = torrents[i].get("title")
                     seeders = try_int(torrents[i].get("seeds"), 1)
                     leechers = try_int(torrents[i].get("leechs"), 0)
-                    if seeders < self.minseed or leechers < self.minleech:
+                    if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                         if mode != 'RSS':
                             logger.log(u"Torrent doesn't meet minimum seeds & leechers not selecting : %s" % title, logger.DEBUG)
                         continue

--- a/sickbeard/providers/torrentz.py
+++ b/sickbeard/providers/torrentz.py
@@ -101,7 +101,7 @@ class TorrentzProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
                             size = convert_size(torrent_size) or -1
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
                                                (title, seeders, leechers), logger.DEBUG)

--- a/sickbeard/providers/transmitthenet.py
+++ b/sickbeard/providers/transmitthenet.py
@@ -161,7 +161,7 @@ class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-insta
                             leechers = try_int(cells[9].text.strip())
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the"
                                                u" minimum seeders or leechers: {} (S:{} L:{})".format

--- a/sickbeard/providers/tvchaosuk.py
+++ b/sickbeard/providers/tvchaosuk.py
@@ -137,7 +137,7 @@ class TVChaosUKProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                             leechers = try_int(torrent.find(title='Leechers').get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log('Discarding torrent because it doesn\'t meet the'
                                                ' minimum seeders or leechers: {} (S:{} L:{})'.format

--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -165,7 +165,7 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
                             leechers = try_int(cells[labels.index('Leechers')].get_text(strip=True))
 
                             # Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
+                            if seeders < min(self.minseed, 1) or leechers < min(self.minleech, 0):
                                 if mode != 'RSS':
                                     logger.log(u"Discarding torrent because it doesn't meet the"
                                                u" minimum seeders or leechers: {} (S:{} L:{})".format

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -237,8 +237,11 @@ def pickBestResult(results, show):  # pylint: disable=too-many-branches
 
         # If doesnt have min seeders OR min leechers then discard it
         if cur_result.seeders not in (-1, None) and cur_result.leechers not in (-1, None) \
-            and (int(cur_result.seeders) < int(cur_result.provider.minseed) or int(cur_result.leechers) < int(cur_result.provider.minleech)):
-            logger.log(u"Discarding torrent because it doesn't meet the minimum provider setting S:{0} L:{1}. Result has S:{2} L:{3}".format(cur_result.provider.minseed, cur_result.provider.minleech, cur_result.seeders, cur_result.leechers))
+            and (int(cur_result.seeders) < int(cur_result.provider.minseed) or 
+                 int(cur_result.leechers) < int(cur_result.provider.minleech)):
+            logger.log(u"Discarding torrent because it doesn't meet the minimum provider setting \
+                        S:{0} L:{1}. Result has S:{2} L:{3}".format(cur_result.provider.minseed,
+                        cur_result.provider.minleech, cur_result.seeders, cur_result.leechers))
             continue
         
         show_words = show_name_helpers.show_words(cur_result.show)

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -234,6 +234,12 @@ def pickBestResult(results, show):  # pylint: disable=too-many-branches
         if cur_result.quality not in anyQualities + bestQualities:
             logger.log(cur_result.name + " is a quality we know we don't want, rejecting it", logger.DEBUG)
             continue
+
+        # If doesnt have min seeders OR min leechers then discard it
+        if cur_result.seeders not in (-1, None) and cur_result.leechers not in (-1, None) \
+            and (int(cur_result.seeders) < int(cur_result.provider.minseed) or int(cur_result.leechers) < int(cur_result.provider.minleech)):
+            logger.log(u"Discarding torrent because it doesn't meet the minimum provider setting S:{0} L:{1}. Result has S:{2} L:{3}".format(cur_result.provider.minseed, cur_result.provider.minleech, cur_result.seeders, cur_result.leechers))
+            continue
         
         show_words = show_name_helpers.show_words(cur_result.show)
         ignore_words = show_words.ignore_words


### PR DESCRIPTION
... and allow to cache all torrents using min(minseed, 1) and min(minleech, 0)

This fixes when torrent was cached when seed > minseed but when seed get below minseed, it would never be updated again so when manual search, user would have a wrong information and or auto download will choose a bad torrent with less seeds then when it got cached
