### PR TITLE
[Manual Search] Added a ForcedSearchQueue scheduler for processing forced searches and failed downloads.

### DIFF
--- a/gui/slick/views/manage_manageSearches.mako
+++ b/gui/slick/views/manage_manageSearches.mako
@@ -56,11 +56,11 @@ ${('Not in progress', 'In Progress')[dailySearchStatus]}<br>
 <br>
 
 <h3>Search Queue:</h3>
-Backlog: <i>${queueLength['backlog']} pending items</i><br>
-Daily: <i>${queueLength['daily']} pending items</i><br>
-Forced: <i>${queueLength['forced_search']} pending items</i><br>
-Manual: <i>${queueLength['manual_search']} pending items</i><br>
-Failed: <i>${queueLength['failed']} pending items</i><br>
+Backlog: <i>${searchQueueLength['backlog']} pending items</i><br>
+Daily: <i>${searchQueueLength['daily']} pending items</i><br>
+Forced: <i>${forcedSearchQueueLength['forced_search']} pending items</i><br>
+Manual: <i>${forcedSearchQueueLength['manual_search']} pending items</i><br>
+Failed: <i>${forcedSearchQueueLength['failed']} pending items</i><br>
 </div>
 </div>
 </%block>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -106,6 +106,7 @@ showUpdateScheduler = None
 versionCheckScheduler = None
 showQueueScheduler = None
 searchQueueScheduler = None
+forcedSearchQueueScheduler = None
 manualSnatchScheduler = None
 properFinderScheduler = None
 autoPostProcesserScheduler = None
@@ -631,7 +632,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             USE_PUSHBULLET, PUSHBULLET_NOTIFY_ONSNATCH, PUSHBULLET_NOTIFY_ONDOWNLOAD, PUSHBULLET_NOTIFY_ONSUBTITLEDOWNLOAD, PUSHBULLET_API, PUSHBULLET_DEVICE, \
             versionCheckScheduler, VERSION_NOTIFY, AUTO_UPDATE, NOTIFY_ON_UPDATE, PROCESS_AUTOMATICALLY, NO_DELETE, UNPACK, CPU_PRESET, \
             KEEP_PROCESSED_DIR, PROCESS_METHOD, DELRARCONTENTS, TV_DOWNLOAD_DIR, UPDATE_FREQUENCY, \
-            showQueueScheduler, searchQueueScheduler, manualSnatchScheduler, ROOT_DIRS, CACHE_DIR, ACTUAL_CACHE_DIR, TIMEZONE_DISPLAY, \
+            showQueueScheduler, searchQueueScheduler, forcedSearchQueueScheduler, manualSnatchScheduler, ROOT_DIRS, CACHE_DIR, ACTUAL_CACHE_DIR, TIMEZONE_DISPLAY, \
             NAMING_PATTERN, NAMING_MULTI_EP, NAMING_ANIME_MULTI_EP, NAMING_FORCE_FOLDERS, NAMING_ABD_PATTERN, NAMING_CUSTOM_ABD, NAMING_SPORTS_PATTERN, NAMING_CUSTOM_SPORTS, NAMING_ANIME_PATTERN, NAMING_CUSTOM_ANIME, NAMING_STRIP_YEAR, \
             RENAME_EPISODES, AIRDATE_EPISODES, FILE_TIMESTAMP_TIMEZONE, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
             providerList, newznabProviderList, torrentRssProviderList, \
@@ -1480,6 +1481,10 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
                                                    cycleTime=datetime.timedelta(seconds=3),
                                                    threadName="SEARCHQUEUE")
 
+        forcedSearchQueueScheduler = scheduler.Scheduler(search_queue.ForcedSearchQueue(),
+                                                         cycleTime=datetime.timedelta(seconds=3),
+                                                         threadName="FORCEDSEARCHQUEUE")
+
         # TODO: update_interval should take last daily/backlog times into account!
         update_interval = datetime.timedelta(minutes=DAILYSEARCH_FREQUENCY)
         dailySearchScheduler = scheduler.Scheduler(dailysearcher.DailySearcher(),
@@ -1564,6 +1569,10 @@ def start():
             searchQueueScheduler.enable = True
             searchQueueScheduler.start()
 
+            # start the forced search queue checker
+            forcedSearchQueueScheduler.enable = True
+            forcedSearchQueueScheduler.start()
+
             # start the search queue checker
             manualSnatchScheduler.enable = True
             manualSnatchScheduler.start()
@@ -1623,6 +1632,7 @@ def halt():
                 versionCheckScheduler,
                 showQueueScheduler,
                 searchQueueScheduler,
+                forcedSearchQueueScheduler,
                 manualSnatchScheduler,
                 autoPostProcesserScheduler,
                 traktCheckerScheduler,

--- a/sickbeard/dailysearcher.py
+++ b/sickbeard/dailysearcher.py
@@ -46,10 +46,9 @@ class DailySearcher(object):  # pylint:disable=too-few-public-methods
             logger.log(u"Daily search is still running, not starting it again", logger.DEBUG)
             return
 
-        if sickbeard.searchQueueScheduler.action.is_manualsearch_in_progress():
+        if sickbeard.forcedSearchQueueScheduler.action.is_forced_search_in_progress():
             logger.log(u"Manual search is running. Can't start Daily search", logger.WARNING)
             return
-
 
         self.amActive = True
         _ = force

--- a/sickbeard/failedProcessor.py
+++ b/sickbeard/failedProcessor.py
@@ -70,7 +70,7 @@ class FailedProcessor(object):
             segment = parsed.show.getEpisode(parsed.season_number, episode)
 
             cur_failed_queue_item = search_queue.FailedQueueItem(parsed.show, [segment])
-            sickbeard.searchQueueScheduler.action.add_item(cur_failed_queue_item)
+            sickbeard.forcedSearchQueueScheduler.action.add_item(cur_failed_queue_item)
 
         return True
 

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -51,12 +51,12 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
         :param force: Start even if already running (currently not used, defaults to False)
         """
         logger.log(u"Beginning the search for new propers")
-        
+
         if self.amActive:
             logger.log(u"Find propers is still running, not starting it again", logger.DEBUG)
             return
 
-        if sickbeard.searchQueueScheduler.action.is_manualsearch_in_progress():
+        if sickbeard.forcedSearchQueueScheduler.action.is_forced_search_in_progress():
             logger.log(u"Manual search is running. Can't start Find propers", logger.WARNING)
             return
 

--- a/sickbeard/searchBacklog.py
+++ b/sickbeard/searchBacklog.py
@@ -73,8 +73,8 @@ class BacklogSearcher(object):
         if self.amActive:
             logger.log(u"Backlog is still running, not starting it again", logger.DEBUG)
             return
-        
-        if sickbeard.searchQueueScheduler.action.is_manualsearch_in_progress():
+
+        if sickbeard.forcedSearchQueueScheduler.action.is_forced_search_in_progress():
             logger.log(u"Manual search is running. Can't start Backlog Search", logger.WARNING)
             return
 

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -781,7 +781,7 @@ class CMD_EpisodeSearch(ApiCall):
 
         # make a queue item for it and put it on the queue
         ep_queue_item = search_queue.ForcedSearchQueueItem(show_obj, ep_obj)
-        sickbeard.searchQueueScheduler.action.add_item(ep_queue_item)  # @UndefinedVariable
+        sickbeard.forcedSearchQueueScheduler.action.add_item(ep_queue_item)  # @UndefinedVariable
 
         # wait until the queue item tells us whether it worked or not
         while ep_queue_item.success is None:  # @UndefinedVariable

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2275,7 +2275,7 @@ class Home(WebRoot):
         # make a queue item for it and put it on the queue
         ep_queue_item = search_queue.ForcedSearchQueueItem(ep_obj.show, ep_obj, bool(int(down_cur_quality)), bool(manual_search))
 
-        sickbeard.searchQueueScheduler.action.add_item(ep_queue_item)
+        sickbeard.forcedSearchQueueScheduler.action.add_item(ep_queue_item)
 
         # give the CPU a break and some time to start the queue
         time.sleep(cpu_presets[sickbeard.CPU_PRESET])
@@ -2417,7 +2417,7 @@ class Home(WebRoot):
 
         # make a queue item for it and put it on the queue
         ep_queue_item = search_queue.FailedQueueItem(ep_obj.show, [ep_obj], bool(int(down_cur_quality)))  # pylint: disable=no-member
-        sickbeard.searchQueueScheduler.action.add_item(ep_queue_item)
+        sickbeard.forcedSearchQueueScheduler.action.add_item(ep_queue_item)
 
         if not ep_queue_item.started and ep_queue_item.success is None:
             return json.dumps(
@@ -3864,8 +3864,11 @@ class ManageSearches(Manage):
         # t.backlogPI = sickbeard.backlogSearchScheduler.action.getProgressIndicator()
 
         return t.render(backlogPaused=sickbeard.searchQueueScheduler.action.is_backlog_paused(),
-                        backlogRunning=sickbeard.searchQueueScheduler.action.is_backlog_in_progress(), dailySearchStatus=sickbeard.dailySearchScheduler.action.amActive,
-                        findPropersStatus=sickbeard.properFinderScheduler.action.amActive, queueLength=sickbeard.searchQueueScheduler.action.queue_length(),
+                        backlogRunning=sickbeard.searchQueueScheduler.action.is_backlog_in_progress(),
+                        dailySearchStatus=sickbeard.dailySearchScheduler.action.amActive,
+                        findPropersStatus=sickbeard.properFinderScheduler.action.amActive,
+                        searchQueueLength=sickbeard.searchQueueScheduler.action.queue_length(),
+                        forcedSearchQueueLength=sickbeard.forcedSearchQueueScheduler.action.queue_length(),
                         subtitlesFinderStatus=sickbeard.subtitlesFinderScheduler.action.amActive,
                         title='Manage Searches', header='Manage Searches', topmenu='manage',
                         controller="manage", action="manageSearches")


### PR DESCRIPTION
Added a ForcedSearchQueue scheduler for processing forced searches and failed downloads. These can be run in parallel with the searchQueueScheduler thread (backlog and daily).