### PR TITLE
Upgrade guessit to 61303fa009ff3b17cd91be7a18fcccec8642d027

### DIFF
--- a/lib/guessit/api.py
+++ b/lib/guessit/api.py
@@ -124,6 +124,8 @@ class GuessItApi(object):
         ordered = OrderedDict()
         for k in sorted(unordered.keys(), key=six.text_type):
             ordered[k] = list(sorted(unordered[k], key=six.text_type))
+        if hasattr(self.rebulk, 'customize_properties'):
+            ordered = self.rebulk.customize_properties(ordered)
         return ordered
 
 

--- a/lib/guessit/rules/__init__.py
+++ b/lib/guessit/rules/__init__.py
@@ -71,4 +71,18 @@ def rebulk_builder():
     rebulk.rebulk(mimetype())
     rebulk.rebulk(type_())
 
+    def customize_properties(properties):
+        """
+        Customize default rebulk properties
+        """
+        count = properties['count']
+        del properties['count']
+
+        properties['season_count'] = count
+        properties['episode_count'] = count
+
+        return properties
+
+    rebulk.customize_properties = customize_properties
+
     return rebulk

--- a/lib/guessit/rules/common/formatters.py
+++ b/lib/guessit/rules/common/formatters.py
@@ -3,12 +3,9 @@
 """
 Formatters
 """
-from rebulk.remodule import re
-
 from rebulk.formatters import formatters
-
+from rebulk.remodule import re
 from . import seps
-
 
 _excluded_clean_chars = ',:;-/\\'
 clean_chars = ""
@@ -17,28 +14,94 @@ for sep in seps:
         clean_chars += sep
 
 
+def _potential_before(i, input_string):
+    """
+    Check if the character at position i can be a potential single char separator considering what's before it.
+
+    :param i:
+    :type i: int
+    :param input_string:
+    :type input_string: str
+    :return:
+    :rtype: bool
+    """
+    return i - 2 >= 0 and input_string[i] == input_string[i - 2] and input_string[i - 1] not in seps
+
+
+def _potential_after(i, input_string):
+    """
+    Check if the character at position i can be a potential single char separator considering what's after it.
+
+    :param i:
+    :type i: int
+    :param input_string:
+    :type input_string: str
+    :return:
+    :rtype: bool
+    """
+    return i + 2 >= len(input_string) or \
+           input_string[i + 2] == input_string[i] and input_string[i + 1] not in seps
+
+
 def cleanup(input_string):
     """
     Removes and strip separators from input_string (but keep ',;' characters)
+
+    It also keep separators for single characters (Mavels Agents of S.H.I.E.L.D.)
+
     :param input_string:
-    :type input_string:
+    :type input_string: str
     :return:
     :rtype:
     """
+    clean_string = input_string
     for char in clean_chars:
-        input_string = input_string.replace(char, ' ')
-    return re.sub(' +', ' ', strip(input_string))
+        clean_string = clean_string.replace(char, ' ')
+
+    # Restore input separator if they separate single characters.
+    # Useful for Mavels Agents of S.H.I.E.L.D.
+    # https://github.com/guessit-io/guessit/issues/278
+
+    indices = [i for i, letter in enumerate(clean_string) if letter in seps]
+
+    dots = set()
+    if indices:
+        clean_list = list(clean_string)
+
+        potential_indices = []
+
+        for i in indices:
+            if _potential_before(i, input_string) and _potential_after(i, input_string):
+                potential_indices.append(i)
+
+        replace_indices = []
+
+        for potential_index in potential_indices:
+            if potential_index - 2 in potential_indices or potential_index + 2 in potential_indices:
+                replace_indices.append(potential_index)
+
+        if replace_indices:
+            for replace_index in replace_indices:
+                dots.add(input_string[replace_index])
+                clean_list[replace_index] = input_string[replace_index]
+            clean_string = ''.join(clean_list)
+
+    clean_string = strip(clean_string, ''.join([c for c in seps if c not in dots]))
+
+    clean_string = re.sub(' +', ' ', clean_string)
+    return clean_string
 
 
-def strip(input_string):
+def strip(input_string, chars=seps):
     """
     Strip separators from input_string
     :param input_string:
+    :param chars:
     :type input_string:
     :return:
     :rtype:
     """
-    return input_string.strip(seps)
+    return input_string.strip(chars)
 
 
 def raw_cleanup(raw):

--- a/lib/guessit/rules/properties/audio_codec.py
+++ b/lib/guessit/rules/properties/audio_codec.py
@@ -25,7 +25,7 @@ def audio_codec():
     rebulk.regex("DolbyDigital", "Dolby-Digital", "DD", value="DolbyDigital")
     rebulk.regex("DolbyAtmos", "Dolby-Atmos", "Atmos", value="DolbyAtmos")
     rebulk.regex("AAC", value="AAC")
-    rebulk.regex("AC3", value="AC3")
+    rebulk.regex("AC3D?", value="AC3")
     rebulk.regex("Flac", value="FLAC")
     rebulk.regex("DTS", value="DTS")
     rebulk.regex("True-?HD", value="TrueHD")

--- a/lib/guessit/rules/properties/language.py
+++ b/lib/guessit/rules/properties/language.py
@@ -106,8 +106,10 @@ class GuessitConverter(babelfish.LanguageReverseConverter):  # pylint: disable=m
 
 babelfish.language_converters['guessit'] = GuessitConverter()
 
-subtitle_prefixes = ['sub', 'subs', 'st', 'vost', 'subforced', 'fansub', 'hardsub']
-subtitle_suffixes = ['subforced', 'fansub', 'hardsub', 'sub', 'subs']
+subtitle_both = ['sub', 'subs', 'subbed', 'custom subbed', 'custom subs', 'custom sub', 'customsubbed', 'customsubs',
+                 'customsub']
+subtitle_prefixes = subtitle_both + ['st', 'vost', 'subforced', 'fansub', 'hardsub']
+subtitle_suffixes = subtitle_both + ['subforced', 'fansub', 'hardsub']
 lang_prefixes = ['true']
 
 all_lang_prefixes_suffixes = subtitle_prefixes + subtitle_suffixes + lang_prefixes

--- a/lib/guessit/rules/properties/mimetype.py
+++ b/lib/guessit/rules/properties/mimetype.py
@@ -39,3 +39,10 @@ class Mimetype(CustomRule):
     def then(self, matches, when_response, context):
         mime = when_response
         matches.append(Match(len(matches.input_string), len(matches.input_string), name='mimetype', value=mime))
+
+    @property
+    def properties(self):
+        """
+        Properties for this rule.
+        """
+        return {'mimetype': [None]}

--- a/lib/guessit/test/episodes.yml
+++ b/lib/guessit/test/episodes.yml
@@ -447,8 +447,17 @@
   video_codec: h264
   release_group: IMMERSE
 
+? Marvels.Agents.of.S.H.I.E.L.D-S01E06.720p.HDTV.X264-DIMENSION.mkv
+: title: Marvels Agents of S.H.I.E.L.D
+  season: 1
+  episode: 6
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  release_group: DIMENSION
+
 ? Marvels.Agents.of.S.H.I.E.L.D.S01E06.720p.HDTV.X264-DIMENSION.mkv
-: title: Marvels Agents of S H I E L D
+: title: Marvels Agents of S.H.I.E.L.D.
   season: 1
   episode: 6
   screen_size: 720p
@@ -457,7 +466,7 @@
   release_group: DIMENSION
 
 ? Marvels.Agents.of.S.H.I.E.L.D..S01E06.720p.HDTV.X264-DIMENSION.mkv
-: title: Marvels Agents of S H I E L D
+: title: Marvels Agents of S.H.I.E.L.D.
   season: 1
   episode: 6
   screen_size: 720p
@@ -1755,4 +1764,16 @@
   release_group: W4F
   season: 2
   title: Running Wild With Bear Grylls
+  video_codec: h264
+
+? Homeland.S05E11.Our.Man.in.Damascus.German.Sub.720p.HDTV.x264.iNTERNAL-BaCKToRG
+: episode: 11
+  episode_title: Our Man in Damascus
+  format: HDTV
+  release_group: iNTERNAL-BaCKToRG
+  screen_size: 720p
+  season: 5
+  subtitle_language: de
+  title: Homeland
+  type: episode
   video_codec: h264

--- a/lib/guessit/test/movies.yml
+++ b/lib/guessit/test/movies.yml
@@ -787,3 +787,51 @@
 ? "Looney Tunes 1444x866 Porky's Last Stand.mkv"
 : screen_size: 1444x866
   title: Looney Tunes
+
+? Das.Appartement.German.AC3D.DL.720p.BluRay.x264-TVP
+: audio_codec: AC3
+  format: BluRay
+  language: mul
+  release_group: TVP
+  screen_size: 720p
+  title: Das Appartement German
+  type: movie
+  video_codec: h264
+
+? Das.Appartement.GERMAN.AC3D.DL.720p.BluRay.x264-TVP
+: audio_codec: AC3
+  format: BluRay
+  language:
+  - de
+  - mul
+  release_group: TVP
+  screen_size: 720p
+  title: Das Appartement
+  video_codec: h264
+
+? Hyena.Road.2015.German.1080p.DL.DTSHD.Bluray.x264-pmHD
+: audio_codec: DTS
+  audio_profile: HD
+  format: BluRay
+  language:
+  - de
+  - mul
+  release_group: pmHD
+  screen_size: 1080p
+  title: Hyena Road
+  type: movie
+  video_codec: h264
+  year: 2015
+
+? Hyena.Road.2015.German.Ep.Title.1080p.DL.DTSHD.Bluray.x264-pmHD
+: audio_codec: DTS
+  audio_profile: HD
+  episode_title: German Ep Title
+  format: BluRay
+  language: mul
+  release_group: pmHD
+  screen_size: 1080p
+  title: Hyena Road
+  type: movie
+  video_codec: h264
+  year: 2015


### PR DESCRIPTION
Fix "Regression for titles containing dots" like "Marvels.Agents.of.S.H.I.E.L.D."

https://github.com/guessit-io/guessit/issues/278

@medariox @ratoaq2 