### PR TITLE
Revert "Remove text decoration from forcedSearch icon"

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -1494,8 +1494,6 @@ h2.day, h2.network {
     text-align:center
 }
 
-a.forceUpdate { text-decoration: none;}
-
 /* =======================================================================
 config*.mako
 ========================================================================== */
@@ -3469,4 +3467,3 @@ snatchSelection.mako
 div#searchNotification {
 	display: inline-block;
 }
-


### PR DESCRIPTION
This PR fixed the html: https://github.com/pymedusa/SickRage/pull/440

not needed anymore. reverting