### PR TITLE
Fix imports for urllib, urllib2, and httplib for python 3 compatibility

### DIFF
--- a/sickbeard/classes.py
+++ b/sickbeard/classes.py
@@ -20,7 +20,8 @@
 
 import datetime
 import sys
-import urllib
+
+from six.moves.urllib.request import FancyURLopener
 
 import sickbeard
 from sickbeard.common import USER_AGENT, Quality
@@ -28,7 +29,7 @@ from sickrage.helper.common import dateTimeFormat
 from dateutil import parser
 
 
-class SickBeardURLopener(urllib.FancyURLopener, object):
+class SickBeardURLopener(FancyURLopener, object):
     version = USER_AGENT
 
 

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -21,9 +21,11 @@
 import os.path
 import datetime
 import re
-import urlparse
-import sickbeard
 
+from requests.compat import urlsplit
+from six.moves.urllib.parse import uses_netloc, urlunsplit
+
+import sickbeard
 from sickbeard import helpers
 from sickbeard import logger
 from sickbeard import naming
@@ -35,7 +37,7 @@ from sickrage.helper.encoding import ek
 # Address poor support for scgi over unix domain sockets
 # this is not nicely handled by python currently
 # http://bugs.python.org/issue23636
-urlparse.uses_netloc.append('scgi')
+uses_netloc.append('scgi')
 
 naming_ep_type = ("%(seasonnumber)dx%(episodenumber)02d",
                   "s%(seasonnumber)02de%(episodenumber)02d",
@@ -490,12 +492,12 @@ def clean_url(url):
         if '://' not in url:
             url = '//' + url
 
-        scheme, netloc, path, query, fragment = urlparse.urlsplit(url, 'http')
+        scheme, netloc, path, query, fragment = urlsplit(url, 'http')
 
         if not path:
             path += '/'
 
-        cleaned_url = urlparse.urlunsplit((scheme, netloc, path, query, fragment))
+        cleaned_url = urlunsplit((scheme, netloc, path, query, fragment))
 
     else:
         cleaned_url = ''

--- a/sickbeard/failed_history.py
+++ b/sickbeard/failed_history.py
@@ -19,8 +19,9 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import urllib
 import datetime
+
+from requests.compat import unquote
 
 from sickbeard import db
 from sickbeard import logger
@@ -34,7 +35,7 @@ from sickrage.show.History import History
 def prepareFailedName(release):
     """Standardizes release name for failed DB"""
 
-    fixed = urllib.unquote(release)
+    fixed = unquote(release)
     if fixed.endswith(".nzb"):
         fixed = fixed.rpartition(".")[0]
 
@@ -123,7 +124,7 @@ def revertEpisode(epObj):
     sql_results = failed_db_con.select("SELECT episode, old_status FROM history WHERE showid=? AND season=?",
                                        [epObj.show.indexerid, epObj.season])
 
-    history_eps = {res["episode"]: res for res in sql_results} 
+    history_eps = {res["episode"]: res for res in sql_results}
 
     try:
         logger.log(u"Reverting episode (%s, %s): %s" % (epObj.season, epObj.episode, epObj.name))

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -39,7 +39,7 @@ import subliminal
 import tornado
 import traceback
 
-from urllib import quote
+from requests.compat import quote
 from github import Github, InputFileContent  # pylint: disable=import-error
 
 import sickbeard

--- a/sickbeard/notifiers/emby.py
+++ b/sickbeard/notifiers/emby.py
@@ -18,8 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Medusa. If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
-import urllib2
+from requests.compat import urlencode
+from six.moves.urllib.request import urlopen, Request
+from six.moves.urllib.error import URLError
 
 import sickbeard
 
@@ -52,18 +53,18 @@ class Notifier(object):
         values = {'Name': 'Medusa', 'Description': message, 'ImageUrl': sickbeard.LOGO_URL}
         data = json.dumps(values)
         try:
-            req = urllib2.Request(url, data)
+            req = Request(url, data)
             req.add_header('X-MediaBrowser-Token', emby_apikey)
             req.add_header('Content-Type', 'application/json')
 
-            response = urllib2.urlopen(req)
+            response = urlopen(req)
             result = response.read()
             response.close()
 
             logger.log(u'EMBY: HTTP response: ' + result.replace('\n', ''), logger.DEBUG)
             return True
 
-        except (urllib2.URLError, IOError) as e:
+        except (URLError, IOError) as e:
             logger.log(u'EMBY: Warning: Couldn\'t contact Emby at ' + url + ' ' + ex(e), logger.WARNING)
             return False
 
@@ -104,18 +105,18 @@ class Notifier(object):
 
             url = 'http://%s/emby/Library/Series/Updated%s' % (sickbeard.EMBY_HOST, query)
             values = {}
-            data = urllib.urlencode(values)
+            data = urlencode(values)
             try:
-                req = urllib2.Request(url, data)
+                req = Request(url, data)
                 req.add_header('X-MediaBrowser-Token', sickbeard.EMBY_APIKEY)
 
-                response = urllib2.urlopen(req)
+                response = urlopen(req)
                 result = response.read()
                 response.close()
 
                 logger.log(u'EMBY: HTTP response: ' + result.replace('\n', ''), logger.DEBUG)
                 return True
 
-            except (urllib2.URLError, IOError) as e:
+            except (URLError, IOError) as e:
                 logger.log(u'EMBY: Warning: Couldn\'t contact Emby at ' + url + ' ' + ex(e), logger.WARNING)
                 return False

--- a/sickbeard/notifiers/freemobile.py
+++ b/sickbeard/notifiers/freemobile.py
@@ -19,7 +19,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Medusa. If not, see <http://www.gnu.org/licenses/>.
-import urllib2
+
+from requests.compat import quote
+from six.moves.urllib.request import Request, urlopen
 
 import sickbeard
 from sickbeard import logger
@@ -50,13 +52,13 @@ class Notifier(object):
 
         # build up the URL and parameters
         msg = msg.strip()
-        msg_quoted = urllib2.quote(title.encode('utf-8') + ": " + msg.encode('utf-8'))
+        msg_quoted = quote(title.encode('utf-8') + ": " + msg.encode('utf-8'))
         URL = "https://smsapi.free-mobile.fr/sendmsg?user=" + cust_id + "&pass=" + apiKey + "&msg=" + msg_quoted
 
-        req = urllib2.Request(URL)
+        req = Request(URL)
         # send the request to Free Mobile
         try:
-            urllib2.urlopen(req)
+            urlopen(req)
         except IOError as e:
             if hasattr(e, 'code'):
                 if e.code == 400:

--- a/sickbeard/notifiers/nmj.py
+++ b/sickbeard/notifiers/nmj.py
@@ -18,11 +18,12 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
-import urllib2
 import sickbeard
 import telnetlib
 import re
+
+from requests.compat import urlencode
+from six.moves.urllib.request import Request, urlopen
 
 from sickbeard import logger
 from sickrage.helper.exceptions import ex
@@ -121,9 +122,9 @@ class Notifier(object):
         # if a mount URL is provided then attempt to open a handle to that URL
         if mount:
             try:
-                req = urllib2.Request(mount)
+                req = Request(mount)
                 logger.log(u"Try to mount network drive via url: %s" % mount, logger.DEBUG)
-                handle = urllib2.urlopen(req)
+                handle = urlopen(req)
             except IOError as e:
                 if hasattr(e, 'reason'):
                     logger.log(u"NMJ: Could not contact Popcorn Hour on host %s: %s" % (host, e.reason), logger.WARNING)
@@ -142,14 +143,14 @@ class Notifier(object):
             "arg2": "background",
             "arg3": ""
         }
-        params = urllib.urlencode(params)
+        params = urlencode(params)
         updateUrl = UPDATE_URL % {"host": host, "params": params}
 
         # send the request to the server
         try:
-            req = urllib2.Request(updateUrl)
+            req = Request(updateUrl)
             logger.log(u"Sending NMJ scan update command via url: %s" % updateUrl, logger.DEBUG)
-            handle = urllib2.urlopen(req)
+            handle = urlopen(req)
             response = handle.read()
         except IOError as e:
             if hasattr(e, 'reason'):

--- a/sickbeard/notifiers/nmjv2.py
+++ b/sickbeard/notifiers/nmjv2.py
@@ -19,11 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import urllib2
-from xml.dom.minidom import parseString
-import sickbeard
-import time
 
+import time
+from xml.dom.minidom import parseString
+
+from six.moves.urllib.request import Request, urlopen
+
+import sickbeard
 from sickbeard import logger
 
 try:
@@ -65,8 +67,8 @@ class Notifier(object):
         """
         try:
             url_loc = "http://{}:8008/file_operation?arg0=list_user_storage_file&arg1=&arg2={}&arg3=20&arg4=true&arg5=true&arg6=true&arg7=all&arg8=name_asc&arg9=false&arg10=false".format(host, instance)
-            req = urllib2.Request(url_loc)
-            handle1 = urllib2.urlopen(req)
+            req = Request(url_loc)
+            handle1 = urlopen(req)
             response1 = handle1.read()
             xml = parseString(response1)
             time.sleep(300.0 / 1000.0)
@@ -74,8 +76,8 @@ class Notifier(object):
                 xmlTag = node.toxml()
                 xmlData = xmlTag.replace('<path>', '').replace('</path>', '').replace('[=]', '')
                 url_db = "http://" + host + ":8008/metadata_database?arg0=check_database&arg1=" + xmlData
-                reqdb = urllib2.Request(url_db)
-                handledb = urllib2.urlopen(reqdb)
+                reqdb = Request(url_db)
+                handledb = urlopen(reqdb)
                 responsedb = handledb.read()
                 xmldb = parseString(responsedb)
                 returnvalue = xmldb.getElementsByTagName('returnValue')[0].toxml().replace('<returnValue>', '').replace(
@@ -114,12 +116,12 @@ class Notifier(object):
             logger.log(u"NMJ scan update command sent to host: %s" % host, logger.DEBUG)
             url_updatedb = "http://" + host + ":8008/metadata_database?arg0=scanner_start&arg1=" + sickbeard.NMJv2_DATABASE + "&arg2=background&arg3="
             logger.log(u"Try to mount network drive via url: %s" % host, logger.DEBUG)
-            prereq = urllib2.Request(url_scandir)
-            req = urllib2.Request(url_updatedb)
-            handle1 = urllib2.urlopen(prereq)
+            prereq = Request(url_scandir)
+            req = Request(url_updatedb)
+            handle1 = urlopen(prereq)
             response1 = handle1.read()
             time.sleep(300.0 / 1000.0)
-            handle2 = urllib2.urlopen(req)
+            handle2 = urlopen(req)
             response2 = handle2.read()
         except IOError as e:
             logger.log(u"Warning: Couldn't contact popcorn hour on host %s: %s" % (host, e), logger.WARNING)

--- a/sickbeard/notifiers/prowl.py
+++ b/sickbeard/notifiers/prowl.py
@@ -21,7 +21,7 @@
 ##############################################################################
 
 import socket
-from httplib import HTTPSConnection, HTTPException
+from six.moves.http_client import HTTPSConnection, HTTPException
 from requests.compat import urlencode
 
 try:

--- a/sickbeard/notifiers/pushover.py
+++ b/sickbeard/notifiers/pushover.py
@@ -19,10 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Medusa. If not, see <http://www.gnu.org/licenses/>.
 
-import httplib
-import urllib
-import urllib2
 import time
+
+from requests.compat import urlencode
+from six.moves.urllib.error import HTTPError
+from six.moves.http_client import HTTPSConnection
 
 import sickbeard
 from sickbeard import logger
@@ -93,11 +94,11 @@ class Notifier(object):
             if sickbeard.PUSHOVER_DEVICE:
                 args["device"] = sickbeard.PUSHOVER_DEVICE
 
-            conn = httplib.HTTPSConnection("api.pushover.net:443")
+            conn = HTTPSConnection("api.pushover.net:443")
             conn.request("POST", "/1/messages.json",
-                         urllib.urlencode(args), {"Content-type": "application/x-www-form-urlencoded"})
+                         urlencode(args), {"Content-type": "application/x-www-form-urlencoded"})
 
-        except urllib2.HTTPError as e:
+        except HTTPError as e:
             # if we get an error back that doesn't have an error code then who knows what's really happening
             if not hasattr(e, 'code'):
                 logger.log(u"Pushover notification failed." + ex(e), logger.ERROR)

--- a/sickbeard/notifiers/pytivo.py
+++ b/sickbeard/notifiers/pytivo.py
@@ -22,7 +22,8 @@ import os
 import sickbeard
 
 from requests.compat import urlencode
-from urllib2 import Request, urlopen, HTTPError
+from six.moves.urllib.request import Request, urlopen
+from six.moves.urllib.error import HTTPError
 
 from sickbeard import logger
 from sickrage.helper.encoding import ek

--- a/sickbeard/notifiers/telegram.py
+++ b/sickbeard/notifiers/telegram.py
@@ -21,8 +21,8 @@
 
 from __future__ import unicode_literals
 
-import urllib
-import urllib2
+from requests.compat import urlencode
+from six.moves.urllib.request import Request, urlopen
 
 import sickbeard
 from sickbeard import logger
@@ -64,14 +64,14 @@ class Notifier(object):
         logger.log('Telegram in use with API KEY: %s' % api_key, logger.DEBUG)
 
         message = '%s : %s' % (title.encode(), msg.encode())
-        payload = urllib.urlencode({'chat_id': id, 'text': message})
+        payload = urlencode({'chat_id': id, 'text': message})
         telegram_api = 'https://api.telegram.org/bot%s/%s'
 
-        req = urllib2.Request(telegram_api % (api_key, 'sendMessage'), payload)
+        req = Request(telegram_api % (api_key, 'sendMessage'), payload)
 
         success = False
         try:
-            urllib2.urlopen(req)
+            urlopen(req)
             message = 'Telegram message sent successfully.'
             success = True
         except IOError as e:

--- a/sickbeard/notifiers/tweet.py
+++ b/sickbeard/notifiers/tweet.py
@@ -23,11 +23,7 @@ import sickbeard
 from sickbeard import logger, common
 from sickrage.helper.exceptions import ex
 
-# parse_qsl moved to urlparse module in v2.6
-try:
-    from urlparse import parse_qsl  # @UnusedImport
-except ImportError:
-    from cgi import parse_qsl  # @Reimport
+from six.moves.urllib.parse import parse_qsl
 
 import oauth2 as oauth
 import pythontwitter as twitter

--- a/sickbeard/nzbget.py
+++ b/sickbeard/nzbget.py
@@ -19,10 +19,12 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
-import httplib
+
 import datetime
 from base64 import standard_b64encode
 import xmlrpclib
+
+from six.moves.http_client import socket
 
 import sickbeard
 from sickbeard import logger
@@ -60,7 +62,7 @@ def sendNZB(nzb, proper=False):  # pylint: disable=too-many-locals, too-many-sta
         else:
             logger.log('Successful connected to NZBget, but unable to send a message', logger.WARNING)
 
-    except httplib.socket.error:
+    except socket.error:
         logger.log(
             'Please check your NZBget host and port (if it is running). NZBget is not responding to this combination',
             logger.WARNING)

--- a/sickbeard/providers/hdspace.py
+++ b/sickbeard/providers/hdspace.py
@@ -21,8 +21,9 @@
 
 import re
 from requests.utils import dict_from_cookiejar
-from urllib import quote_plus
 from bs4 import BeautifulSoup
+
+from requests.compat import quote_plus
 
 from sickbeard import logger, tvcache
 

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -19,8 +19,8 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
+from requests.compat import quote_plus
 from requests.utils import dict_from_cookiejar
-from urllib import quote_plus
 
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -20,7 +20,7 @@
 
 import re
 import traceback
-from urllib import quote
+from requests.compat import quote
 from requests.utils import dict_from_cookiejar
 
 from sickbeard import logger, tvcache

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -20,8 +20,8 @@
 
 import re
 import time
-from urllib import quote
-from requests.compat import urljoin
+
+from requests.compat import urljoin, quote
 from requests.utils import dict_from_cookiejar
 
 import sickbeard

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -19,7 +19,8 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from urllib import quote
+
+from requests.compat import quote
 from requests.utils import dict_from_cookiejar
 
 from sickbeard import logger, tvcache

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -28,8 +28,9 @@ import io
 import os
 import re
 import time
-import urllib
 import traceback
+
+from requests.compat import unquote_plus
 
 from tornado.web import RequestHandler  # pylint: disable=import-error
 
@@ -564,7 +565,7 @@ def _get_root_dirs():
         return {}
 
     # clean up the list - replace %xx escapes by their single-character equivalent
-    root_dirs = [urllib.unquote_plus(x) for x in root_dirs]
+    root_dirs = [unquote_plus(x) for x in root_dirs]
 
     default_dir = root_dirs[default_index]
 
@@ -1362,7 +1363,7 @@ class CMD_SickBeardAddRootDir(ApiCall):
     def run(self):
         """ Add a new root (parent) directory to Medusa """
 
-        self.location = urllib.unquote_plus(self.location)
+        self.location = unquote_plus(self.location)
         location_matched = 0
         index = 0
 
@@ -1379,7 +1380,7 @@ class CMD_SickBeardAddRootDir(ApiCall):
             index = int(sickbeard.ROOT_DIRS.split('|')[0])
             root_dirs.pop(0)
             # clean up the list - replace %xx escapes by their single-character equivalent
-            root_dirs = [urllib.unquote_plus(x) for x in root_dirs]
+            root_dirs = [unquote_plus(x) for x in root_dirs]
             for x in root_dirs:
                 if x == self.location:
                     location_matched = 1
@@ -1393,7 +1394,7 @@ class CMD_SickBeardAddRootDir(ApiCall):
             else:
                 root_dirs.append(self.location)
 
-        root_dirs_new = [urllib.unquote_plus(x) for x in root_dirs]
+        root_dirs_new = [unquote_plus(x) for x in root_dirs]
         root_dirs_new.insert(0, index)
         root_dirs_new = '|'.join(unicode(x) for x in root_dirs_new)
 
@@ -1482,7 +1483,7 @@ class CMD_SickBeardDeleteRootDir(ApiCall):
         index = int(root_dirs[0])
         root_dirs.pop(0)
         # clean up the list - replace %xx escapes by their single-character equivalent
-        root_dirs = [urllib.unquote_plus(x) for x in root_dirs]
+        root_dirs = [unquote_plus(x) for x in root_dirs]
         old_root_dir = root_dirs[index]
         for curRootDir in root_dirs:
             if not curRootDir == self.location:
@@ -1495,7 +1496,7 @@ class CMD_SickBeardDeleteRootDir(ApiCall):
                 new_index = curIndex
                 break
 
-        root_dirs_new = [urllib.unquote_plus(x) for x in root_dirs_new]
+        root_dirs_new = [unquote_plus(x) for x in root_dirs_new]
         if root_dirs_new:
             root_dirs_new.insert(0, new_index)
         root_dirs_new = "|".join(unicode(x) for x in root_dirs_new)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -38,8 +38,9 @@ from mako.lookup import TemplateLookup
 from mako.exceptions import RichTraceback
 from mako.runtime import UNDEFINED
 import markdown2
-from requests.compat import unquote_plus, quote_plus
+from requests.compat import unquote_plus, quote_plus, urljoin
 from tornado.concurrent import run_on_executor
+from tornado.escape import utf8
 from tornado.gen import coroutine
 from tornado.ioloop import IOLoop
 from tornado.process import cpu_count
@@ -100,6 +101,7 @@ from sickrage.system.Restart import Restart
 from sickrage.system.Shutdown import Shutdown
 from sickbeard.tv import TVEpisode
 from sickbeard.classes import SearchResult
+
 
 # Conditional imports
 try:
@@ -267,8 +269,6 @@ class BaseHandler(RequestHandler):
         (temporary) is chosen based on the ``permanent`` argument.
         The default is 302 (temporary).
         """
-        import urlparse
-        from tornado.escape import utf8
         if not url.startswith(sickbeard.WEB_ROOT):
             url = sickbeard.WEB_ROOT + url
 
@@ -279,7 +279,7 @@ class BaseHandler(RequestHandler):
         else:
             assert isinstance(status, int) and 300 <= status <= 399
         self.set_status(status)
-        self.set_header("Location", urlparse.urljoin(utf8(self.request.uri),
+        self.set_header("Location", urljoin(utf8(self.request.uri),
                                                      utf8(url)))
 
     def get_current_user(self):
@@ -1439,7 +1439,7 @@ class Home(WebRoot):
         if manual_search_type == 'season':
             try:
                 main_db_con = db.DBConnection()
-                season_pack_episodes_result = main_db_con.action("SELECT episode FROM tv_episodes WHERE showid = ? and season = ?",  
+                season_pack_episodes_result = main_db_con.action("SELECT episode FROM tv_episodes WHERE showid = ? and season = ?",
                                                                  [cached_result['indexerid'], cached_result['season']])
             except Exception as e:
                 logger.log("Couldn't read episodes for season pack result. Error: {}".format(e))
@@ -1647,7 +1647,7 @@ class Home(WebRoot):
                     episode_history.append(dict(item))
         except Exception as e:
             logger.log("Couldn't read latest episode statust. Error: {}".format(e))
-            
+
         show_words = show_name_helpers.show_words(showObj)
 
         return t.render(
@@ -4151,7 +4151,7 @@ class ConfigGeneral(Config):
             sickbeard.ENCRYPTION_VERSION = 0
         sickbeard.WEB_USERNAME = web_username
         sickbeard.WEB_PASSWORD = web_password
-        
+
         # Reconfigure the logger only if subliminal setting changed
         if sickbeard.SUBLIMINAL_LOG != config.checkbox_to_value(subliminal_log):
             logger.reconfigure_levels()


### PR DESCRIPTION
Use a combination of six and requests.compat for python 3 compatibility, preferring requests.compat when possible as many of the urllib calls should be rewritten using requests.
