### PR TITLE
Add lib simpleanidb

### DIFF
--- a/lib/simpleanidb/__init__.py
+++ b/lib/simpleanidb/__init__.py
@@ -1,0 +1,142 @@
+from __future__ import absolute_import
+import os
+import xml.etree.cElementTree as etree
+from datetime import datetime, timedelta
+import tempfile
+import getpass
+from appdirs import user_cache_dir
+import requests
+from simpleanidb.helper import download_file
+from simpleanidb.models import Anime
+from simpleanidb.exceptions import GeneralError
+import xml.etree.ElementTree as ET
+
+__version__ = "0.1.0"
+__author__ = "Dennis Lutter"
+
+ANIME_LIST_URL = "http://anidb.net/api/anime-titles.xml.gz"
+
+ANIDB_URL = \
+    "http://api.anidb.net:9001/httpapi"
+
+# Request list Types
+REQUEST_CATEGORY_LIST = "categorylist"
+REQUEST_RANDOM_RECOMMENDATION = "randomrecommendtion"
+REQUEST_HOT = "hotanime"
+
+
+class Anidb(object):
+    def __init__(self, session=None, cache_dir=None, auto_download=True, lang=None):  # pylint: disable=too-many-arguments
+        if not cache_dir:
+            self._cache_dir = user_cache_dir("simpleanidb", appauthor="simpleanidb")  # appauthor is requered on windows
+            if not os.path.isdir(self._cache_dir):
+                os.makedirs(self._cache_dir)
+        else:
+            self._cache_dir = cache_dir
+        if not os.path.isdir(self._cache_dir):
+            raise ValueError("'%s' does not exist" % self._cache_dir)
+        elif not os.access(self._cache_dir, os.W_OK):
+            raise IOError("'%s' is not writable" % self._cache_dir)
+
+        self.session = session or requests.Session()
+        self.session.headers.setdefault('user-agent', 'simpleanidb/{0}.{1}.{2}'.format(*__version__))
+
+        self.anime_list_path = os.path.join(
+            self._cache_dir, "anime-titles.xml.gz")
+        self.auto_download = auto_download
+        self._xml = None
+        self.lang = lang
+        if not lang:
+            self.lang = "en"
+
+    def _get_temp_dir(self):
+        """Returns the system temp dir"""
+        if hasattr(os, 'getuid'):
+            uid = "u%d" % (os.getuid())
+            path = os.path.join(tempfile.gettempdir(), "simpleanidb-%s" % (uid))
+        else:
+            # For Windows
+            try:
+                uid = getpass.getuser()
+                path = os.path.join(tempfile.gettempdir(), "simpleanidb-%s" % (uid))
+            except ImportError:
+                path = os.path.join(tempfile.gettempdir(), "simpleanidb")
+
+        # Create the directory
+        if not os.path.exists(path):
+            os.makedirs(path)
+
+        return path
+
+    def search(self, term, autoload=False):
+        if not self._xml:
+            try:
+                self._xml = self._read_file(self.anime_list_path)
+            except IOError:
+                if self.auto_download:
+                    self.download_anime_list()
+                    self._xml = self._read_file(self.anime_list_path)
+                else:
+                    raise
+
+        term = term.lower()
+        anime_ids = []
+        for anime in self._xml.findall("anime"):
+            for title in anime.findall("title"):
+                if term in title.text.lower():
+                    anime_ids.append((int(anime.get("aid")), anime))
+                    break
+        return [Anime(self, aid, autoload, xml_node) for aid, xml_node in anime_ids]
+
+    def anime(self, aid):
+        return Anime(self, aid)
+
+    def _read_file(self, path):
+        f = open(path, 'rb')
+        return etree.ElementTree(file=f)
+
+    def download_anime_list(self, force=False):
+        if not force and os.path.exists(self.anime_list_path):
+            modified_date = datetime.fromtimestamp(
+                os.path.getmtime(self.anime_list_path))
+            if modified_date + timedelta(1) > datetime.now():
+                return False
+        return download_file(self.anime_list_path, ANIME_LIST_URL)
+
+    def get_list(self, request_type):
+        """Retrieve a lists of animes from anidb.info
+        @param request_type: type of list, options are:
+        REQUEST_CATEGORY_LIST, REQUEST_RANDOM_RECOMMENDATION, REQUEST_HOST
+
+        @return: A list of Anime objects.
+        """
+        params = {
+            "request": "anime",
+            "client": "adbahttp",
+            "clientver": 100,
+            "protover": 1,
+            "request": request_type
+        }
+
+        self._get_url(ANIDB_URL, params=params)
+
+        anime_ids = []
+        for anime in self._xml.findall("anime"):
+            anime_ids.append((int(anime.get("id")), anime))
+
+        return [Anime(self, aid, False, xml_node) for aid, xml_node in anime_ids]
+
+    def _get_url(self, url, params=None):
+        """Get the an anime or list of animes in XML, raise for status for an unexpected result"""
+        if not params:
+            params = {}
+
+        r = self.session.get(url, params=params)
+
+        r.raise_for_status()
+
+        self._xml = ET.fromstring(r.text.encode("UTF-8"))
+        if self._xml.tag == 'error':
+            raise GeneralError(self._xml.text)
+
+        return self._xml

--- a/lib/simpleanidb/exceptions.py
+++ b/lib/simpleanidb/exceptions.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+
+
+from requests.compat import is_py3
+from requests import RequestException
+
+
+class BaseError(Exception):
+    def __init__(self, value):
+        Exception.__init__()
+        self.value = value
+
+    def __str__(self):
+        return self.value if is_py3 else unicode(self.value).encode('utf-8')
+
+
+class GeneralError(BaseError):
+    """General simpleanidb error"""
+
+
+class AnidbConnectionError(GeneralError, RequestException):
+    """Connection error while accessing Anidb"""
+
+
+class BadRequest(AnidbConnectionError):
+    """Bad request"""

--- a/lib/simpleanidb/helper.py
+++ b/lib/simpleanidb/helper.py
@@ -1,0 +1,22 @@
+from datetime import date
+import requests
+
+
+def download_file(local_filename, url):
+    # NOTE the stream=True parameter
+    r = requests.get(url, stream=True)
+    with open(local_filename, 'wb') as f:
+        for chunk in r.iter_content(chunk_size=1024):
+            if chunk:  # filter out keep-alive new chunks
+                f.write(chunk)
+                f.flush()
+    return local_filename
+
+
+def date_to_date(date_str):
+    if not date_str:
+        return None
+
+    return date(
+        *map(int, date_str.split("-"))
+    )

--- a/lib/simpleanidb/models.py
+++ b/lib/simpleanidb/models.py
@@ -16,7 +16,9 @@ class Anime(object):  # pylint: disable=too-many-instance-attributes
         self.episodes = {}
         self.picture = None
         self.rating_permanent = None
+        self.count_permanent = None
         self.rating_temporary = None
+        self.count_temporary = None
         self.rating_review = None
         self.categories = []
         self.tags = []
@@ -24,7 +26,7 @@ class Anime(object):  # pylint: disable=too-many-instance-attributes
         self.end_date = None
         self.description = None
 
-        if xml:
+        if len(xml):
             self.fill_from_xml(xml)
 
         self._loaded = False
@@ -72,8 +74,10 @@ class Anime(object):  # pylint: disable=too-many-instance-attributes
         if xml.find("ratings") is not None:
             if xml.find("ratings").find("permanent") is not None:
                 self.rating_permanent = xml.find("ratings").find("permanent").text
+                self.count_permanent = xml.find("ratings").find("permanent").get('count', 0)
             if xml.find("ratings").find("temporary") is not None:
                 self.rating_temporary = xml.find("ratings").find("temporary").text
+                self.count_temporary = xml.find("ratings").find("temporary").get('count', 0)
             if xml.find("ratings").find("review") is not None:
                 self.rating_review = xml.find("ratings").find("review").text
         if xml.find("categories") is not None:

--- a/lib/simpleanidb/models.py
+++ b/lib/simpleanidb/models.py
@@ -1,0 +1,230 @@
+from __future__ import absolute_import
+import requests
+import xml.etree.ElementTree as ET
+
+from .helper import date_to_date
+from .exceptions import GeneralError
+
+
+class Anime(object):  # pylint: disable=too-many-instance-attributes
+    def __init__(self, anidb, aid, auto_load=True, xml=None):
+        self.anidb = anidb
+        self.aid = aid
+        self.titles = []
+        self.synonyms = []
+        self.all_episodes = []
+        self.episodes = {}
+        self.picture = None
+        self.rating_permanent = None
+        self.rating_temporary = None
+        self.rating_review = None
+        self.categories = []
+        self.tags = []
+        self.start_date = None
+        self.end_date = None
+        self.description = None
+
+        if xml:
+            self.fill_from_xml(xml)
+
+        self._loaded = False
+        if auto_load:
+            self.load()
+
+    def __repr__(self):
+        return "<Anime:{0} loaded:{1}>".format(self.aid, self.loaded)
+
+    @property
+    def loaded(self):
+        return self._loaded
+
+    def load(self):
+        """Load all extra information for this anime.
+
+        The anidb url should look like this:
+        http://api.anidb.net:9001/httpapi?request=anime&client={str}&clientver={int}&protover=1&aid={int}
+        """
+        params = {
+            "request": "anime",
+            "client": "adbahttp",
+            "clientver": 100,
+            "protover": 1,
+            "aid": self.aid
+        }
+
+        self._xml = self.anidb._get_url("http://api.anidb.net:9001/httpapi", params=params)
+
+        self.fill_from_xml(self._xml)
+        self._loaded = True
+
+    def fill_from_xml(self, xml):  # pylint: disable=too-many-branches
+        if xml.find("titles") is not None:
+            self.titles = [Title(self, n) for n in xml.find("titles")]
+        else:
+            self.titles = [Title(self, n) for n in xml.findall("title")]
+            # return # returning from here will result in not loading attribute information for anime lists like hot_animes
+        self.synonyms = [t for t in self.titles if t.type == "synonym"]
+        if xml.find("episodes") is not None:
+            self.all_episodes = sorted([Episode(self, n) for n in xml.find("episodes")])
+            self.episodes = {e.number: e for e in self.all_episodes if e.type == 1}
+        if xml.find("picture") is not None:
+            self.picture = Picture(self, xml.find("picture"))
+        if xml.find("ratings") is not None:
+            if xml.find("ratings").find("permanent") is not None:
+                self.rating_permanent = xml.find("ratings").find("permanent").text
+            if xml.find("ratings").find("temporary") is not None:
+                self.rating_temporary = xml.find("ratings").find("temporary").text
+            if xml.find("ratings").find("review") is not None:
+                self.rating_review = xml.find("ratings").find("review").text
+        if xml.find("categories") is not None:
+            self.categories = [Category(self, c) for c in xml.find("categories")]
+        if xml.find("tags") is not None:
+            self.tags = sorted([Tag(self, t) for t in xml.find("tags") if t.text.strip()])
+        if xml.find("startdate") is not None:
+            self.start_date = date_to_date(xml.find("startdate").text)
+        if xml.find("enddate") is not None:
+            self.end_date = date_to_date(xml.find("enddate").text)
+        if xml.find("description") is not None:
+            self.description = xml.find("description").text
+
+    @property
+    def title(self):
+        return self.get_title("main")
+
+    def get_title(self, title_type=None, lang=None):
+        if not title_type:
+            title_type = "main"
+        for t in self.titles:
+            if t.type == title_type:
+                return t
+        if not lang:
+            lang = self.anidb.lang
+        for t in self.titles:
+            if t.lang == lang:
+                return t
+
+
+class BaseAttribute(object):  # pylint: disable=too-few-public-methods
+
+    def __init__(self, anime, xml_node):
+        self.anime = anime
+        self._xml = xml_node
+
+    def _attributes(self, *attrs):
+        """Set the given attributes.
+
+        :param list attrs: the attributes to be set.
+        """
+        for attr in attrs:
+            setattr(self, attr, self._xml.attrib.get(attr))
+
+    def _booleans(self, *attrs):
+        """Set the given attributes after casting them to bools.
+
+        :param list attrs: the attributes to be set.
+        """
+        for attr in attrs:
+            value = self._xml.attrib.get(attr)
+            setattr(self, attr, value is not None and value.lower() == "true")
+
+    def _texts(self, *attrs):
+        """Set the text values of the given attributes.
+
+        :param list attrs: the attributes to be found.
+        """
+        for attr in attrs:
+            value = self._xml.find(attr)
+            setattr(self, attr, value.text if value is not None else None)
+
+    def __str__(self):
+        return self._xml.text
+
+    def __repr__(self):
+        return u"<{0}: {1}>".format(
+            self.__class__.__name__,
+            unicode(self)
+        )
+
+
+class Category(BaseAttribute):  # pylint: disable=too-few-public-methods
+
+    def __init__(self, anime, xml_node):
+        super(Category, self).__init__(anime, xml_node)
+        self._attributes('id', 'weight')
+        self._booleans('hentai')
+        self._texts('name', 'description')
+
+
+class Tag(BaseAttribute):  # pylint: disable=too-few-public-methods
+
+    def __init__(self, anime, xml_node):
+        super(Tag, self).__init__(anime, xml_node)
+        self._attributes('id', 'update', 'weight')
+        if self.update:
+            self.update = date_to_date(self.update)
+
+        self._booleans('spoiler', 'localspoiler', 'globalspoiler', 'verified')
+        self._texts('name', 'description')
+        self.count = int(self.weight) if self.weight else 0
+        """The importance of this tag."""
+
+    def __cmp__(self, other):
+        return self.count - other.count
+
+
+class Title(BaseAttribute):  # pylint: disable=too-few-public-methods
+
+    def __init__(self, anime, xml_node):
+        super(Title, self).__init__(anime, xml_node)
+        # apperently xml:lang is "{http://www.w3.org/XML/1998/namespace}lang"
+        self.lang = self._xml.attrib["{http://www.w3.org/XML/1998/namespace}lang"]
+        self.type = self._xml.attrib.get("type")
+
+
+class Picture(BaseAttribute):  # pylint: disable=too-few-public-methods
+
+    def __str__(self):
+        return self.url
+
+    @property
+    def url(self):
+        return "http://img7.anidb.net/pics/anime/{0}".format(self._xml.text)
+
+
+class Episode(BaseAttribute):
+
+    def __init__(self, anime, xml_node):
+        super(Episode, self).__init__(anime, xml_node)
+        self._attributes('id')
+        self._texts('airdate', 'length', 'epno')
+        self.airdate = date_to_date(self.airdate)
+
+        self.titles = [Title(self, n) for n in self._xml.findall("title")]
+        self.type = int(self._xml.find("epno").attrib["type"])
+        self.number = self.epno or 0
+        if self.type == 1:
+            self.number = int(self.number)
+
+    @property
+    def title(self):
+        return self.get_title()
+
+    def get_title(self, lang=None):
+        if not lang:
+            lang = self.anime.anidb.lang
+        for t in self.titles:
+            if t.lang == lang:
+                return t
+
+    def __str__(self):
+        return u"{0}: {1}".format(self.number, self.title)
+
+    def __cmp__(self, other):
+        if self.type > other.type:
+            return -1
+        elif self.type < other.type:
+            return 1
+
+        if self.number < other.number:
+            return -1
+        return 1


### PR DESCRIPTION
This lib has support for anidb.net's http api, as also the http://anidb.net/api/anime-titles.xml.gz for the show search. It's a step in the direction for building an anidb indexer, with the biggest limitation that the xml does not have the airdates. Making it not ideal for indexer searches.

For now it will be used for retrieving the anidb.net recommended lists.