### PR TITLE
Fix "stupid" regex wrongfully matching

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -116,7 +116,7 @@ normal_regexes = [
     ('stupid',
      # tpz-abc102
      r'''
-     (?P<release_group>.+?)-\w+?[\. ]?           # tpz-abc
+     (?P<release_group>.+?)(?<!WEB)-\w+?[\. ]?           # tpz-abc
      (?!264)                                     # don't count x264
      (?P<season_num>\d{1,2})                     # 1
      (?P<ep_num>\d{2})$                          # 02


### PR DESCRIPTION
Fixes "stupid" regex matching Web-Dl and similiar qualities becouse of the "-"
This makes sure it isnt preceded by a "web"
Fixes https://github.com/pymedusa/SickRage/issues/509

Result: `Chernobyl.Zona.otchuzhdeniya.s01.2014.WEB-DLRip.720`
Without this fix (matching result wrongfully) : 
https://regex101.com/r/nU3tR7/1
With fix: not matching : 
https://regex101.com/r/zV6iL2/2
With fix still matching intended results ( any TOPAZ release, the file not dirname *) : https://regex101.com/r/zV6iL2/1

\* aka release name
