### PR TITLE
Support for non US "season", meaning AU, UK , etc

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # URL: http://code.google.com/p/sickbeard/
 #
@@ -116,7 +115,7 @@ normal_regexes = [
     ('stupid',
      # tpz-abc102
      r'''
-     (?P<release_group>.+?)(?<!WEB)-\w+?[\. ]?           # tpz-abc
+     (?P<release_group>.+?)(?<!WEB)-\w+?[\. ]?   # tpz-abc
      (?!264)                                     # don't count x264
      (?P<season_num>\d{1,2})                     # 1
      (?P<ep_num>\d{2})$                          # 02
@@ -125,7 +124,7 @@ normal_regexes = [
      # Show Name Season 1 Episode 2 Ep Name
      r'''
      ^(?P<series_name>.+?)[. _-]+                # Show Name and separator
-     season[. _-]+                               # season and separator
+     (season|series)[. _-]+                      # season and separator
      (?P<season_num>\d+)[. _-]+                  # 1
      episode[. _-]+                              # episode and separator
      (?P<ep_num>\d+)[. _-]+                      # 02 and separator


### PR DESCRIPTION
Adds support for `The Katering Show Series 2 Episode 1 Red Ramen` (UK,AU), while maintaining support for `Show Name Season 1 Episode 2 Ep Name` (US)  alike namings