### PR TITLE
Fix propers issue since manual search implementation

### DIFF
--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -147,7 +147,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                     proper.provider = cur_provider
                     propers[name] = proper
 
-            threading.currentThread().name = original_thread_name
+        threading.currentThread().name = original_thread_name
 
         # take the list of unique propers and get it sorted by
         sortedPropers = sorted(propers.values(), key=operator.attrgetter('date'), reverse=True)

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -104,7 +104,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                 logger.log(u"Authentication error: {error}".format
                            (error=ex(e)), logger.DEBUG)
                 continue
-            except (SocketTimeout, TypeError) as e:
+            except (SocketTimeout) as e:
                 logger.log(u"Socket time out while searching for propers in {provider}, skipping: {error}".format
                            (provider=cur_provider.name, error=ex(e)), logger.DEBUG)
                 continue

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -110,7 +110,7 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
     def find_propers(self, search_date=None):
         results = self.cache.listPropers(search_date)
 
-        return [Proper(x['name'], x['url'], datetime.fromtimestamp(x['time']), self.show) for x in results]
+        return [Proper(x['name'], x['url'], datetime.fromtimestamp(x['time']), self.show, x['seeders'], x['leechers'], x['size'], x['pubdate'], x['hash']) for x in results]
 
     def find_search_results(self, show, episodes, search_mode, forced_search=False, download_current_quality=False, manual_search=False, manual_search_type='episode'):  # pylint: disable=too-many-branches,too-many-arguments,too-many-locals,too-many-statements
         self._check_auth()


### PR DESCRIPTION
When manual search was implemented, seeders and leechers were added to cache but the sockets timeout issue (catching `TypeError`) were preventing us to see the traceback and submit issue

```
FINDPROPERS :: [Provider] :: [hash] Socket time out while searching for propers in Provider, skipping: __init__() takes exactly 10 arguments (5 given)
```

This PR fixes the error handling and the `__init__` proper error
Alsos fixes the multiple thread names in the log like:
` [provider1] [provider1] [provider1] [provider1] [provider1]`

already tested by me and @duramato at `pubdate2` branch