### PR TITLE
Cache is already being created at startup

### DIFF
--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -418,7 +418,6 @@ def searchForNeededEpisodes():
 
     for curShow in show_list:
         if not curShow.paused:
-            sickbeard.name_cache.buildNameCache(curShow)
             episodes.extend(wantedEpisodes(curShow, fromDate))
 
     if not episodes:


### PR DESCRIPTION
Issue from old repo. This was added when the name cache creation was removed from SR startup. Then it was reverted and "someone" forgot to remove this line

this was fully tested by me and @duramato in `pubdate2` branch for the past 4 days

