### PR TITLE
	Do not show traceback and as error when issue connecting to indexer occurs in metadata creation

### DIFF
--- a/sickbeard/metadata/kodi_12plus.py
+++ b/sickbeard/metadata/kodi_12plus.py
@@ -258,9 +258,9 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
             myShow = t[ep_obj.show.indexerid]
         except sickbeard.indexer_shownotfound as e:
             raise ShowNotFoundException(e.message)
-        except sickbeard.indexer_error as e:
+        except sickbeard.indexer_error:
             logger.log(u"Unable to connect to " + sickbeard.indexerApi(
-                ep_obj.show.indexer).name + " while creating meta files - skipping - " + ex(e), logger.ERROR)
+                ep_obj.show.indexer).name + " while creating meta files - skipping it.", logger.WARNING)
             return
 
         if len(eps_to_write) > 1:

--- a/sickbeard/metadata/kodi_12plus.py
+++ b/sickbeard/metadata/kodi_12plus.py
@@ -22,10 +22,10 @@ import datetime
 from babelfish import Country
 
 import sickbeard
-from sickbeard.metadata import generic
 from sickbeard import logger, helpers
-from sickrage.helper.common import dateFormat
-from sickrage.helper.exceptions import ex, ShowNotFoundException
+from sickbeard.metadata import generic
+from sickrage.helper.common import dateFormat, episode_num
+from sickrage.helper.exceptions import ShowNotFoundException
 
 try:
     import xml.etree.cElementTree as etree
@@ -78,25 +78,26 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
 
         self.name = u'KODI 12+'
 
-        self.poster_name = u"poster.jpg"
-        self.season_all_poster_name = u"season-all-poster.jpg"
+        self.poster_name = u'poster.jpg'
+        self.season_all_poster_name = u'season-all-poster.jpg'
 
         # web-ui metadata template
-        self.eg_show_metadata = u"tvshow.nfo"
-        self.eg_episode_metadata = u"Season##\\<i>filename</i>.nfo"
-        self.eg_fanart = u"fanart.jpg"
-        self.eg_poster = u"poster.jpg"
-        self.eg_banner = u"banner.jpg"
-        self.eg_episode_thumbnails = u"Season##\\<i>filename</i>-thumb.jpg"
-        self.eg_season_posters = u"season##-poster.jpg"
-        self.eg_season_banners = u"season##-banner.jpg"
-        self.eg_season_all_poster = u"season-all-poster.jpg"
-        self.eg_season_all_banner = u"season-all-banner.jpg"
+        self.eg_show_metadata = u'tvshow.nfo'
+        self.eg_episode_metadata = u'Season##\\<i>filename</i>.nfo'
+        self.eg_fanart = u'fanart.jpg'
+        self.eg_poster = u'poster.jpg'
+        self.eg_banner = u'banner.jpg'
+        self.eg_episode_thumbnails = u'Season##\\<i>filename</i>-thumb.jpg'
+        self.eg_season_posters = u'season##-poster.jpg'
+        self.eg_season_banners = u'season##-banner.jpg'
+        self.eg_season_all_poster = u'season-all-poster.jpg'
+        self.eg_season_all_banner = u'season-all-banner.jpg'
 
     @staticmethod
     def _split_info(info_string):
         return {x.strip().title() for x in re.sub(r'[,/]+', '|', info_string).split('|') if x.strip()}
 
+    # SHOW DATA
     def _show_data(self, show_obj):
         """
         Creates an elementTree XML structure for an KODI-style tvshow.nfo and
@@ -105,78 +106,82 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
         show_obj: a TVShow instance to create the NFO for
         """
 
-        show_ID = show_obj.indexerid
+        show_id = show_obj.indexerid
 
         indexer_lang = show_obj.lang
-        lINDEXER_API_PARMS = sickbeard.indexerApi(show_obj.indexer).api_params.copy()
+        l_indexer_api_params = sickbeard.indexerApi(show_obj.indexer).api_params.copy()
 
-        lINDEXER_API_PARMS['actors'] = True
+        l_indexer_api_params['actors'] = True
 
         if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
-            lINDEXER_API_PARMS['language'] = indexer_lang
+            l_indexer_api_params['language'] = indexer_lang
 
         if show_obj.dvdorder != 0:
-            lINDEXER_API_PARMS['dvdorder'] = True
+            l_indexer_api_params['dvdorder'] = True
 
-        t = sickbeard.indexerApi(show_obj.indexer).indexer(**lINDEXER_API_PARMS)
+        t = sickbeard.indexerApi(show_obj.indexer).indexer(**l_indexer_api_params)
 
-        tv_node = etree.Element("tvshow")
+        tv_node = etree.Element('tvshow')
 
         try:
-            myShow = t[int(show_ID)]
+            my_show = t[int(show_id)]
         except sickbeard.indexer_shownotfound:
-            logger.log(u"Unable to find show with id " + str(show_ID) + " on " + sickbeard.indexerApi(
-                show_obj.indexer).name + ", skipping it", logger.ERROR)
+            logger.log(u'Unable to find {indexer} show {id}, skipping it'.format
+                       (indexer=sickbeard.indexerApi(show_obj.indexer).name,
+                        id=show_id), logger.ERROR)
             raise
 
         except sickbeard.indexer_error:
-            logger.log(
-                u"" + sickbeard.indexerApi(show_obj.indexer).name + " is down, can't use its data to add this show",
-                logger.ERROR)
+            logger.log(u'{indexer} is down, can\'t use its data to add this show'.format
+                       (indexer=sickbeard.indexerApi(show_obj.indexer).name), logger.ERROR)
             raise
 
         # check for title and id
-        if not (getattr(myShow, 'seriesname', None) and getattr(myShow, 'id', None)):
-            logger.log(u"Incomplete info for show with id " + str(show_ID) + " on " + sickbeard.indexerApi(
-                show_obj.indexer).name + ", skipping it")
+        if not (getattr(my_show, 'seriesname', None) and getattr(my_show, 'id', None)):
+            logger.log(u'Incomplete info for {indexer} show {id}, skipping it'.format
+                       (indexer=sickbeard.indexerApi(show_obj.indexer).name,
+                        id=show_id), logger.ERROR)
             return False
 
-        title = etree.SubElement(tv_node, "title")
-        title.text = myShow["seriesname"]
+        title = etree.SubElement(tv_node, 'title')
+        title.text = my_show['seriesname']
 
-        if getattr(myShow, 'rating', None):
-            rating = etree.SubElement(tv_node, "rating")
-            rating.text = myShow["rating"]
+        if getattr(my_show, 'rating', None):
+            rating = etree.SubElement(tv_node, 'rating')
+            rating.text = my_show['rating']
 
-        if getattr(myShow, 'firstaired', None):
+        if getattr(my_show, 'firstaired', None):
             try:
-                year_text = str(datetime.datetime.strptime(myShow["firstaired"], dateFormat).year)
+                year_text = str(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
                 if year_text:
-                    year = etree.SubElement(tv_node, "year")
+                    year = etree.SubElement(tv_node, 'year')
                     year.text = year_text
             except Exception:
                 pass
 
-        if getattr(myShow, 'overview', None):
-            plot = etree.SubElement(tv_node, "plot")
-            plot.text = myShow["overview"]
+        if getattr(my_show, 'overview', None):
+            plot = etree.SubElement(tv_node, 'plot')
+            plot.text = my_show['overview']
 
-        if getattr(myShow, 'id', None):
-            episodeguide = etree.SubElement(tv_node, "episodeguide")
-            episodeguideurl = etree.SubElement(episodeguide, "url")
-            episodeguideurl.text = sickbeard.indexerApi(show_obj.indexer).config['base_url'] + str(myShow["id"]) + '/all/en.zip'
+        if getattr(my_show, 'id', None):
+            episode_guide = etree.SubElement(tv_node, 'episodeguide')
+            episode_guide_url = etree.SubElement(episode_guide, 'url')
+            episode_guide_url.text = '{url}{id}/all/en.zip'.format(
+                url=sickbeard.indexerApi(show_obj.indexer).config['base_url'],
+                id=my_show['id']
+            )
 
-        if getattr(myShow, 'contentrating', None):
-            mpaa = etree.SubElement(tv_node, "mpaa")
-            mpaa.text = myShow["contentrating"]
+        if getattr(my_show, 'contentrating', None):
+            mpaa = etree.SubElement(tv_node, 'mpaa')
+            mpaa.text = my_show['contentrating']
 
-        if getattr(myShow, 'id', None):
-            indexerid = etree.SubElement(tv_node, "id")
-            indexerid.text = str(myShow["id"])
+        if getattr(my_show, 'id', None):
+            indexer_id = etree.SubElement(tv_node, 'id')
+            indexer_id.text = str(my_show['id'])
 
-        if getattr(myShow, 'genre', None) and isinstance(myShow["genre"], basestring):
-            for genre in self._split_info(myShow["genre"]):
-                cur_genre = etree.SubElement(tv_node, "genre")
+        if getattr(my_show, 'genre', None) and isinstance(my_show['genre'], basestring):
+            for genre in self._split_info(my_show['genre']):
+                cur_genre = etree.SubElement(tv_node, 'genre')
                 cur_genre.text = genre
 
         if 'country_codes' in show_obj.imdb_info:
@@ -186,43 +191,43 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
                 except Exception:
                     continue
 
-                cur_country = etree.SubElement(tv_node, "country")
+                cur_country = etree.SubElement(tv_node, 'country')
                 cur_country.text = cur_country_name
 
-        if getattr(myShow, 'firstaired', None):
-            premiered = etree.SubElement(tv_node, "premiered")
-            premiered.text = myShow["firstaired"]
+        if getattr(my_show, 'firstaired', None):
+            premiered = etree.SubElement(tv_node, 'premiered')
+            premiered.text = my_show['firstaired']
 
-        if getattr(myShow, 'network', None):
-            studio = etree.SubElement(tv_node, "studio")
-            studio.text = myShow["network"].strip()
+        if getattr(my_show, 'network', None):
+            studio = etree.SubElement(tv_node, 'studio')
+            studio.text = my_show['network'].strip()
 
-        if getattr(myShow, 'writer', None) and isinstance(myShow['writer'], basestring):
-            for writer in self._split_info(myShow['writer']):
-                cur_writer = etree.SubElement(tv_node, "credits")
+        if getattr(my_show, 'writer', None) and isinstance(my_show['writer'], basestring):
+            for writer in self._split_info(my_show['writer']):
+                cur_writer = etree.SubElement(tv_node, 'credits')
                 cur_writer.text = writer
 
-        if getattr(myShow, 'director', None) and isinstance(myShow['director'], basestring):
-            for director in self._split_info(myShow['director']):
-                cur_director = etree.SubElement(tv_node, "director")
+        if getattr(my_show, 'director', None) and isinstance(my_show['director'], basestring):
+            for director in self._split_info(my_show['director']):
+                cur_director = etree.SubElement(tv_node, 'director')
                 cur_director.text = director
 
-        if getattr(myShow, '_actors', None):
-            for actor in myShow['_actors']:
-                cur_actor = etree.SubElement(tv_node, "actor")
+        if getattr(my_show, '_actors', None):
+            for actor in my_show['_actors']:
+                cur_actor = etree.SubElement(tv_node, 'actor')
 
                 if 'name' in actor and actor['name'].strip():
-                    cur_actor_name = etree.SubElement(cur_actor, "name")
+                    cur_actor_name = etree.SubElement(cur_actor, 'name')
                     cur_actor_name.text = actor['name'].strip()
                 else:
                     continue
 
                 if 'role' in actor and actor['role'].strip():
-                    cur_actor_role = etree.SubElement(cur_actor, "role")
+                    cur_actor_role = etree.SubElement(cur_actor, 'role')
                     cur_actor_role.text = actor['role'].strip()
 
                 if 'image' in actor and actor['image'].strip():
-                    cur_actor_thumb = etree.SubElement(cur_actor, "thumb")
+                    cur_actor_thumb = etree.SubElement(cur_actor, 'thumb')
                     cur_actor_thumb.text = actor['image'].strip()
 
         # Make it purdy
@@ -236,152 +241,157 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
         """
         Creates an elementTree XML structure for an KODI-style episode.nfo and
         returns the resulting data object.
-            show_obj: a TVEpisode instance to create the NFO for
+
+        show_obj: a TVEpisode instance to create the NFO for
         """
 
         eps_to_write = [ep_obj] + ep_obj.relatedEps
 
         indexer_lang = ep_obj.show.lang
 
-        lINDEXER_API_PARMS = sickbeard.indexerApi(ep_obj.show.indexer).api_params.copy()
+        # There's gotta be a better way of doing this but we don't wanna
+        # change the language value elsewhere
+        l_indexer_api_params = sickbeard.indexerApi(ep_obj.show.indexer).api_params.copy()
 
-        lINDEXER_API_PARMS['actors'] = True
+        l_indexer_api_params[b'actors'] = True
 
         if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
-            lINDEXER_API_PARMS['language'] = indexer_lang
+            l_indexer_api_params[b'language'] = indexer_lang
 
         if ep_obj.show.dvdorder != 0:
-            lINDEXER_API_PARMS['dvdorder'] = True
+            l_indexer_api_params[b'dvdorder'] = True
 
         try:
-            t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**lINDEXER_API_PARMS)
-            myShow = t[ep_obj.show.indexerid]
+            t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**l_indexer_api_params)
+            my_show = t[ep_obj.show.indexerid]
         except sickbeard.indexer_shownotfound as e:
             raise ShowNotFoundException(e.message)
         except sickbeard.indexer_error:
-            logger.log(u"Unable to connect to " + sickbeard.indexerApi(
-                ep_obj.show.indexer).name + " while creating meta files - skipping it.", logger.WARNING)
+            logger.log(u'Unable to connect to {indexer} while creating meta files - skipping it.'.format
+                       (indexer=sickbeard.indexerApi(ep_obj.show.indexer).name), logger.WARNING)
             return
 
         if len(eps_to_write) > 1:
-            rootNode = etree.Element("kodimultiepisode")
+            root_node = etree.Element('kodimultiepisode')
         else:
-            rootNode = etree.Element("episodedetails")
+            root_node = etree.Element('episodedetails')
 
         # write an NFO containing info for all matching episodes
-        for curEpToWrite in eps_to_write:
+        for ep_to_write in eps_to_write:
 
             try:
-                myEp = myShow[curEpToWrite.season][curEpToWrite.episode]
+                my_ep = my_show[ep_to_write.season][ep_to_write.episode]
             except (sickbeard.indexer_episodenotfound, sickbeard.indexer_seasonnotfound):
-                logger.log(u"Unable to find episode %dx%d on %s... has it been removed? Should I delete from db?" %
-                           (curEpToWrite.season, curEpToWrite.episode, sickbeard.indexerApi(ep_obj.show.indexer).name))
-
+                logger.log(u'Unable to find episode {ep_num} on {indexer}... '
+                           u'has it been removed? Should I delete from db?'.format
+                           (ep_num=episode_num(ep_to_write.season, ep_to_write.episode),
+                            indexer=sickbeard.indexerApi(ep_obj.show.indexer).name))
                 return None
 
-            if not getattr(myEp, 'firstaired', None):
-                myEp["firstaired"] = str(datetime.date.fromordinal(1))
+            if not getattr(my_ep, 'firstaired', None):
+                my_ep['firstaired'] = str(datetime.date.fromordinal(1))
 
-            if not getattr(myEp, 'episodename', None):
-                logger.log(u"Not generating nfo because the ep has no title", logger.DEBUG)
+            if not getattr(my_ep, 'episodename', None):
+                logger.log(u'Not generating nfo because the ep has no title', logger.DEBUG)
                 return None
 
-            logger.log(u"Creating metadata for episode " + str(ep_obj.season) + "x" + str(ep_obj.episode), logger.DEBUG)
+            logger.log(u'Creating metadata for episode {ep_num}'.format
+                       (ep_num=episode_num(ep_obj.season, ep_obj.episode)), logger.DEBUG)
 
             if len(eps_to_write) > 1:
-                episode = etree.SubElement(rootNode, "episodedetails")
+                episode = etree.SubElement(root_node, 'episodedetails')
             else:
-                episode = rootNode
+                episode = root_node
 
-            if getattr(myEp, 'episodename', None):
-                title = etree.SubElement(episode, "title")
-                title.text = myEp['episodename']
+            if getattr(my_ep, 'episodename', None):
+                title = etree.SubElement(episode, 'title')
+                title.text = my_ep['episodename']
 
-            if getattr(myShow, 'seriesname', None):
-                showtitle = etree.SubElement(episode, "showtitle")
-                showtitle.text = myShow['seriesname']
+            if getattr(my_show, 'seriesname', None):
+                showtitle = etree.SubElement(episode, 'showtitle')
+                showtitle.text = my_show['seriesname']
 
-            season = etree.SubElement(episode, "season")
-            season.text = str(curEpToWrite.season)
+            season = etree.SubElement(episode, 'season')
+            season.text = str(ep_to_write.season)
 
-            episodenum = etree.SubElement(episode, "episode")
-            episodenum.text = str(curEpToWrite.episode)
+            episodenum = etree.SubElement(episode, 'episode')
+            episodenum.text = str(ep_to_write.episode)
 
-            uniqueid = etree.SubElement(episode, "uniqueid")
-            uniqueid.text = str(curEpToWrite.indexerid)
+            uniqueid = etree.SubElement(episode, 'uniqueid')
+            uniqueid.text = str(ep_to_write.indexerid)
 
-            if curEpToWrite.airdate != datetime.date.fromordinal(1):
-                aired = etree.SubElement(episode, "aired")
-                aired.text = str(curEpToWrite.airdate)
+            if ep_to_write.airdate != datetime.date.fromordinal(1):
+                aired = etree.SubElement(episode, 'aired')
+                aired.text = str(ep_to_write.airdate)
 
-            if getattr(myEp, 'overview', None):
-                plot = etree.SubElement(episode, "plot")
-                plot.text = myEp['overview']
+            if getattr(my_ep, 'overview', None):
+                plot = etree.SubElement(episode, 'plot')
+                plot.text = my_ep['overview']
 
-            if curEpToWrite.season and getattr(myShow, 'runtime', None):
-                runtime = etree.SubElement(episode, "runtime")
-                runtime.text = myShow["runtime"]
+            if ep_to_write.season and getattr(my_show, 'runtime', None):
+                runtime = etree.SubElement(episode, 'runtime')
+                runtime.text = my_show['runtime']
 
-            if getattr(myEp, 'airsbefore_season', None):
-                displayseason = etree.SubElement(episode, "displayseason")
-                displayseason.text = myEp['airsbefore_season']
+            if getattr(my_ep, 'airsbefore_season', None):
+                displayseason = etree.SubElement(episode, 'displayseason')
+                displayseason.text = my_ep['airsbefore_season']
 
-            if getattr(myEp, 'airsbefore_episode', None):
-                displayepisode = etree.SubElement(episode, "displayepisode")
-                displayepisode.text = myEp['airsbefore_episode']
+            if getattr(my_ep, 'airsbefore_episode', None):
+                displayepisode = etree.SubElement(episode, 'displayepisode')
+                displayepisode.text = my_ep['airsbefore_episode']
 
-            if getattr(myEp, 'filename', None):
-                thumb = etree.SubElement(episode, "thumb")
-                thumb.text = myEp['filename'].strip()
+            if getattr(my_ep, 'filename', None):
+                thumb = etree.SubElement(episode, 'thumb')
+                thumb.text = my_ep['filename'].strip()
 
-            # watched = etree.SubElement(episode, "watched")
+            # watched = etree.SubElement(episode, 'watched')
             # watched.text = 'false'
 
-            if getattr(myEp, 'rating', None):
-                rating = etree.SubElement(episode, "rating")
-                rating.text = myEp['rating']
+            if getattr(my_ep, 'rating', None):
+                rating = etree.SubElement(episode, 'rating')
+                rating.text = my_ep['rating']
 
-            if getattr(myEp, 'writer', None) and isinstance(myEp['writer'], basestring):
-                for writer in self._split_info(myEp['writer']):
-                    cur_writer = etree.SubElement(episode, "credits")
+            if getattr(my_ep, 'writer', None) and isinstance(my_ep['writer'], basestring):
+                for writer in self._split_info(my_ep['writer']):
+                    cur_writer = etree.SubElement(episode, 'credits')
                     cur_writer.text = writer
 
-            if getattr(myEp, 'director', None) and isinstance(myEp['director'], basestring):
-                for director in self._split_info(myEp['director']):
-                    cur_director = etree.SubElement(episode, "director")
+            if getattr(my_ep, 'director', None) and isinstance(my_ep['director'], basestring):
+                for director in self._split_info(my_ep['director']):
+                    cur_director = etree.SubElement(episode, 'director')
                     cur_director.text = director
 
-            if getattr(myEp, 'gueststars', None) and isinstance(myEp['gueststars'], basestring):
-                for actor in self._split_info(myEp['gueststars']):
-                    cur_actor = etree.SubElement(episode, "actor")
-                    cur_actor_name = etree.SubElement(cur_actor, "name")
+            if getattr(my_ep, 'gueststars', None) and isinstance(my_ep['gueststars'], basestring):
+                for actor in self._split_info(my_ep['gueststars']):
+                    cur_actor = etree.SubElement(episode, 'actor')
+                    cur_actor_name = etree.SubElement(cur_actor, 'name')
                     cur_actor_name.text = actor
 
-            if getattr(myShow, '_actors', None):
-                for actor in myShow['_actors']:
-                    cur_actor = etree.SubElement(episode, "actor")
+            if getattr(my_show, '_actors', None):
+                for actor in my_show['_actors']:
+                    cur_actor = etree.SubElement(episode, 'actor')
 
                     if 'name' in actor and actor['name'].strip():
-                        cur_actor_name = etree.SubElement(cur_actor, "name")
+                        cur_actor_name = etree.SubElement(cur_actor, 'name')
                         cur_actor_name.text = actor['name'].strip()
                     else:
                         continue
 
                     if 'role' in actor and actor['role'].strip():
-                        cur_actor_role = etree.SubElement(cur_actor, "role")
+                        cur_actor_role = etree.SubElement(cur_actor, 'role')
                         cur_actor_role.text = actor['role'].strip()
 
                     if 'image' in actor and actor['image'].strip():
-                        cur_actor_thumb = etree.SubElement(cur_actor, "thumb")
+                        cur_actor_thumb = etree.SubElement(cur_actor, 'thumb')
                         cur_actor_thumb.text = actor['image'].strip()
 
         # Make it purdy
-        helpers.indentXML(rootNode)
+        helpers.indentXML(root_node)
 
-        data = etree.ElementTree(rootNode)
+        data = etree.ElementTree(root_node)
 
         return data
 
 
-# present a standard "interface" from the module
+# present a standard 'interface' from the module
 metadata_class = KODI_12PlusMetadata

--- a/sickbeard/metadata/mede8er.py
+++ b/sickbeard/metadata/mede8er.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
+
 import io
 import os
 import datetime
@@ -25,7 +26,7 @@ import sickbeard
 from sickbeard import logger, helpers
 from sickbeard.metadata import mediabrowser
 
-from sickrage.helper.common import dateFormat, replace_extension
+from sickrage.helper.common import dateFormat, replace_extension, episode_num
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex, ShowNotFoundException
 
@@ -68,21 +69,21 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
             season_banners, season_all_poster, season_all_banner
         )
 
-        self.name = "Mede8er"
+        self.name = 'Mede8er'
 
-        self.fanart_name = "fanart.jpg"
+        self.fanart_name = 'fanart.jpg'
 
         # web-ui metadata template
-        # self.eg_show_metadata = "series.xml"
-        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
-        self.eg_fanart = "fanart.jpg"
-        # self.eg_poster = "folder.jpg"
-        # self.eg_banner = "banner.jpg"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.jpg"
-        # self.eg_season_posters = "Season##\\folder.jpg"
-        # self.eg_season_banners = "Season##\\banner.jpg"
-        # self.eg_season_all_poster = "<i>not supported</i>"
-        # self.eg_season_all_banner = "<i>not supported</i>"
+        # self.eg_show_metadata = 'series.xml'
+        self.eg_episode_metadata = 'Season##\\<i>filename</i>.xml'
+        self.eg_fanart = 'fanart.jpg'
+        # self.eg_poster = 'folder.jpg'
+        # self.eg_banner = 'banner.jpg'
+        self.eg_episode_thumbnails = 'Season##\\<i>filename</i>.jpg'
+        # self.eg_season_posters = 'Season##\\folder.jpg'
+        # self.eg_season_banners = 'Season##\\banner.jpg'
+        # self.eg_season_all_poster = '<i>not supported</i>'
+        # self.eg_season_all_banner = '<i>not supported</i>'
 
     def get_episode_file_path(self, ep_obj):
         return replace_extension(ep_obj.location, self._ep_nfo_extension)
@@ -91,6 +92,7 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
     def get_episode_thumb_path(ep_obj):
         return replace_extension(ep_obj.location, 'jpg')
 
+    # SHOW DATA
     def _show_data(self, show_obj):
         """
         Creates an elementTree XML structure for a MediaBrowser-style series.xml
@@ -99,109 +101,113 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
         show_obj: a TVShow instance to create the NFO for
         """
 
-        indexer_lang = show_obj.lang
-        lINDEXER_API_PARMS = sickbeard.indexerApi(show_obj.indexer).api_params.copy()
+        show_id = show_obj.indexerid
 
-        lINDEXER_API_PARMS['actors'] = True
+        indexer_lang = show_obj.lang
+        l_indexer_api_params = sickbeard.indexerApi(show_obj.indexer).api_params.copy()
+
+        l_indexer_api_params['actors'] = True
 
         if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
-            lINDEXER_API_PARMS['language'] = indexer_lang
+            l_indexer_api_params['language'] = indexer_lang
 
         if show_obj.dvdorder != 0:
-            lINDEXER_API_PARMS['dvdorder'] = True
+            l_indexer_api_params['dvdorder'] = True
 
-        t = sickbeard.indexerApi(show_obj.indexer).indexer(**lINDEXER_API_PARMS)
+        t = sickbeard.indexerApi(show_obj.indexer).indexer(**l_indexer_api_params)
 
-        rootNode = etree.Element("details")
-        tv_node = etree.SubElement(rootNode, "movie")
-        tv_node.attrib["isExtra"] = "false"
-        tv_node.attrib["isSet"] = "false"
-        tv_node.attrib["isTV"] = "true"
+        root_node = etree.Element('details')
+        tv_node = etree.SubElement(root_node, 'movie')
+        tv_node.attrib['isExtra'] = 'false'
+        tv_node.attrib['isSet'] = 'false'
+        tv_node.attrib['isTV'] = 'true'
 
         try:
-            myShow = t[int(show_obj.indexerid)]
+            my_show = t[int(show_id)]
         except sickbeard.indexer_shownotfound:
-            logger.log(u"Unable to find show with id " + str(show_obj.indexerid) + " on tvdb, skipping it", logger.ERROR)
+            logger.log(u'Unable to find {indexer} show {id}, skipping it'.format
+                       (indexer=sickbeard.indexerApi(show_obj.indexer).name,
+                        id=show_id), logger.ERROR)
             raise
 
         except sickbeard.indexer_error:
-            logger.log(u"TVDB is down, can't use its data to make the NFO", logger.ERROR)
+            logger.log(u'{indexer} is down, can\'t use its data to add this show'.format
+                       (indexer=sickbeard.indexerApi(show_obj.indexer).name), logger.ERROR)
             raise
 
         # check for title and id
-        if not (getattr(myShow, 'seriesname', None) and getattr(myShow, 'id', None)):
-            logger.log(u"Incomplete info for show with id " + str(show_obj.indexerid) + " on " + sickbeard.indexerApi(
-                show_obj.indexer).name + ", skipping it")
+        if not (getattr(my_show, 'seriesname', None) and getattr(my_show, 'id', None)):
+            logger.log(u'Incomplete info for {indexer} show {id}, skipping it'.format
+                       (indexer=sickbeard.indexerApi(show_obj.indexer).name,
+                        id=show_id), logger.ERROR)
             return False
 
-        SeriesName = etree.SubElement(tv_node, "title")
-        SeriesName.text = myShow['seriesname']
+        title = etree.SubElement(tv_node, 'title')
+        title.text = my_show['seriesname']
 
-        if getattr(myShow, "genre", None):
-            Genres = etree.SubElement(tv_node, "genres")
-            for genre in myShow['genre'].split('|'):
+        if getattr(my_show, 'genre', None):
+            genres = etree.SubElement(tv_node, 'genres')
+            for genre in my_show['genre'].split('|'):
                 if genre and genre.strip():
-                    cur_genre = etree.SubElement(Genres, "Genre")
+                    cur_genre = etree.SubElement(genres, 'Genre')
                     cur_genre.text = genre.strip()
 
-        if getattr(myShow, 'firstaired', None):
-            FirstAired = etree.SubElement(tv_node, "premiered")
-            FirstAired.text = myShow['firstaired']
-
-        if getattr(myShow, "firstaired", None):
+        if getattr(my_show, 'firstaired', None):
+            first_aired = etree.SubElement(tv_node, 'premiered')
+            first_aired.text = my_show['firstaired']
             try:
-                year_text = str(datetime.datetime.strptime(myShow["firstaired"], dateFormat).year)
+                year_text = str(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
                 if year_text:
-                    year = etree.SubElement(tv_node, "year")
+                    year = etree.SubElement(tv_node, 'year')
                     year.text = year_text
             except Exception:
                 pass
 
-        if getattr(myShow, 'overview', None):
-            plot = etree.SubElement(tv_node, "plot")
-            plot.text = myShow["overview"]
+        if getattr(my_show, 'overview', None):
+            plot = etree.SubElement(tv_node, 'plot')
+            plot.text = my_show['overview']
 
-        if getattr(myShow, 'rating', None):
+        if getattr(my_show, 'rating', None):
             try:
-                rating = int(float(myShow['rating']) * 10)
+                rating = int(float(my_show['rating']) * 10)
             except ValueError:
                 rating = 0
 
             if rating:
-                Rating = etree.SubElement(tv_node, "rating")
-                Rating.text = str(rating)
+                rating = etree.SubElement(tv_node, 'rating')
+                rating.text = str(rating)
 
-        if getattr(myShow, 'status', None):
-            Status = etree.SubElement(tv_node, "status")
-            Status.text = myShow['status']
+        if getattr(my_show, 'status', None):
+            status = etree.SubElement(tv_node, 'status')
+            status.text = my_show['status']
 
-        if getattr(myShow, "contentrating", None):
-            mpaa = etree.SubElement(tv_node, "mpaa")
-            mpaa.text = myShow["contentrating"]
+        if getattr(my_show, 'contentrating', None):
+            mpaa = etree.SubElement(tv_node, 'mpaa')
+            mpaa.text = my_show['contentrating']
 
-        if getattr(myShow, 'imdb_id', None):
-            imdb_id = etree.SubElement(tv_node, "id")
-            imdb_id.attrib["moviedb"] = "imdb"
-            imdb_id.text = myShow['imdb_id']
+        if getattr(my_show, 'imdb_id', None):
+            imdb_id = etree.SubElement(tv_node, 'id')
+            imdb_id.attrib['moviedb'] = 'imdb'
+            imdb_id.text = my_show['imdb_id']
 
-        if getattr(myShow, 'id', None):
-            indexerid = etree.SubElement(tv_node, "indexerid")
-            indexerid.text = myShow['id']
+        if getattr(my_show, 'id', None):
+            indexer_id = etree.SubElement(tv_node, 'indexerid')
+            indexer_id.text = my_show['id']
 
-        if getattr(myShow, 'runtime', None):
-            Runtime = etree.SubElement(tv_node, "runtime")
-            Runtime.text = myShow['runtime']
+        if getattr(my_show, 'runtime', None):
+            runtime = etree.SubElement(tv_node, 'runtime')
+            runtime.text = my_show['runtime']
 
-        if getattr(myShow, '_actors', None):
-            cast = etree.SubElement(tv_node, "cast")
-            for actor in myShow['_actors']:
+        if getattr(my_show, '_actors', None):
+            cast = etree.SubElement(tv_node, 'cast')
+            for actor in my_show['_actors']:
                 if 'name' in actor and actor['name'].strip():
-                    cur_actor = etree.SubElement(cast, "actor")
+                    cur_actor = etree.SubElement(cast, 'actor')
                     cur_actor.text = actor['name'].strip()
 
-        helpers.indentXML(rootNode)
+        helpers.indentXML(root_node)
 
-        data = etree.ElementTree(rootNode)
+        data = etree.ElementTree(root_node)
 
         return data
 
@@ -217,134 +223,138 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
 
         indexer_lang = ep_obj.show.lang
 
+        # There's gotta be a better way of doing this but we don't wanna
+        # change the language value elsewhere
+        l_indexer_api_params = sickbeard.indexerApi(ep_obj.show.indexer).api_params.copy()
+
+        if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
+            l_indexer_api_params[b'language'] = indexer_lang
+
+        if ep_obj.show.dvdorder != 0:
+            l_indexer_api_params[b'dvdorder'] = True
+
         try:
-            # There's gotta be a better way of doing this but we don't wanna
-            # change the language value elsewhere
-            lINDEXER_API_PARMS = sickbeard.indexerApi(ep_obj.show.indexer).api_params.copy()
-
-            if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
-                lINDEXER_API_PARMS['language'] = indexer_lang
-
-            if ep_obj.show.dvdorder != 0:
-                lINDEXER_API_PARMS['dvdorder'] = True
-
-            t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**lINDEXER_API_PARMS)
-            myShow = t[ep_obj.show.indexerid]
+            t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**l_indexer_api_params)
+            my_show = t[ep_obj.show.indexerid]
         except sickbeard.indexer_shownotfound as e:
             raise ShowNotFoundException(e.message)
         except sickbeard.indexer_error:
-            logger.log(u"Unable to connect to " + sickbeard.indexerApi(
-                ep_obj.show.indexer).name + " while creating meta files - skipping it.", logger.WARNING)
-            return False
+            logger.log(u'Unable to connect to {indexer} while creating meta files - skipping it.'.format
+                       (indexer=sickbeard.indexerApi(ep_obj.show.indexer).name), logger.WARNING)
+            return
 
-        rootNode = etree.Element("details")
-        movie = etree.SubElement(rootNode, "movie")
+        root_node = etree.Element('details')
+        movie = etree.SubElement(root_node, 'movie')
 
-        movie.attrib["isExtra"] = "false"
-        movie.attrib["isSet"] = "false"
-        movie.attrib["isTV"] = "true"
+        movie.attrib['isExtra'] = 'false'
+        movie.attrib['isSet'] = 'false'
+        movie.attrib['isTV'] = 'true'
 
         # write an MediaBrowser XML containing info for all matching episodes
-        for curEpToWrite in eps_to_write:
+        for ep_to_write in eps_to_write:
 
             try:
-                myEp = myShow[curEpToWrite.season][curEpToWrite.episode]
+                my_ep = my_show[ep_to_write.season][ep_to_write.episode]
             except (sickbeard.indexer_episodenotfound, sickbeard.indexer_seasonnotfound):
-                logger.log(u"Unable to find episode %dx%d on %s... has it been removed? Should I delete from db?" %
-                           (curEpToWrite.season, curEpToWrite.episode, sickbeard.indexerApi(ep_obj.show.indexer).name))
+                logger.log(u'Unable to find episode {ep_num} on {indexer}... '
+                           u'has it been removed? Should I delete from db?'.format
+                           (ep_num=episode_num(ep_to_write.season, ep_to_write.episode),
+                            indexer=sickbeard.indexerApi(ep_obj.show.indexer).name))
                 return None
 
-            if curEpToWrite == ep_obj:
+            if ep_to_write == ep_obj:
                 # root (or single) episode
 
                 # default to today's date for specials if firstaired is not set
-                if curEpToWrite.season == 0 and not getattr(myEp, 'firstaired', None):
-                    myEp['firstaired'] = str(datetime.date.fromordinal(1))
+                if ep_to_write.season == 0 and not getattr(my_ep, 'firstaired', None):
+                    my_ep['firstaired'] = str(datetime.date.fromordinal(1))
 
-                if not (getattr(myEp, 'episodename', None) and getattr(myEp, 'firstaired', None)):
+                if not (getattr(my_ep, 'episodename', None) and getattr(my_ep, 'firstaired', None)):
                     return None
 
                 episode = movie
 
-                if curEpToWrite.name:
-                    EpisodeName = etree.SubElement(episode, "title")
-                    EpisodeName.text = curEpToWrite.name
+                if ep_to_write.name:
+                    episode_name = etree.SubElement(episode, 'title')
+                    episode_name.text = ep_to_write.name
 
-                SeasonNumber = etree.SubElement(episode, "season")
-                SeasonNumber.text = str(curEpToWrite.season)
+                season_number = etree.SubElement(episode, 'season')
+                season_number.text = str(ep_to_write.season)
 
-                EpisodeNumber = etree.SubElement(episode, "episode")
-                EpisodeNumber.text = str(curEpToWrite.episode)
+                episode_number = etree.SubElement(episode, 'episode')
+                episode_number.text = str(ep_to_write.episode)
 
-                if getattr(myShow, "firstaired", None):
+                if getattr(my_show, 'firstaired', None):
                     try:
-                        year_text = str(datetime.datetime.strptime(myShow["firstaired"], dateFormat).year)
+                        year_text = str(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
                         if year_text:
-                            year = etree.SubElement(episode, "year")
+                            year = etree.SubElement(episode, 'year')
                             year.text = year_text
                     except Exception:
                         pass
 
-                if getattr(myShow, "overview", None):
-                    plot = etree.SubElement(episode, "plot")
-                    plot.text = myShow["overview"]
+                if getattr(my_show, 'overview', None):
+                    plot = etree.SubElement(episode, 'plot')
+                    plot.text = my_show['overview']
 
-                if curEpToWrite.description:
-                    Overview = etree.SubElement(episode, "episodeplot")
-                    Overview.text = curEpToWrite.description
+                if ep_to_write.description:
+                    overview = etree.SubElement(episode, 'episodeplot')
+                    overview.text = ep_to_write.description
 
-                if getattr(myShow, 'contentrating', None):
-                    mpaa = etree.SubElement(episode, "mpaa")
-                    mpaa.text = myShow["contentrating"]
+                if getattr(my_show, 'contentrating', None):
+                    mpaa = etree.SubElement(episode, 'mpaa')
+                    mpaa.text = my_show['contentrating']
 
-                if not ep_obj.relatedEps and getattr(myEp, "rating", None):
+                if not ep_obj.relatedEps and getattr(my_ep, 'rating', None):
                     try:
-                        rating = int((float(myEp['rating']) * 10))
+                        rating = int((float(my_ep['rating']) * 10))
                     except ValueError:
                         rating = 0
 
                     if rating:
-                        Rating = etree.SubElement(episode, "rating")
-                        Rating.text = str(rating)
+                        rating = etree.SubElement(episode, 'rating')
+                        rating.text = str(rating)
 
-                if getattr(myEp, 'director', None):
-                    director = etree.SubElement(episode, "director")
-                    director.text = myEp['director']
+                if getattr(my_ep, 'director', None):
+                    director = etree.SubElement(episode, 'director')
+                    director.text = my_ep['director']
 
-                if getattr(myEp, 'writer', None):
-                    writer = etree.SubElement(episode, "credits")
-                    writer.text = myEp['writer']
+                if getattr(my_ep, 'writer', None):
+                    writer = etree.SubElement(episode, 'credits')
+                    writer.text = my_ep['writer']
 
-                if getattr(myShow, '_actors', None) or getattr(myEp, 'gueststars', None):
-                    cast = etree.SubElement(episode, "cast")
-                    if getattr(myEp, 'gueststars', None) and isinstance(myEp['gueststars'], basestring):
-                        for actor in (x.strip() for x in myEp['gueststars'].split('|') if x.strip()):
-                            cur_actor = etree.SubElement(cast, "actor")
+                if getattr(my_show, '_actors', None) or getattr(my_ep, 'gueststars', None):
+                    cast = etree.SubElement(episode, 'cast')
+                    if getattr(my_ep, 'gueststars', None) and isinstance(my_ep['gueststars'], basestring):
+                        for actor in (x.strip() for x in my_ep['gueststars'].split('|') if x.strip()):
+                            cur_actor = etree.SubElement(cast, 'actor')
                             cur_actor.text = actor
 
-                    if getattr(myShow, '_actors', None):
-                        for actor in myShow['_actors']:
+                    if getattr(my_show, '_actors', None):
+                        for actor in my_show['_actors']:
                             if 'name' in actor and actor['name'].strip():
-                                cur_actor = etree.SubElement(cast, "actor")
+                                cur_actor = etree.SubElement(cast, 'actor')
                                 cur_actor.text = actor['name'].strip()
 
             else:
                 # append data from (if any) related episodes
 
-                if curEpToWrite.name:
-                    if not EpisodeName.text:
-                        EpisodeName.text = curEpToWrite.name
+                if ep_to_write.name:
+                    if not episode_name.text:
+                        episode_name.text = ep_to_write.name
                     else:
-                        EpisodeName.text = EpisodeName.text + ", " + curEpToWrite.name
+                        episode_name.text = u', '.join([episode_name.text, ep_to_write.name])
 
-                if curEpToWrite.description:
-                    if not Overview.text:
-                        Overview.text = curEpToWrite.description
+                if ep_to_write.description:
+                    if not overview.text:
+                        overview.text = ep_to_write.description
                     else:
-                        Overview.text = Overview.text + "\r" + curEpToWrite.description
+                        overview.text = u'\r'.join([overview.text, ep_to_write.description])
 
-        helpers.indentXML(rootNode)
-        data = etree.ElementTree(rootNode)
+        # Make it purdy
+        helpers.indentXML(root_node)
+
+        data = etree.ElementTree(root_node)
 
         return data
 
@@ -373,19 +383,23 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
 
         try:
             if not ek(os.path.isdir, nfo_file_dir):
-                logger.log(u"Metadata dir didn't exist, creating it at " + nfo_file_dir, logger.DEBUG)
+                logger.log(u'Metadata directory did not exist, creating it at {path}'.format
+                           (path=nfo_file_dir), logger.DEBUG)
                 ek(os.makedirs, nfo_file_dir)
                 helpers.chmodAsParent(nfo_file_dir)
 
-            logger.log(u"Writing show nfo file to " + nfo_file_path, logger.DEBUG)
+            logger.log(u'Writing show nfo file to {path}'.format
+                       (path=nfo_file_path), logger.DEBUG)
 
             nfo_file = io.open(nfo_file_path, 'wb')
 
-            data.write(nfo_file, encoding="utf-8", xml_declaration=True)
+            data.write(nfo_file, encoding='utf-8', xml_declaration=True)
             nfo_file.close()
             helpers.chmodAsParent(nfo_file_path)
         except IOError as e:
-            logger.log(u"Unable to write file to " + nfo_file_path + " - are you sure the folder is writable? " + ex(e),
+            logger.log(u'Unable to write file to {path} - '
+                       u'are you sure the folder is writable? {exception}'.format
+                       (path=nfo_file_path, exception=ex(e)),
                        logger.ERROR)
             return False
 
@@ -418,23 +432,28 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
 
         try:
             if not ek(os.path.isdir, nfo_file_dir):
-                logger.log(u"Metadata dir didn't exist, creating it at " + nfo_file_dir, logger.DEBUG)
+                logger.log(u'Metadata directory did not exist, creating it at {path}'.format
+                           (path=nfo_file_dir), logger.DEBUG)
                 ek(os.makedirs, nfo_file_dir)
                 helpers.chmodAsParent(nfo_file_dir)
 
-            logger.log(u"Writing episode nfo file to " + nfo_file_path, logger.DEBUG)
+            logger.log(u'Writing episode nfo file to {path}'.format
+                       (path=nfo_file_path), logger.DEBUG)
 
-            nfo_file = io.open(nfo_file_path, 'wb')
+            with io.open(nfo_file_path, 'wb') as nfo_file:
+                # Calling encode directly, b/c often descriptions have wonky characters.
+                data.write(nfo_file, encoding='utf-8', xml_declaration=True)
 
-            data.write(nfo_file, encoding="utf-8", xml_declaration=True)
-            nfo_file.close()
             helpers.chmodAsParent(nfo_file_path)
+
         except IOError as e:
-            logger.log(u"Unable to write file to " + nfo_file_path + " - are you sure the folder is writable? " + ex(e),
-                       logger.ERROR)
+            logger.log(u'Unable to write file to {path} - '
+                       u'are you sure the folder is writable? {exception}'.format
+                       (path=nfo_file_path, exception=ex(e)), logger.ERROR)
             return False
 
         return True
 
-# present a standard "interface" from the module
+
+# present a standard 'interface' from the module
 metadata_class = Mede8erMetadata

--- a/sickbeard/metadata/mede8er.py
+++ b/sickbeard/metadata/mede8er.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # URL: http://code.google.com/p/sickbeard/
 #
@@ -233,8 +232,9 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
             myShow = t[ep_obj.show.indexerid]
         except sickbeard.indexer_shownotfound as e:
             raise ShowNotFoundException(e.message)
-        except sickbeard.indexer_error as e:
-            logger.log(u"Unable to connect to TVDB while creating meta files - skipping - " + ex(e), logger.ERROR)
+        except sickbeard.indexer_error:
+            logger.log(u"Unable to connect to " + sickbeard.indexerApi(
+                ep_obj.show.indexer).name + " while creating meta files - skipping it.", logger.WARNING)
             return False
 
         rootNode = etree.Element("details")

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # URL: http://code.google.com/p/sickbeard/
 #
@@ -422,13 +421,12 @@ class MediaBrowserMetadata(generic.GenericMetadata):
                 lINDEXER_API_PARMS['dvdorder'] = True
 
             t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**lINDEXER_API_PARMS)
-
             myShow = t[ep_obj.show.indexerid]
         except sickbeard.indexer_shownotfound as e:
             raise ShowNotFoundException(e.message)
-        except sickbeard.indexer_error as e:
+        except sickbeard.indexer_error:
             logger.log(u"Unable to connect to " + sickbeard.indexerApi(
-                ep_obj.show.indexer).name + " while creating meta files - skipping - " + ex(e), logger.ERROR)
+                ep_obj.show.indexer).name + " while creating meta files - skipping it.", logger.WARNING)
             return False
 
         rootNode = etree.Element("Item")

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -27,9 +27,9 @@ from sickbeard.metadata import generic
 
 from sickbeard import logger, helpers
 
-from sickrage.helper.common import dateFormat, replace_extension
+from sickrage.helper.common import dateFormat, replace_extension, episode_num
 from sickrage.helper.encoding import ek
-from sickrage.helper.exceptions import ex, ShowNotFoundException
+from sickrage.helper.exceptions import ShowNotFoundException
 
 try:
     import xml.etree.cElementTree as etree
@@ -81,20 +81,20 @@ class MediaBrowserMetadata(generic.GenericMetadata):
         self._ep_nfo_extension = 'xml'
         self._show_metadata_filename = 'series.xml'
 
-        self.fanart_name = "backdrop.jpg"
-        self.poster_name = "folder.jpg"
+        self.fanart_name = 'backdrop.jpg'
+        self.poster_name = 'folder.jpg'
 
         # web-ui metadata template
-        self.eg_show_metadata = "series.xml"
-        self.eg_episode_metadata = "Season##\\metadata\\<i>filename</i>.xml"
-        self.eg_fanart = "backdrop.jpg"
-        self.eg_poster = "folder.jpg"
-        self.eg_banner = "banner.jpg"
-        self.eg_episode_thumbnails = "Season##\\metadata\\<i>filename</i>.jpg"
-        self.eg_season_posters = "Season##\\folder.jpg"
-        self.eg_season_banners = "Season##\\banner.jpg"
-        self.eg_season_all_poster = "<i>not supported</i>"
-        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_show_metadata = 'series.xml'
+        self.eg_episode_metadata = 'Season##\\metadata\\<i>filename</i>.xml'
+        self.eg_fanart = 'backdrop.jpg'
+        self.eg_poster = 'folder.jpg'
+        self.eg_banner = 'banner.jpg'
+        self.eg_episode_thumbnails = 'Season##\\metadata\\<i>filename</i>.jpg'
+        self.eg_season_posters = 'Season##\\folder.jpg'
+        self.eg_season_banners = 'Season##\\banner.jpg'
+        self.eg_season_all_poster = '<i>not supported</i>'
+        self.eg_season_all_banner = '<i>not supported</i>'
 
     # Override with empty methods for unsupported features
     def retrieveShowMetadata(self, folder):
@@ -120,7 +120,8 @@ class MediaBrowserMetadata(generic.GenericMetadata):
             metadata_dir_name = ek(os.path.join, ek(os.path.dirname, ep_obj.location), 'metadata')
             xml_file_path = ek(os.path.join, metadata_dir_name, xml_file_name)
         else:
-            logger.log(u"Episode location doesn't exist: " + str(ep_obj.location), logger.DEBUG)
+            logger.log(u'Episode location doesn\'t exist: {path}'.format
+                       (path=ep_obj.location), logger.DEBUG)
             return ''
 
         return xml_file_path
@@ -162,7 +163,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
             # MediaBrowser 1.x only supports 'Specials'
             # MediaBrowser 2.x looks to only support 'Season 0'
             # MediaBrowser 3.x looks to mimic KODI/Plex support
-            if season == 0 and cur_dir == "Specials":
+            if season == 0 and cur_dir == 'Specials':
                 season_dir = cur_dir
                 break
 
@@ -177,10 +178,12 @@ class MediaBrowserMetadata(generic.GenericMetadata):
                 break
 
         if not season_dir:
-            logger.log(u"Unable to find a season dir for season " + str(season), logger.DEBUG)
+            logger.log(u'Unable to find a season directory for season {season_num}'.format
+                       (season_num=season), logger.DEBUG)
             return None
 
-        logger.log(u"Using " + str(season_dir) + "/folder.jpg as season dir for season " + str(season), logger.DEBUG)
+        logger.log(u'Using {path}/folder.jpg as season dir for season {season_num}'.format
+                   (path=season_dir, season_num=season), logger.DEBUG)
 
         return ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
 
@@ -203,7 +206,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
             # MediaBrowser 1.x only supports 'Specials'
             # MediaBrowser 2.x looks to only support 'Season 0'
             # MediaBrowser 3.x looks to mimic KODI/Plex support
-            if season == 0 and cur_dir == "Specials":
+            if season == 0 and cur_dir == 'Specials':
                 season_dir = cur_dir
                 break
 
@@ -218,10 +221,12 @@ class MediaBrowserMetadata(generic.GenericMetadata):
                 break
 
         if not season_dir:
-            logger.log(u"Unable to find a season dir for season " + str(season), logger.DEBUG)
+            logger.log(u'Unable to find a season directory for season {season_num}'.format
+                       (season_num=season), logger.DEBUG)
             return None
 
-        logger.log(u"Using " + str(season_dir) + "/banner.jpg as season dir for season " + str(season), logger.DEBUG)
+        logger.log(u'Using {path}/banner.jpg as season dir for season {season_num}'.format
+                   (path=season_dir, season_num=season), logger.DEBUG)
 
         return ek(os.path.join, show_obj.location, season_dir, 'banner.jpg')
 
@@ -233,156 +238,159 @@ class MediaBrowserMetadata(generic.GenericMetadata):
         show_obj: a TVShow instance to create the NFO for
         """
 
+        show_id = show_obj.indexerid
+
         indexer_lang = show_obj.lang
         # There's gotta be a better way of doing this but we don't wanna
         # change the language value elsewhere
-        lINDEXER_API_PARMS = sickbeard.indexerApi(show_obj.indexer).api_params.copy()
+        l_indexer_api_params = sickbeard.indexerApi(show_obj.indexer).api_params.copy()
 
-        lINDEXER_API_PARMS['actors'] = True
+        l_indexer_api_params['actors'] = True
 
         if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
-            lINDEXER_API_PARMS['language'] = indexer_lang
+            l_indexer_api_params['language'] = indexer_lang
 
         if show_obj.dvdorder != 0:
-            lINDEXER_API_PARMS['dvdorder'] = True
+            l_indexer_api_params['dvdorder'] = True
 
-        t = sickbeard.indexerApi(show_obj.indexer).indexer(**lINDEXER_API_PARMS)
+        t = sickbeard.indexerApi(show_obj.indexer).indexer(**l_indexer_api_params)
 
-        tv_node = etree.Element("Series")
+        tv_node = etree.Element('Series')
 
         try:
-            myShow = t[int(show_obj.indexerid)]
+            my_show = t[int(show_id)]
         except sickbeard.indexer_shownotfound:
-            logger.log(u"Unable to find show with id " + str(show_obj.indexerid) + " on " + sickbeard.indexerApi(
-                show_obj.indexer).name + ", skipping it", logger.ERROR)
+            logger.log(u'Unable to find {indexer} show {id}, skipping it'.format
+                       (indexer=sickbeard.indexerApi(show_obj.indexer).name,
+                        id=show_id), logger.ERROR)
             raise
 
         except sickbeard.indexer_error:
-            logger.log(
-                u"" + sickbeard.indexerApi(show_obj.indexer).name + " is down, can't use its data to make the NFO",
-                logger.ERROR)
+            logger.log(u'{indexer} is down, can\'t use its data to add this show'.format
+                       (indexer=sickbeard.indexerApi(show_obj.indexer).name), logger.ERROR)
             raise
 
         # check for title and id
-        if not (getattr(myShow, 'seriesname', None) and getattr(myShow, 'id', None)):
-            logger.log(u"Incomplete info for show with id " + str(show_obj.indexerid) + " on " + sickbeard.indexerApi(
-                show_obj.indexer).name + ", skipping it")
+        if not (getattr(my_show, 'seriesname', None) and getattr(my_show, 'id', None)):
+            logger.log(u'Incomplete info for {indexer} show {id}, skipping it'.format
+                       (indexer=sickbeard.indexerApi(show_obj.indexer).name,
+                        id=show_id), logger.ERROR)
             return False
 
-        if getattr(myShow, 'id', None):
-            indexerid = etree.SubElement(tv_node, "id")
-            indexerid.text = str(myShow['id'])
+        if getattr(my_show, 'id', None):
+            indexerid = etree.SubElement(tv_node, 'id')
+            indexerid.text = str(my_show['id'])
 
-        if getattr(myShow, 'seriesname', None):
-            SeriesName = etree.SubElement(tv_node, "SeriesName")
-            SeriesName.text = myShow['seriesname']
+        if getattr(my_show, 'seriesname', None):
+            series_name = etree.SubElement(tv_node, 'SeriesName')
+            series_name.text = my_show['seriesname']
 
-        if getattr(myShow, 'status', None):
-            Status = etree.SubElement(tv_node, "Status")
-            Status.text = myShow['status']
+        if getattr(my_show, 'status', None):
+            status = etree.SubElement(tv_node, 'Status')
+            status.text = my_show['status']
 
-        if getattr(myShow, 'network', None):
-            Network = etree.SubElement(tv_node, "Network")
-            Network.text = myShow['network']
+        if getattr(my_show, 'network', None):
+            network = etree.SubElement(tv_node, 'Network')
+            network.text = my_show['network']
 
-        if getattr(myShow, 'airs_time', None):
-            Airs_Time = etree.SubElement(tv_node, "Airs_Time")
-            Airs_Time.text = myShow['airs_time']
+        if getattr(my_show, 'airs_time', None):
+            airs_time = etree.SubElement(tv_node, 'Airs_Time')
+            airs_time.text = my_show['airs_time']
 
-        if getattr(myShow, 'airs_dayofweek', None):
-            Airs_DayOfWeek = etree.SubElement(tv_node, "Airs_DayOfWeek")
-            Airs_DayOfWeek.text = myShow['airs_dayofweek']
+        if getattr(my_show, 'airs_dayofweek', None):
+            airs_day_of_week = etree.SubElement(tv_node, 'Airs_DayOfWeek')
+            airs_day_of_week.text = my_show['airs_dayofweek']
 
-        FirstAired = etree.SubElement(tv_node, "FirstAired")
-        if getattr(myShow, 'firstaired', None):
-            FirstAired.text = myShow['firstaired']
+        first_aired = etree.SubElement(tv_node, 'FirstAired')
+        if getattr(my_show, 'firstaired', None):
+            first_aired.text = my_show['firstaired']
 
-        if getattr(myShow, 'contentrating', None):
-            ContentRating = etree.SubElement(tv_node, "ContentRating")
-            ContentRating.text = myShow['contentrating']
+        if getattr(my_show, 'contentrating', None):
+            content_rating = etree.SubElement(tv_node, 'ContentRating')
+            content_rating.text = my_show['contentrating']
 
-            MPAARating = etree.SubElement(tv_node, "MPAARating")
-            MPAARating.text = myShow['contentrating']
+            mpaa = etree.SubElement(tv_node, 'MPAARating')
+            mpaa.text = my_show['contentrating']
 
-            certification = etree.SubElement(tv_node, "certification")
-            certification.text = myShow['contentrating']
+            certification = etree.SubElement(tv_node, 'certification')
+            certification.text = my_show['contentrating']
 
-        MetadataType = etree.SubElement(tv_node, "Type")
-        MetadataType.text = "Series"
+        metadata_type = etree.SubElement(tv_node, 'Type')
+        metadata_type.text = 'Series'
 
-        if getattr(myShow, 'overview', None):
-            Overview = etree.SubElement(tv_node, "Overview")
-            Overview.text = myShow['overview']
+        if getattr(my_show, 'overview', None):
+            overview = etree.SubElement(tv_node, 'Overview')
+            overview.text = my_show['overview']
 
-        if getattr(myShow, 'firstaired', None):
-            PremiereDate = etree.SubElement(tv_node, "PremiereDate")
-            PremiereDate.text = myShow['firstaired']
+        if getattr(my_show, 'firstaired', None):
+            premiere_date = etree.SubElement(tv_node, 'PremiereDate')
+            premiere_date.text = my_show['firstaired']
 
-        if getattr(myShow, 'rating', None):
-            Rating = etree.SubElement(tv_node, "Rating")
-            Rating.text = myShow['rating']
+        if getattr(my_show, 'rating', None):
+            rating = etree.SubElement(tv_node, 'Rating')
+            rating.text = my_show['rating']
 
-        if getattr(myShow, 'firstaired', None):
+        if getattr(my_show, 'firstaired', None):
             try:
-                year_text = str(datetime.datetime.strptime(myShow['firstaired'], dateFormat).year)
+                year_text = str(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
                 if year_text:
-                    ProductionYear = etree.SubElement(tv_node, "ProductionYear")
-                    ProductionYear.text = year_text
+                    production_year = etree.SubElement(tv_node, 'ProductionYear')
+                    production_year.text = year_text
             except Exception:
                 pass
 
-        if getattr(myShow, 'runtime', None):
-            RunningTime = etree.SubElement(tv_node, "RunningTime")
-            RunningTime.text = myShow['runtime']
+        if getattr(my_show, 'runtime', None):
+            running_time = etree.SubElement(tv_node, 'RunningTime')
+            running_time.text = my_show['runtime']
 
-            Runtime = etree.SubElement(tv_node, "Runtime")
-            Runtime.text = myShow['runtime']
+            runtime = etree.SubElement(tv_node, 'Runtime')
+            runtime.text = my_show['runtime']
 
-        if getattr(myShow, 'imdb_id', None):
-            imdb_id = etree.SubElement(tv_node, "IMDB_ID")
-            imdb_id.text = myShow['imdb_id']
+        if getattr(my_show, 'imdb_id', None):
+            imdb_id = etree.SubElement(tv_node, 'IMDB_ID')
+            imdb_id.text = my_show['imdb_id']
 
-            imdb_id = etree.SubElement(tv_node, "IMDB")
-            imdb_id.text = myShow['imdb_id']
+            imdb_id = etree.SubElement(tv_node, 'IMDB')
+            imdb_id.text = my_show['imdb_id']
 
-            imdb_id = etree.SubElement(tv_node, "IMDbId")
-            imdb_id.text = myShow['imdb_id']
+            imdb_id = etree.SubElement(tv_node, 'IMDbId')
+            imdb_id.text = my_show['imdb_id']
 
-        if getattr(myShow, 'zap2it_id', None):
-            Zap2ItId = etree.SubElement(tv_node, "Zap2ItId")
-            Zap2ItId.text = myShow['zap2it_id']
+        if getattr(my_show, 'zap2it_id', None):
+            zap2it_id = etree.SubElement(tv_node, 'Zap2ItId')
+            zap2it_id.text = my_show['zap2it_id']
 
-        if getattr(myShow, 'genre', None) and isinstance(myShow["genre"], basestring):
-            Genres = etree.SubElement(tv_node, "Genres")
-            for genre in myShow['genre'].split('|'):
+        if getattr(my_show, 'genre', None) and isinstance(my_show['genre'], basestring):
+            genres = etree.SubElement(tv_node, 'Genres')
+            for genre in my_show['genre'].split('|'):
                 if genre.strip():
-                    cur_genre = etree.SubElement(Genres, "Genre")
+                    cur_genre = etree.SubElement(genres, 'Genre')
                     cur_genre.text = genre.strip()
 
-            Genre = etree.SubElement(tv_node, "Genre")
-            Genre.text = "|".join([x.strip() for x in myShow["genre"].split('|') if x.strip()])
+            genre = etree.SubElement(tv_node, 'Genre')
+            genre.text = '|'.join([x.strip() for x in my_show['genre'].split('|') if x.strip()])
 
-        if getattr(myShow, 'network', None):
-            Studios = etree.SubElement(tv_node, "Studios")
-            Studio = etree.SubElement(Studios, "Studio")
-            Studio.text = myShow['network']
+        if getattr(my_show, 'network', None):
+            studios = etree.SubElement(tv_node, 'Studios')
+            studio = etree.SubElement(studios, 'Studio')
+            studio.text = my_show['network']
 
-        if getattr(myShow, '_actors', None):
-            Persons = etree.SubElement(tv_node, "Persons")
-            for actor in myShow['_actors']:
+        if getattr(my_show, '_actors', None):
+            persons = etree.SubElement(tv_node, 'Persons')
+            for actor in my_show['_actors']:
                 if not ('name' in actor and actor['name'].strip()):
                     continue
 
-                cur_actor = etree.SubElement(Persons, "Person")
+                cur_actor = etree.SubElement(persons, 'Person')
 
-                cur_actor_name = etree.SubElement(cur_actor, "Name")
+                cur_actor_name = etree.SubElement(cur_actor, 'Name')
                 cur_actor_name.text = actor['name'].strip()
 
-                cur_actor_type = etree.SubElement(cur_actor, "Type")
-                cur_actor_type.text = "Actor"
+                cur_actor_type = etree.SubElement(cur_actor, 'Type')
+                cur_actor_type.text = 'Actor'
 
                 if 'role' in actor and actor['role'].strip():
-                    cur_actor_role = etree.SubElement(cur_actor, "Role")
+                    cur_actor_role = etree.SubElement(cur_actor, 'Role')
                     cur_actor_role.text = actor['role'].strip()
 
         helpers.indentXML(tv_node)
@@ -409,123 +417,125 @@ class MediaBrowserMetadata(generic.GenericMetadata):
 
         indexer_lang = ep_obj.show.lang
 
+        l_indexer_api_params = sickbeard.indexerApi(ep_obj.show.indexer).api_params.copy()
+
+        l_indexer_api_params[b'actors'] = True
+
+        if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
+            l_indexer_api_params[b'language'] = indexer_lang
+
+        if ep_obj.show.dvdorder != 0:
+            l_indexer_api_params[b'dvdorder'] = True
+
         try:
-            lINDEXER_API_PARMS = sickbeard.indexerApi(ep_obj.show.indexer).api_params.copy()
-
-            lINDEXER_API_PARMS['actors'] = True
-
-            if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
-                lINDEXER_API_PARMS['language'] = indexer_lang
-
-            if ep_obj.show.dvdorder != 0:
-                lINDEXER_API_PARMS['dvdorder'] = True
-
-            t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**lINDEXER_API_PARMS)
-            myShow = t[ep_obj.show.indexerid]
+            t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**l_indexer_api_params)
+            my_show = t[ep_obj.show.indexerid]
         except sickbeard.indexer_shownotfound as e:
             raise ShowNotFoundException(e.message)
         except sickbeard.indexer_error:
-            logger.log(u"Unable to connect to " + sickbeard.indexerApi(
-                ep_obj.show.indexer).name + " while creating meta files - skipping it.", logger.WARNING)
-            return False
+            logger.log(u'Unable to connect to {indexer} while creating meta files - skipping it.'.format
+                       (indexer=sickbeard.indexerApi(ep_obj.show.indexer).name), logger.WARNING)
+            return
 
-        rootNode = etree.Element("Item")
+        root_node = etree.Element('Item')
 
         # write an MediaBrowser XML containing info for all matching episodes
-        for curEpToWrite in eps_to_write:
+        for ep_to_write in eps_to_write:
 
             try:
-                myEp = myShow[curEpToWrite.season][curEpToWrite.episode]
+                my_ep = my_show[ep_to_write.season][ep_to_write.episode]
             except (sickbeard.indexer_episodenotfound, sickbeard.indexer_seasonnotfound):
-                logger.log(u"Unable to find episode %dx%d on %s... has it been removed? Should I delete from db?" %
-                           (curEpToWrite.season, curEpToWrite.episode, sickbeard.indexerApi(ep_obj.show.indexer).name))
+                logger.log(u'Unable to find episode {ep_num} on {indexer}... '
+                           u'has it been removed? Should I delete from db?'.format
+                           (ep_num=episode_num(ep_to_write.season, ep_to_write.episode),
+                            indexer=sickbeard.indexerApi(ep_obj.show.indexer).name))
                 return None
 
-            if curEpToWrite == ep_obj:
+            if ep_to_write == ep_obj:
                 # root (or single) episode
 
                 # default to today's date for specials if firstaired is not set
-                if ep_obj.season == 0 and not getattr(myEp, 'firstaired', None):
-                    myEp['firstaired'] = str(datetime.date.fromordinal(1))
+                if ep_to_write.season == 0 and not getattr(my_ep, 'firstaired', None):
+                    my_ep['firstaired'] = str(datetime.date.fromordinal(1))
 
-                if not (getattr(myEp, 'episodename', None) and getattr(myEp, 'firstaired', None)):
+                if not (getattr(my_ep, 'episodename', None) and getattr(my_ep, 'firstaired', None)):
                     return None
 
-                episode = rootNode
+                episode = root_node
 
-                if curEpToWrite.name:
-                    EpisodeName = etree.SubElement(episode, "EpisodeName")
-                    EpisodeName.text = curEpToWrite.name
+                if ep_to_write.name:
+                    episode_name = etree.SubElement(episode, 'EpisodeName')
+                    episode_name.text = ep_to_write.name
 
-                EpisodeNumber = etree.SubElement(episode, "EpisodeNumber")
-                EpisodeNumber.text = str(ep_obj.episode)
+                episode_number = etree.SubElement(episode, 'EpisodeNumber')
+                episode_number.text = str(ep_obj.episode)
 
                 if ep_obj.relatedEps:
-                    EpisodeNumberEnd = etree.SubElement(episode, "EpisodeNumberEnd")
-                    EpisodeNumberEnd.text = str(curEpToWrite.episode)
+                    episode_number_end = etree.SubElement(episode, 'EpisodeNumberEnd')
+                    episode_number_end.text = str(ep_to_write.episode)
 
-                SeasonNumber = etree.SubElement(episode, "SeasonNumber")
-                SeasonNumber.text = str(curEpToWrite.season)
+                season_number = etree.SubElement(episode, 'SeasonNumber')
+                season_number.text = str(ep_to_write.season)
 
-                if not ep_obj.relatedEps and getattr(myEp, 'absolute_number', None):
-                    absolute_number = etree.SubElement(episode, "absolute_number")
-                    absolute_number.text = str(myEp['absolute_number'])
+                if not ep_obj.relatedEps and getattr(my_ep, 'absolute_number', None):
+                    absolute_number = etree.SubElement(episode, 'absolute_number')
+                    absolute_number.text = str(my_ep['absolute_number'])
 
-                if curEpToWrite.airdate != datetime.date.fromordinal(1):
-                    FirstAired = etree.SubElement(episode, "FirstAired")
-                    FirstAired.text = str(curEpToWrite.airdate)
+                if ep_to_write.airdate != datetime.date.fromordinal(1):
+                    first_aired = etree.SubElement(episode, 'FirstAired')
+                    first_aired.text = str(ep_to_write.airdate)
 
-                MetadataType = etree.SubElement(episode, "Type")
-                MetadataType.text = "Episode"
+                metadata_type = etree.SubElement(episode, 'Type')
+                metadata_type.text = 'Episode'
 
-                if curEpToWrite.description:
-                    Overview = etree.SubElement(episode, "Overview")
-                    Overview.text = curEpToWrite.description
+                if ep_to_write.description:
+                    overview = etree.SubElement(episode, 'Overview')
+                    overview.text = ep_to_write.description
 
                 if not ep_obj.relatedEps:
-                    if getattr(myEp, 'rating', None):
-                        Rating = etree.SubElement(episode, "Rating")
-                        Rating.text = myEp['rating']
+                    if getattr(my_ep, 'rating', None):
+                        rating = etree.SubElement(episode, 'Rating')
+                        rating.text = my_ep['rating']
 
-                    if getattr(myShow, 'imdb_id', None):
-                        IMDB_ID = etree.SubElement(episode, "IMDB_ID")
-                        IMDB_ID.text = myShow['imdb_id']
+                    if getattr(my_show, 'imdb_id', None):
+                        IMDB_ID = etree.SubElement(episode, 'IMDB_ID')
+                        IMDB_ID.text = my_show['imdb_id']
 
-                        IMDB = etree.SubElement(episode, "IMDB")
-                        IMDB.text = myShow['imdb_id']
+                        IMDB = etree.SubElement(episode, 'IMDB')
+                        IMDB.text = my_show['imdb_id']
 
-                        IMDbId = etree.SubElement(episode, "IMDbId")
-                        IMDbId.text = myShow['imdb_id']
+                        IMDbId = etree.SubElement(episode, 'IMDbId')
+                        IMDbId.text = my_show['imdb_id']
 
-                indexerid = etree.SubElement(episode, "id")
-                indexerid.text = str(curEpToWrite.indexerid)
+                indexer_id = etree.SubElement(episode, 'id')
+                indexer_id.text = str(ep_to_write.indexerid)
 
-                Persons = etree.SubElement(episode, "Persons")
+                persons = etree.SubElement(episode, 'Persons')
 
-                if getattr(myShow, '_actors', None):
-                    for actor in myShow['_actors']:
+                if getattr(my_show, '_actors', None):
+                    for actor in my_show['_actors']:
                         if not ('name' in actor and actor['name'].strip()):
                             continue
 
-                        cur_actor = etree.SubElement(Persons, "Person")
+                        cur_actor = etree.SubElement(persons, 'Person')
 
-                        cur_actor_name = etree.SubElement(cur_actor, "Name")
+                        cur_actor_name = etree.SubElement(cur_actor, 'Name')
                         cur_actor_name.text = actor['name'].strip()
 
-                        cur_actor_type = etree.SubElement(cur_actor, "Type")
-                        cur_actor_type.text = "Actor"
+                        cur_actor_type = etree.SubElement(cur_actor, 'Type')
+                        cur_actor_type.text = 'Actor'
 
                         if 'role' in actor and actor['role'].strip():
-                            cur_actor_role = etree.SubElement(cur_actor, "Role")
+                            cur_actor_role = etree.SubElement(cur_actor, 'Role')
                             cur_actor_role.text = actor['role'].strip()
 
-                Language = etree.SubElement(episode, "Language")
+                language = etree.SubElement(episode, 'Language')
                 try:
-                    Language.text = myEp['language']
+                    language.text = my_ep['language']
                 except Exception:
-                    Language.text = sickbeard.INDEXER_DEFAULT_LANGUAGE  # tvrage api doesn't provide language so we must assume a value here
+                    language.text = sickbeard.INDEXER_DEFAULT_LANGUAGE  # tvrage api doesn't provide language so we must assume a value here
 
-                thumb = etree.SubElement(episode, "filename")
+                thumb = etree.SubElement(episode, 'filename')
                 # TODO: See what this is needed for.. if its still needed
                 # just write this to the NFO regardless of whether it actually exists or not
                 # note: renaming files after nfo generation will break this, tough luck
@@ -535,44 +545,45 @@ class MediaBrowserMetadata(generic.GenericMetadata):
 
             else:
                 # append data from (if any) related episodes
-                EpisodeNumberEnd.text = str(curEpToWrite.episode)
+                episode_number_end.text = str(ep_to_write.episode)
 
-                if curEpToWrite.name:
-                    if not EpisodeName.text:
-                        EpisodeName.text = curEpToWrite.name
+                if ep_to_write.name:
+                    if not episode_name.text:
+                        episode_name.text = ep_to_write.name
                     else:
-                        EpisodeName.text = EpisodeName.text + ", " + curEpToWrite.name
+                        episode_name.text = u', '.join([episode_name.text, ep_to_write.name])
 
-                if curEpToWrite.description:
-                    if not Overview.text:
-                        Overview.text = curEpToWrite.description
+                if ep_to_write.description:
+                    if not overview.text:
+                        overview.text = ep_to_write.description
                     else:
-                        Overview.text = Overview.text + "\r" + curEpToWrite.description
+                        overview.text = u'\r'.join([overview.text, ep_to_write.description])
 
             # collect all directors, guest stars and writers
-            if getattr(myEp, 'director', None):
-                persons_dict['Director'] += [x.strip() for x in myEp['director'].split('|') if x.strip()]
-            if getattr(myEp, 'gueststars', None):
-                persons_dict['GuestStar'] += [x.strip() for x in myEp['gueststars'].split('|') if x.strip()]
-            if getattr(myEp, 'writer', None):
-                persons_dict['Writer'] += [x.strip() for x in myEp['writer'].split('|') if x.strip()]
+            if getattr(my_ep, 'director', None):
+                persons_dict['Director'] += [x.strip() for x in my_ep['director'].split('|') if x.strip()]
+            if getattr(my_ep, 'gueststars', None):
+                persons_dict['GuestStar'] += [x.strip() for x in my_ep['gueststars'].split('|') if x.strip()]
+            if getattr(my_ep, 'writer', None):
+                persons_dict['Writer'] += [x.strip() for x in my_ep['writer'].split('|') if x.strip()]
 
         # fill in Persons section with collected directors, guest starts and writers
         for person_type, names in persons_dict.iteritems():
             # remove doubles
             names = list(set(names))
             for cur_name in names:
-                Person = etree.SubElement(Persons, "Person")
-                cur_person_name = etree.SubElement(Person, "Name")
+                person = etree.SubElement(persons, 'Person')
+                cur_person_name = etree.SubElement(person, 'Name')
                 cur_person_name.text = cur_name
-                cur_person_type = etree.SubElement(Person, "Type")
+                cur_person_type = etree.SubElement(person, 'Type')
                 cur_person_type.text = person_type
 
-        helpers.indentXML(rootNode)
-        data = etree.ElementTree(rootNode)
+        # Make it purdy
+        helpers.indentXML(root_node)
+        data = etree.ElementTree(root_node)
 
         return data
 
 
-# present a standard "interface" from the module
+# present a standard 'interface' from the module
 metadata_class = MediaBrowserMetadata

--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -26,6 +26,7 @@ import datetime
 import sickbeard
 from sickbeard import logger, helpers
 from sickbeard.metadata import generic
+from sickrage.helper.common import episode_num
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex, ShowNotFoundException
 
@@ -68,19 +69,19 @@ class TIVOMetadata(generic.GenericMetadata):
 
         self.name = 'TIVO'
 
-        self._ep_nfo_extension = "txt"
+        self._ep_nfo_extension = 'txt'
 
         # web-ui metadata template
-        self.eg_show_metadata = "<i>not supported</i>"
-        self.eg_episode_metadata = "Season##\\.meta\\<i>filename</i>.ext.txt"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "<i>not supported</i>"
-        self.eg_banner = "<i>not supported</i>"
-        self.eg_episode_thumbnails = "<i>not supported</i>"
-        self.eg_season_posters = "<i>not supported</i>"
-        self.eg_season_banners = "<i>not supported</i>"
-        self.eg_season_all_poster = "<i>not supported</i>"
-        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_show_metadata = '<i>not supported</i>'
+        self.eg_episode_metadata = 'Season##\\.meta\\<i>filename</i>.ext.txt'
+        self.eg_fanart = '<i>not supported</i>'
+        self.eg_poster = '<i>not supported</i>'
+        self.eg_banner = '<i>not supported</i>'
+        self.eg_episode_thumbnails = '<i>not supported</i>'
+        self.eg_season_posters = '<i>not supported</i>'
+        self.eg_season_banners = '<i>not supported</i>'
+        self.eg_season_all_poster = '<i>not supported</i>'
+        self.eg_season_all_banner = '<i>not supported</i>'
 
     # Override with empty methods for unsupported features
     def retrieveShowMetadata(self, folder):
@@ -137,12 +138,16 @@ class TIVOMetadata(generic.GenericMetadata):
         ep_obj: a TVEpisode object to get the path for
         """
         if ek(os.path.isfile, ep_obj.location):
-            metadata_file_name = ek(os.path.basename, ep_obj.location) + "." + self._ep_nfo_extension
+            metadata_file_name = '{file}.{extension}'.format(
+                file=ek(os.path.basename, ep_obj.location),
+                extension=self._ep_nfo_extension
+            )
             metadata_dir_name = ek(os.path.join, ek(os.path.dirname, ep_obj.location), '.meta')
             metadata_file_path = ek(os.path.join, metadata_dir_name, metadata_file_name)
         else:
-            logger.log(u"Episode location doesn't exist: " + str(ep_obj.location), logger.DEBUG)
-            return ''
+            logger.log(u'Episode location does not exist: {path}'.format
+                       (path=ep_obj.location), logger.DEBUG)
+            return u''
         return metadata_file_path
 
     def _ep_data(self, ep_obj):
@@ -163,52 +168,54 @@ class TIVOMetadata(generic.GenericMetadata):
         http://pytivo.sourceforge.net/wiki/index.php/Metadata
         """
 
-        data = ""
+        data = ''
 
         eps_to_write = [ep_obj] + ep_obj.relatedEps
 
         indexer_lang = ep_obj.show.lang
 
         try:
-            lINDEXER_API_PARMS = sickbeard.indexerApi(ep_obj.show.indexer).api_params.copy()
+            l_indexer_api_params = sickbeard.indexerApi(ep_obj.show.indexer).api_params.copy()
 
-            lINDEXER_API_PARMS['actors'] = True
+            l_indexer_api_params['actors'] = True
 
             if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
-                lINDEXER_API_PARMS['language'] = indexer_lang
+                l_indexer_api_params['language'] = indexer_lang
 
             if ep_obj.show.dvdorder != 0:
-                lINDEXER_API_PARMS['dvdorder'] = True
+                l_indexer_api_params['dvdorder'] = True
 
-            t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**lINDEXER_API_PARMS)
-            myShow = t[ep_obj.show.indexerid]
+            t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**l_indexer_api_params)
+            my_show = t[ep_obj.show.indexerid]
         except sickbeard.indexer_shownotfound as e:
             raise ShowNotFoundException(e.message)
         except sickbeard.indexer_error:
-            logger.log(u"Unable to connect to " + sickbeard.indexerApi(
-                ep_obj.show.indexer).name + " while creating meta files - skipping it.", logger.WARNING)
+            logger.log(u'Unable to connect to {indexer} while creating meta files - skipping it.'.format
+                       (indexer=sickbeard.indexerApi(ep_obj.show.indexer).name), logger.WARNING)
             return False
 
-        for curEpToWrite in eps_to_write:
+        for ep_to_write in eps_to_write:
 
             try:
-                myEp = myShow[curEpToWrite.season][curEpToWrite.episode]
+                my_ep = my_show[ep_to_write.season][ep_to_write.episode]
             except (sickbeard.indexer_episodenotfound, sickbeard.indexer_seasonnotfound):
-                logger.log(u"Unable to find episode %dx%d on %s... has it been removed? Should I delete from db?" %
-                           (curEpToWrite.season, curEpToWrite.episode, sickbeard.indexerApi(ep_obj.show.indexer).name))
+                logger.log(u'Unable to find episode {ep_num} on {indexer}... '
+                           u'has it been removed? Should I delete from db?'.format
+                           (ep_num=episode_num(ep_to_write.season, ep_to_write.episode),
+                            indexer=sickbeard.indexerApi(ep_obj.show.indexer).name))
                 return None
 
-            if ep_obj.season == 0 and not getattr(myEp, 'firstaired', None):
-                myEp["firstaired"] = str(datetime.date.fromordinal(1))
+            if ep_obj.season == 0 and not getattr(my_ep, 'firstaired', None):
+                my_ep['firstaired'] = str(datetime.date.fromordinal(1))
 
-            if not (getattr(myEp, 'episodename', None) and getattr(myEp, 'firstaired', None)):
+            if not (getattr(my_ep, 'episodename', None) and getattr(my_ep, 'firstaired', None)):
                 return None
 
-            if getattr(myShow, 'seriesname', None):
-                data += ("title : " + myShow["seriesname"] + "\n")
-                data += ("seriesTitle : " + myShow["seriesname"] + "\n")
+            if getattr(my_show, 'seriesname', None):
+                data += ('title : {title}\n'.format(title=my_show['seriesname']))
+                data += ('seriesTitle : {title}\n'.format(title=my_show['seriesname']))
 
-            data += ("episodeTitle : " + curEpToWrite._format_pattern('%Sx%0E %EN') + "\n")
+            data += ('episodeTitle : {title}\n'.format(title=ep_to_write._format_pattern('%Sx%0E %EN')))
 
             # This should be entered for episodic shows and omitted for movies. The standard tivo format is to enter
             # the season number followed by the episode number for that season. For example, enter 201 for season 2
@@ -219,66 +226,66 @@ class TIVOMetadata(generic.GenericMetadata):
             # This seems to disappear once the video is transferred to TiVo.
 
             # NOTE: May not be correct format, missing season, but based on description from wiki leaving as is.
-            data += ("episodeNumber : " + str(curEpToWrite.episode) + "\n")
+            data += ('episodeNumber : {ep_num}\n'.format(ep_to_write.episode))
 
             # Must be entered as true or false. If true, the year from originalAirDate will be shown in parentheses
             # after the episode's title and before the description on the Program screen.
 
             # FIXME: Hardcode isEpisode to true for now, not sure how to handle movies
-            data += "isEpisode : true\n"
+            data += 'isEpisode : true\n'
 
             # Write the synopsis of the video here
             # Micrsoft Word's smartquotes can die in a fire.
-            sanitizedDescription = curEpToWrite.description
+            sanitized_description = ep_to_write.description
             # Replace double curly quotes
-            sanitizedDescription = sanitizedDescription.replace(u"\u201c", "\"").replace(u"\u201d", "\"")
+            sanitized_description = sanitized_description.replace(u'\u201c', '\'').replace(u'\u201d', '\'')
             # Replace single curly quotes
-            sanitizedDescription = sanitizedDescription.replace(u"\u2018", "'").replace(u"\u2019", "'").replace(u"\u02BC", "'")
+            sanitized_description = sanitized_description.replace(u'\u2018', '\'').replace(u'\u2019', '\'').replace(u'\u02BC', '\'')
 
-            data += ("description : " + sanitizedDescription + "\n")
+            data += ('description : {desc}\n'.format(desc=sanitized_description))
 
-            # Usually starts with "SH" and followed by 6-8 digits.
-            # Tivo uses zap2it for thier data, so the series id is the zap2it_id.
-            if getattr(myShow, 'zap2it_id', None):
-                data += ("seriesId : " + myShow["zap2it_id"] + "\n")
+            # Usually starts with 'SH' and followed by 6-8 digits.
+            # TiVo uses zap2it for their data, so the series id is the zap2it_id.
+            if getattr(my_show, 'zap2it_id', None):
+                data += ('seriesId : {zap2it}\n'.format(zap2it=my_show['zap2it_id']))
 
             # This is the call sign of the channel the episode was recorded from.
-            if getattr(myShow, 'network', None):
-                data += ("callsign : " + myShow["network"] + "\n")
+            if getattr(my_show, 'network', None):
+                data += ('callsign : {network}\n'.format(network=my_show['network']))
 
             # This must be entered as yyyy-mm-ddThh:mm:ssZ (the t is capitalized and never changes, the Z is also
             # capitalized and never changes). This is the original air date of the episode.
             # NOTE: Hard coded the time to T00:00:00Z as we really don't know when during the day the first run happened.
-            if curEpToWrite.airdate != datetime.date.fromordinal(1):
-                data += ("originalAirDate : " + str(curEpToWrite.airdate) + "T00:00:00Z\n")
+            if ep_to_write.airdate != datetime.date.fromordinal(1):
+                data += ('originalAirDate : {airdate}T00:00:00Z\n'.format(airdate=ep_to_write.airdate))
 
             # This shows up at the beginning of the description on the Program screen and on the Details screen.
-            if getattr(myShow, '_actors', None):
-                for actor in myShow["_actors"]:
+            if getattr(my_show, '_actors', None):
+                for actor in my_show['_actors']:
                     if 'name' in actor and actor['name'].strip():
-                        data += ("vActor : " + actor['name'].strip() + "\n")
+                        data += ('vActor : {actor}\n'.format(actor=actor['name'].strip()))
 
             # This is shown on both the Program screen and the Details screen.
-            if getattr(myEp, 'rating', None):
+            if getattr(my_ep, 'rating', None):
                 try:
-                    rating = float(myEp['rating'])
+                    rating = float(my_ep['rating'])
                 except ValueError:
                     rating = 0.0
                 # convert 10 to 4 star rating. 4 * rating / 10
                 # only whole numbers or half numbers work. multiply by 2, round, divide by 2.0
                 rating = round(8 * rating / 10) / 2.0
-                data += ("starRating : " + str(rating) + "\n")
+                data += ('starRating : {rating}\n'.format(rating=rating))
 
             # This is shown on both the Program screen and the Details screen.
             # It uses the standard TV rating system of: TV-Y7, TV-Y, TV-G, TV-PG, TV-14, TV-MA and TV-NR.
-            if getattr(myShow, 'contentrating', None):
-                data += ("tvRating : " + str(myShow["contentrating"]) + "\n")
+            if getattr(my_show, 'contentrating', None):
+                data += ('tvRating : {rating}\n'.format(rating=my_show['contentrating']))
 
             # This field can be repeated as many times as necessary or omitted completely.
             if ep_obj.show.genre:
                 for genre in ep_obj.show.genre.split('|'):
                     if genre:
-                        data += ("vProgramGenre : " + str(genre) + "\n")
+                        data += ('vProgramGenre : {genre}\n'.format(genre=genre))
 
                         # NOTE: The following are metadata keywords are not used
                         # displayMajorNumber
@@ -304,6 +311,7 @@ class TIVOMetadata(generic.GenericMetadata):
                 will be automatically added based on _ep_nfo_extension. This should
                 include an absolute path.
         """
+
         data = self._ep_data(ep_obj)
 
         if not data:
@@ -314,25 +322,28 @@ class TIVOMetadata(generic.GenericMetadata):
 
         try:
             if not ek(os.path.isdir, nfo_file_dir):
-                logger.log(u"Metadata dir didn't exist, creating it at " + nfo_file_dir, logger.DEBUG)
+                logger.log(u'Metadata directory did not exist, creating it at {path}'.format
+                           (path=nfo_file_dir), logger.DEBUG)
                 ek(os.makedirs, nfo_file_dir)
                 helpers.chmodAsParent(nfo_file_dir)
 
-            logger.log(u"Writing episode nfo file to " + nfo_file_path, logger.DEBUG)
+            logger.log(u'Writing episode nfo file to {path}'.format
+                       (path=nfo_file_path), logger.DEBUG)
 
             with io.open(nfo_file_path, 'wb') as nfo_file:
                 # Calling encode directly, b/c often descriptions have wonky characters.
-                nfo_file.write(data.encode("utf-8"))
+                nfo_file.write(data.encode('utf-8'))
 
             helpers.chmodAsParent(nfo_file_path)
 
         except EnvironmentError as e:
-            logger.log(u"Unable to write file to " + nfo_file_path + " - are you sure the folder is writable? " + ex(e),
-                       logger.ERROR)
+            logger.log(u'Unable to write file to {path} - '
+                       u'are you sure the folder is writable? {exception}'.format
+                       (path=nfo_file_path, exception=ex(e)), logger.ERROR)
             return False
 
         return True
 
 
-# present a standard "interface" from the module
+# present a standard 'interface' from the module
 metadata_class = TIVOMetadata

--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # Author: Gordon Turner <gordonturner@gordonturner.ca>
 # URL: http://code.google.com/p/sickbeard/
@@ -184,10 +183,10 @@ class TIVOMetadata(generic.GenericMetadata):
             t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**lINDEXER_API_PARMS)
             myShow = t[ep_obj.show.indexerid]
         except sickbeard.indexer_shownotfound as e:
-            raise ShowNotFoundException(str(e))
-        except sickbeard.indexer_error as e:
+            raise ShowNotFoundException(e.message)
+        except sickbeard.indexer_error:
             logger.log(u"Unable to connect to " + sickbeard.indexerApi(
-                ep_obj.show.indexer).name + " while creating meta files - skipping - " + str(e), logger.ERROR)
+                ep_obj.show.indexer).name + " while creating meta files - skipping it.", logger.WARNING)
             return False
 
         for curEpToWrite in eps_to_write:

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # URL: http://code.google.com/p/sickbeard/
 #
@@ -201,9 +200,9 @@ class WDTVMetadata(generic.GenericMetadata):
             myShow = t[ep_obj.show.indexerid]
         except sickbeard.indexer_shownotfound as e:
             raise ShowNotFoundException(e.message)
-        except sickbeard.indexer_error as e:
+        except sickbeard.indexer_error:
             logger.log(u"Unable to connect to " + sickbeard.indexerApi(
-                ep_obj.show.indexer).name + " while creating meta files - skipping - " + ex(e), logger.ERROR)
+                ep_obj.show.indexer).name + " while creating meta files - skipping it.", logger.WARNING)
             return False
 
         rootNode = etree.Element("details")

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -26,7 +26,7 @@ import sickbeard
 from sickbeard.metadata import generic
 
 from sickbeard import logger, helpers
-from sickrage.helper.common import dateFormat, replace_extension
+from sickrage.helper.common import dateFormat, replace_extension, episode_num
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex, ShowNotFoundException
 
@@ -77,19 +77,19 @@ class WDTVMetadata(generic.GenericMetadata):
 
         self._ep_nfo_extension = 'xml'
 
-        self.poster_name = "folder.jpg"
+        self.poster_name = 'folder.jpg'
 
         # web-ui metadata template
-        self.eg_show_metadata = "<i>not supported</i>"
-        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "folder.jpg"
-        self.eg_banner = "<i>not supported</i>"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.metathumb"
-        self.eg_season_posters = "Season##\\folder.jpg"
-        self.eg_season_banners = "<i>not supported</i>"
-        self.eg_season_all_poster = "<i>not supported</i>"
-        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_show_metadata = '<i>not supported</i>'
+        self.eg_episode_metadata = 'Season##\\<i>filename</i>.xml'
+        self.eg_fanart = '<i>not supported</i>'
+        self.eg_poster = 'folder.jpg'
+        self.eg_banner = '<i>not supported</i>'
+        self.eg_episode_thumbnails = 'Season##\\<i>filename</i>.metathumb'
+        self.eg_season_posters = 'Season##\\folder.jpg'
+        self.eg_season_banners = '<i>not supported</i>'
+        self.eg_season_all_poster = '<i>not supported</i>'
+        self.eg_season_all_banner = '<i>not supported</i>'
 
     # Override with empty methods for unsupported features
     def retrieveShowMetadata(self, folder):
@@ -151,7 +151,7 @@ class WDTVMetadata(generic.GenericMetadata):
         season_dir = None
 
         for cur_dir in dir_list:
-            if season == 0 and cur_dir == "Specials":
+            if season == 0 and cur_dir == 'Specials':
                 season_dir = cur_dir
                 break
 
@@ -166,10 +166,12 @@ class WDTVMetadata(generic.GenericMetadata):
                 break
 
         if not season_dir:
-            logger.log(u"Unable to find a season dir for season " + str(season), logger.DEBUG)
+            logger.log(u'Unable to find a season directory for season {season_num}'.format
+                       (season_num=season), logger.DEBUG)
             return None
 
-        logger.log(u"Using " + str(season_dir) + "/folder.jpg as season dir for season " + str(season), logger.DEBUG)
+        logger.log(u'Using {path}/folder.jpg as season dir for season {season_num}'.format
+                   (path=season_dir, season_num=season), logger.DEBUG)
 
         return ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
 
@@ -185,120 +187,122 @@ class WDTVMetadata(generic.GenericMetadata):
 
         indexer_lang = ep_obj.show.lang
 
+        l_indexer_api_params = sickbeard.indexerApi(ep_obj.show.indexer).api_params.copy()
+
+        l_indexer_api_params[b'actors'] = True
+
+        if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
+            l_indexer_api_params[b'language'] = indexer_lang
+
+        if ep_obj.show.dvdorder != 0:
+            l_indexer_api_params[b'dvdorder'] = True
+
         try:
-            lINDEXER_API_PARMS = sickbeard.indexerApi(ep_obj.show.indexer).api_params.copy()
-
-            lINDEXER_API_PARMS['actors'] = True
-
-            if indexer_lang and not indexer_lang == sickbeard.INDEXER_DEFAULT_LANGUAGE:
-                lINDEXER_API_PARMS['language'] = indexer_lang
-
-            if ep_obj.show.dvdorder != 0:
-                lINDEXER_API_PARMS['dvdorder'] = True
-
-            t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**lINDEXER_API_PARMS)
-            myShow = t[ep_obj.show.indexerid]
+            t = sickbeard.indexerApi(ep_obj.show.indexer).indexer(**l_indexer_api_params)
+            my_show = t[ep_obj.show.indexerid]
         except sickbeard.indexer_shownotfound as e:
             raise ShowNotFoundException(e.message)
         except sickbeard.indexer_error:
-            logger.log(u"Unable to connect to " + sickbeard.indexerApi(
-                ep_obj.show.indexer).name + " while creating meta files - skipping it.", logger.WARNING)
+            logger.log(u'Unable to connect to {indexer} while creating meta files - skipping it.'.format
+                       (indexer=sickbeard.indexerApi(ep_obj.show.indexer).name), logger.WARNING)
             return False
 
-        rootNode = etree.Element("details")
+        root_node = etree.Element('details')
 
         # write an WDTV XML containing info for all matching episodes
-        for curEpToWrite in eps_to_write:
+        for ep_to_write in eps_to_write:
 
             try:
-                myEp = myShow[curEpToWrite.season][curEpToWrite.episode]
+                my_ep = my_show[ep_to_write.season][ep_to_write.episode]
             except (sickbeard.indexer_episodenotfound, sickbeard.indexer_seasonnotfound):
-                logger.log(u"Unable to find episode %dx%d on %s... has it been removed? Should I delete from db?" %
-                           (curEpToWrite.season, curEpToWrite.episode, sickbeard.indexerApi(ep_obj.show.indexer).name))
+                logger.log(u'Unable to find episode {ep_num} on {indexer}... '
+                           u'has it been removed? Should I delete from db?'.format
+                           (ep_num=episode_num(ep_to_write.season, ep_to_write.episode),
+                            indexer=sickbeard.indexerApi(ep_obj.show.indexer).name))
                 return None
 
-            if ep_obj.season == 0 and not getattr(myEp, 'firstaired', None):
-                myEp["firstaired"] = str(datetime.date.fromordinal(1))
+            if ep_obj.season == 0 and not getattr(my_ep, 'firstaired', None):
+                my_ep['firstaired'] = str(datetime.date.fromordinal(1))
 
-            if not (getattr(myEp, 'episodename', None) and getattr(myEp, 'firstaired', None)):
+            if not (getattr(my_ep, 'episodename', None) and getattr(my_ep, 'firstaired', None)):
                 return None
 
             if len(eps_to_write) > 1:
-                episode = etree.SubElement(rootNode, "details")
+                episode = etree.SubElement(root_node, 'details')
             else:
-                episode = rootNode
+                episode = root_node
 
             # TODO: get right EpisodeID
-            episodeID = etree.SubElement(episode, "id")
-            episodeID.text = str(curEpToWrite.indexerid)
+            episode_id = etree.SubElement(episode, 'id')
+            episode_id.text = str(ep_to_write.indexerid)
 
-            title = etree.SubElement(episode, "title")
+            title = etree.SubElement(episode, 'title')
             title.text = ep_obj.prettyName()
 
-            if getattr(myShow, 'seriesname', None):
-                seriesName = etree.SubElement(episode, "series_name")
-                seriesName.text = myShow["seriesname"]
+            if getattr(my_show, 'seriesname', None):
+                series_name = etree.SubElement(episode, 'series_name')
+                series_name.text = my_show['seriesname']
 
-            if curEpToWrite.name:
-                episodeName = etree.SubElement(episode, "episode_name")
-                episodeName.text = curEpToWrite.name
+            if ep_to_write.name:
+                episode_name = etree.SubElement(episode, 'episode_name')
+                episode_name.text = ep_to_write.name
 
-            seasonNumber = etree.SubElement(episode, "season_number")
-            seasonNumber.text = str(curEpToWrite.season)
+            season_number = etree.SubElement(episode, 'season_number')
+            season_number.text = str(ep_to_write.season)
 
-            episodeNum = etree.SubElement(episode, "episode_number")
-            episodeNum.text = str(curEpToWrite.episode)
+            episode_num = etree.SubElement(episode, 'episode_number')
+            episode_num.text = str(ep_to_write.episode)
 
-            firstAired = etree.SubElement(episode, "firstaired")
+            first_aired = etree.SubElement(episode, 'firstaired')
 
-            if curEpToWrite.airdate != datetime.date.fromordinal(1):
-                firstAired.text = str(curEpToWrite.airdate)
+            if ep_to_write.airdate != datetime.date.fromordinal(1):
+                first_aired.text = str(ep_to_write.airdate)
 
-            if getattr(myShow, 'firstaired', None):
+            if getattr(my_show, 'firstaired', None):
                 try:
-                    year_text = str(datetime.datetime.strptime(myShow["firstaired"], dateFormat).year)
+                    year_text = str(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
                     if year_text:
-                        year = etree.SubElement(episode, "year")
+                        year = etree.SubElement(episode, 'year')
                         year.text = year_text
                 except Exception:
                     pass
 
-            if curEpToWrite.season != 0 and getattr(myShow, 'runtime', None):
-                runtime = etree.SubElement(episode, "runtime")
-                runtime.text = myShow["runtime"]
+            if ep_to_write.season != 0 and getattr(my_show, 'runtime', None):
+                runtime = etree.SubElement(episode, 'runtime')
+                runtime.text = my_show['runtime']
 
-            if getattr(myShow, 'genre', None):
-                genre = etree.SubElement(episode, "genre")
-                genre.text = " / ".join([x.strip() for x in myShow["genre"].split('|') if x.strip()])
+            if getattr(my_show, 'genre', None):
+                genre = etree.SubElement(episode, 'genre')
+                genre.text = ' / '.join([x.strip() for x in my_show['genre'].split('|') if x.strip()])
 
-            if getattr(myEp, 'director', None):
-                director = etree.SubElement(episode, "director")
-                director.text = myEp['director']
+            if getattr(my_ep, 'director', None):
+                director = etree.SubElement(episode, 'director')
+                director.text = my_ep['director']
 
-            if getattr(myShow, '_actors', None):
-                for actor in myShow['_actors']:
+            if getattr(my_show, '_actors', None):
+                for actor in my_show['_actors']:
                     if not ('name' in actor and actor['name'].strip()):
                         continue
 
-                    cur_actor = etree.SubElement(episode, "actor")
+                    cur_actor = etree.SubElement(episode, 'actor')
 
-                    cur_actor_name = etree.SubElement(cur_actor, "name")
+                    cur_actor_name = etree.SubElement(cur_actor, 'name')
                     cur_actor_name.text = actor['name']
 
                     if 'role' in actor and actor['role'].strip():
-                        cur_actor_role = etree.SubElement(cur_actor, "role")
+                        cur_actor_role = etree.SubElement(cur_actor, 'role')
                         cur_actor_role.text = actor['role'].strip()
 
-            if curEpToWrite.description:
-                overview = etree.SubElement(episode, "overview")
-                overview.text = curEpToWrite.description
+            if ep_to_write.description:
+                overview = etree.SubElement(episode, 'overview')
+                overview.text = ep_to_write.description
 
             # Make it purdy
-            helpers.indentXML(rootNode)
-            data = etree.ElementTree(rootNode)
+            helpers.indentXML(root_node)
+            data = etree.ElementTree(root_node)
 
         return data
 
 
-# present a standard "interface" from the module
+# present a standard 'interface' from the module
 metadata_class = WDTVMetadata


### PR DESCRIPTION
"Fixes" stuff like this showing the full traceback and at the same time making them not submitable but still showing up to the user, as warning
```
2016-05-06 06:10:31 POSTPROCESSER :: [6cb78fe] Unable to connect to theTVDB while creating meta files - skipping - error Connection error HTTPConnectionPool(host='thetvdb.com', port=80): Max retries exceeded with url: /api/F9C450E78D99172E/series/268592/en.xml (Caused by NewConnectionError(': Failed to establish a new connection: [Errno -2] Nome ou servi\xc3\xa7o desconhecido',)) while loading URL http://thetvdb.com/api/F9C450E78D99172E/series/268592/en.xml
Traceback (most recent call last):
  File "/home/home/SickRage/sickbeard/metadata/kodi_12plus.py", line 258, in _ep_data
    myShow = t[ep_obj.show.indexerid]
  File "/home/home/SickRage/lib/tvdb_api/tvdb_api.py", line 953, in __getitem__
    self._getShowData(key, self.config['language'], True)
  File "/home/home/SickRage/lib/tvdb_api/tvdb_api.py", line 848, in _getShowData
    self.config['url_seriesInfo'] % (sid, getShowInLanguage)
  File "/home/home/SickRage/lib/tvdb_api/tvdb_api.py", line 636, in _getetsrc
    raise tvdb_error(e)
tvdb_error: Connection error HTTPConnectionPool(host='thetvdb.com', port=80): Max retries exceeded with url: /api/F9C450E78D99172E/series/268592/en.xml (Caused by NewConnectionError(': Failed to establish a new connection: [Errno -2] Nome ou servi\xc3\xa7o desconhecido',)) while loading URL http://thetvdb.com/api/F9C450E78D99172E/series/268592/en.xml
```