### PR TITLE
Do not log warning when no results exist in RARBG

### DIFF
--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
 #
-
-#
 # This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
@@ -136,7 +134,7 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
                 # Don't log when {"error":"No results found","error_code":20}
                 # List of errors: https://github.com/rarbg/torrentapi/issues/1#issuecomment-114763312
                 if error:
-                    if try_int(error_code) != 20:
+                    if try_int(error_code) != 20 or try_int(error_code) != 14:
                         logger.log(error, logger.WARNING)
                     continue
 

--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -134,7 +134,7 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
                 # Don't log when {"error":"No results found","error_code":20}
                 # List of errors: https://github.com/rarbg/torrentapi/issues/1#issuecomment-114763312
                 if error:
-                    if try_int(error_code) != 20 or try_int(error_code) != 14:
+                    if try_int(error_code) not in (20, 14):
                         logger.log(error, logger.WARNING)
                     continue
 


### PR DESCRIPTION
No need to show warning when show doesnt exist in rarbg , same as done for erro code 20 `No results found` when a show exists in the site already.
error code 14 is preety much the same but its becouse the show isnt even in the site, so no results at all `Cant find thetvdb in database. Are you sure this thetvdb exists? 14 `