### PR TITLE
Fix scene name unicode save error

### DIFF
--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -190,8 +190,8 @@
                 % else:
                     <tr><td class="showLegend"><span style="color: red;">Location: </span></td><td><span style="color: red;">${showLoc[0]}</span> (Missing)</td></tr>
                 % endif
-                % if show.exceptions:
-                    <tr><td class="showLegend" style="vertical-align: top;">Scene Name:</td><td>${(show.name, " | ".join(show.exceptions))[show.exceptions != 0]}</td></tr>
+                % if all_scene_exceptions:
+                    <tr><td class="showLegend" style="vertical-align: top;">Scene Name:</td><td>${all_scene_exceptions}</td></tr>
                 % endif
 
                 % if require_words:

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -69,7 +69,8 @@ if SPOOF_USER_AGENT:
 cpu_presets = {
     'HIGH': 5,
     'NORMAL': 2,
-    'LOW': 1
+    'LOW': 1,
+    'DISABLED': 0
 }
 
 # Other constants

--- a/sickbeard/providers/hounddawgs.py
+++ b/sickbeard/providers/hounddawgs.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 # Author: Idan Gutman
 #
-
-#
 # This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
@@ -153,8 +151,8 @@ class HoundDawgsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                                 torrent_size = result.find("td", class_="nobr").find_next_sibling("td").string
                                 if torrent_size:
                                     size = convert_size(torrent_size) or -1
-                                seeders = try_int((result('td')[6]).text)
-                                leechers = try_int((result('td')[7]).text)
+                                seeders = try_int((result('td')[6]).text.replace(',', ''))
+                                leechers = try_int((result('td')[7]).text.replace(',', ''))
 
                             except (AttributeError, TypeError):
                                 continue

--- a/sickbeard/scene_exceptions.py
+++ b/sickbeard/scene_exceptions.py
@@ -273,9 +273,9 @@ def update_scene_exceptions(indexer_id, scene_exceptions, season=-1):
     # A change has been made to the scene exception list. Let's clear the cache, to make this visible
     if indexer_id in exceptionsCache:
         exceptionsCache[indexer_id] = {}
-        exceptionsCache[indexer_id][season] = scene_exceptions
+        exceptionsCache[indexer_id][season] = [se.decode('utf-8', 'ignore') for se in scene_exceptions]
 
-    for cur_exception in scene_exceptions:
+    for cur_exception in [se.decode('utf-8', 'ignore') for se in scene_exceptions]:
         cache_db_con.action("INSERT INTO scene_exceptions (indexer_id, show_name, season) VALUES (?,?,?)",
                             [indexer_id, cur_exception, season])
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -205,6 +205,10 @@ class PageTemplate(MakoTemplate):
             kwargs['title'] = '500'
             kwargs['header'] = 'Mako Error'
             kwargs['backtrace'] = RichTraceback()
+            for (filename, lineno, function, line) in kwargs['backtrace'].traceback:
+                print("File %s, line %s, in %s" % (filename, lineno, function))
+                print(line, "\n")
+            print("%s: %s" % (str(kwargs['backtrace'].error.__class__.__name__), kwargs['backtrace'].error))
             return get_lookup().get_template('500.mako').render_unicode(*args, **kwargs)
 
 
@@ -1393,7 +1397,7 @@ class Home(WebRoot):
             submenu=submenu, showLoc=showLoc, show_message=show_message,
             show=showObj, sql_results=sql_results, seasonResults=seasonResults,
             sortedShowLists=sortedShowLists, bwl=bwl, epCounts=epCounts,
-            epCats=epCats, all_scene_exceptions=showObj.exceptions,
+            epCats=epCats, all_scene_exceptions=' | '.join(showObj.exceptions),
             scene_numbering=get_scene_numbering_for_show(indexerid, indexer),
             xem_numbering=get_xem_numbering_for_show(indexerid, indexer),
             scene_absolute_numbering=get_scene_absolute_numbering_for_show(indexerid, indexer),


### PR DESCRIPTION
How to reproduce the issue:
1. Run medusa on windows. I've used Windows 7
2. Make sure used locale is x.cp1252
3. Add Naruto Shippuuden
4. Now you can open the show in displayShow and editShow just fine.
5. Go to editShow and save the show, you should be redirected to displayShow
6. You'r getting a mako 500 error page.

![image](https://cloud.githubusercontent.com/assets/1331394/15130263/4ac9ea20-1647-11e6-9aa4-60444ab34637.png)


- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Always make sure the PR has a clear description of why,how, and what your trying to fix. The same goes for improvements or new features. Also if you refering to an issue, make sure a summary is available in the PR.
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)
