### PR TITLE
Fixed updating of snatch/download status for manual searched episodes.

### DIFF
--- a/sickbeard/manual_search.py
+++ b/sickbeard/manual_search.py
@@ -159,19 +159,6 @@ def collectEpisodesFromSearchThread(show):
         if show and not search_thread.show.indexerid == int(show):
             continue
 
-        # Let's get the status from db instead from the recent list of completed downloads. We can still use
-        # the list to know which episode's where looking for
-
-#         for ep_obj in search_thread.segment:
-#             ep_obj.loadFromDB(ep_obj.season, ep_obj.episode)
-#             episodes += [{'show': ep_obj.show.indexerid,
-#                           'episode': ep_obj.episode,
-#                           'episodeindexid': ep_obj.indexerid,
-#                           'season': ep_obj.season,
-#                           'searchstatus': searchstatus,
-#                           'status': statusStrings[ep_obj.status],
-#                           'quality': getQualityClass(ep_obj),
-#                           'overview': Overview.overviewStrings[ep_obj.show.getOverview(ep_obj.status)]}]
         if isinstance(search_thread, sickbeard.search_queue.ForcedSearchQueueItem):
             if not [x for x in episodes if x['episodeindexid'] in [search.indexerid for search in search_thread.segment]]:
                 episodes += getEpisodes(search_thread, searchstatus)

--- a/sickbeard/manual_search.py
+++ b/sickbeard/manual_search.py
@@ -93,14 +93,16 @@ def getEpisodes(search_thread, searchstatus):
 
     for ep_obj in search_thread.segment:
         ep = show_obj.getEpisode(ep_obj.season, ep_obj.episode)
-        results.append({'show': show_obj.indexerid,
-                        'episode': ep.episode,
-                        'episodeindexid': ep.indexerid,
-                        'season': ep.season,
-                        'searchstatus': searchstatus,
-                        'status': statusStrings[ep.status],
-                        'quality': getQualityClass(ep),
-                        'overview': Overview.overviewStrings[show_obj.getOverview(ep.status)]})
+        results.append({
+            'show': show_obj.indexerid,
+            'episode': ep.episode,
+            'episodeindexid': ep.indexerid,
+            'season': ep.season,
+            'searchstatus': searchstatus,
+            'status': statusStrings[ep.status],
+            'quality': getQualityClass(ep),
+            'overview': Overview.overviewStrings[show_obj.getOverview(ep.status)],
+        })
 
     return results
 

--- a/sickbeard/manual_search.py
+++ b/sickbeard/manual_search.py
@@ -92,14 +92,15 @@ def getEpisodes(search_thread, searchstatus):
             search_thread.segment = [search_thread.segment]
 
     for ep_obj in search_thread.segment:
-        results.append({'show': ep_obj.show.indexerid,
-                        'episode': ep_obj.episode,
-                        'episodeindexid': ep_obj.indexerid,
-                        'season': ep_obj.season,
+        ep = show_obj.getEpisode(ep_obj.season, ep_obj.episode)
+        results.append({'show': show_obj.indexerid,
+                        'episode': ep.episode,
+                        'episodeindexid': ep.indexerid,
+                        'season': ep.season,
                         'searchstatus': searchstatus,
-                        'status': statusStrings[ep_obj.status],
-                        'quality': getQualityClass(ep_obj),
-                        'overview': Overview.overviewStrings[show_obj.getOverview(ep_obj.status)]})
+                        'status': statusStrings[ep.status],
+                        'quality': getQualityClass(ep),
+                        'overview': Overview.overviewStrings[show_obj.getOverview(ep.status)]})
 
     return results
 
@@ -111,6 +112,7 @@ def update_finished_search_queue_item(snatch_queue_item):
     @return: True if status update was successful, False if not.
     """
     # Finished Searches
+
     for search_thread in sickbeard.search_queue.FORCED_SEARCH_HISTORY:
         if snatch_queue_item.show and not search_thread.show.indexerid == snatch_queue_item.show.indexerid:
             continue
@@ -119,10 +121,10 @@ def update_finished_search_queue_item(snatch_queue_item):
             if not isinstance(search_thread.segment, list):
                 search_thread.segment = [search_thread.segment]
 
-            for segment in snatch_queue_item.segment:
-                if all([[search for search in search_thread.segment if search.indexerid == segment.indexerid],
-                        [search for search in search_thread.segment if search.season == segment.season],
-                        [search for search in search_thread.segment if search.episode == segment.episode]]):
+            for ep_obj in snatch_queue_item.segment:
+                if all([[search for search in search_thread.segment if search.indexerid == ep_obj.indexerid],
+                        [search for search in search_thread.segment if search.season == ep_obj.season],
+                        [search for search in search_thread.segment if search.episode == ep_obj.episode]]):
                     search_thread.segment = snatch_queue_item.segment
                     return True
     return False
@@ -154,9 +156,22 @@ def collectEpisodesFromSearchThread(show):
     # Finished Searches
     searchstatus = SEARCH_STATUS_FINISHED
     for search_thread in sickbeard.search_queue.FORCED_SEARCH_HISTORY:
-        if show and not str(search_thread.show.indexerid) == show:
+        if show and not search_thread.show.indexerid == int(show):
             continue
 
+        # Let's get the status from db instead from the recent list of completed downloads. We can still use
+        # the list to know which episode's where looking for
+
+#         for ep_obj in search_thread.segment:
+#             ep_obj.loadFromDB(ep_obj.season, ep_obj.episode)
+#             episodes += [{'show': ep_obj.show.indexerid,
+#                           'episode': ep_obj.episode,
+#                           'episodeindexid': ep_obj.indexerid,
+#                           'season': ep_obj.season,
+#                           'searchstatus': searchstatus,
+#                           'status': statusStrings[ep_obj.status],
+#                           'quality': getQualityClass(ep_obj),
+#                           'overview': Overview.overviewStrings[ep_obj.show.getOverview(ep_obj.status)]}]
         if isinstance(search_thread, sickbeard.search_queue.ForcedSearchQueueItem):
             if not [x for x in episodes if x['episodeindexid'] in [search.indexerid for search in search_thread.segment]]:
                 episodes += getEpisodes(search_thread, searchstatus)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1466,7 +1466,7 @@ class Home(WebRoot):
         ep_objs = []
         for episode in episodes:
             if episode:
-                ep_objs.append(TVEpisode(show_obj, int(cached_result['season']), int(episode)))
+                ep_objs.append(show_obj.getEpisode(int(cached_result['season']), int(episode)))
 
         # Create the queue item
         snatch_queue_item = search_queue.ManualSnatchQueueItem(show_obj, ep_objs, provider, cached_result)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Always make sure the PR has a clear description of why,how, and what your trying to fix. The same goes for improvements or new features. Also if you refering to an issue, make sure a summary is available in the PR.
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

The manual snatched episode is now retrieved from the showsList, instead of being build from the class. Because it was newly initiated, there was no reference to the show in memory. Now there is.