### PR TITLE
Spring cleaning

### DIFF
--- a/sickbeard/clients/__init__.py
+++ b/sickbeard/clients/__init__.py
@@ -42,7 +42,7 @@ default_host = {
 }
 
 
-def getClientModule(name):
+def get_client_module(name):
     name = name.lower()
     prefix = "sickbeard.clients."
 
@@ -50,8 +50,8 @@ def getClientModule(name):
                       (prefix=prefix, name=name), fromlist=_clients)
 
 
-def getClientIstance(name):
-    module = getClientModule(name)
+def get_client_instance(name):
+    module = get_client_module(name)
     class_name = module.api.__class__.__name__
 
     return getattr(module, class_name)

--- a/sickbeard/clients/__init__.py
+++ b/sickbeard/clients/__init__.py
@@ -44,7 +44,7 @@ default_host = {
 
 def get_client_module(name):
     name = name.lower()
-    prefix = "sickbeard.clients."
+    prefix = 'sickbeard.clients.'
 
     return __import__('{prefix}{name}_client'.format
                       (prefix=prefix, name=name), fromlist=_clients)

--- a/sickbeard/clients/deluge_client.py
+++ b/sickbeard/clients/deluge_client.py
@@ -30,7 +30,7 @@ class DelugeAPI(GenericClient):
 
         super(DelugeAPI, self).__init__('Deluge', host, username, password)
 
-        self.url = self.host + 'json'
+        self.url = '{host}json'.format(host=self.host)
 
     def _get_auth(self):
 
@@ -67,7 +67,7 @@ class DelugeAPI(GenericClient):
 
             hosts = self.response.json()['result']
             if not hosts:
-                logger.log(self.name + u': WebUI does not contain daemons', logger.ERROR)
+                logger.log(u'{name}: WebUI does not contain daemons'.format(name=self.name), logger.ERROR)
                 return None
 
             post_data = json.dumps({'method': 'web.connect',
@@ -90,7 +90,7 @@ class DelugeAPI(GenericClient):
 
             connected = self.response.json()['result']
             if not connected:
-                logger.log(self.name + u': WebUI could not connect to daemon', logger.ERROR)
+                logger.log(u'{name}: WebUI could not connect to daemon'.format(name=self.name), logger.ERROR)
                 return None
 
         return self.auth
@@ -109,9 +109,15 @@ class DelugeAPI(GenericClient):
 
     def _add_torrent_file(self, result):
 
-        post_data = json.dumps({'method': 'core.add_torrent_file',
-                                'params': [result.name + '.torrent', b64encode(result.content), {}],
-                                'id': 2})
+        post_data = json.dumps({
+            'method': 'core.add_torrent_file',
+            'params': [
+                '{name}.torrent'.format(name=result.name),
+                b64encode(result.content),
+                {},
+            ],
+            'id': 2,
+        })
 
         self._request(method='post', data=post_data)
 
@@ -125,7 +131,8 @@ class DelugeAPI(GenericClient):
         if result.show.is_anime:
             label = sickbeard.TORRENT_LABEL_ANIME.lower()
         if ' ' in label:
-            logger.log(self.name + u': Invalid label. Label must not contain a space', logger.ERROR)
+            logger.log(u'{name}: Invalid label. Label must not contain a space'.format
+                       (name=self.name), logger.ERROR)
             return False
 
         if label:
@@ -139,14 +146,19 @@ class DelugeAPI(GenericClient):
 
             if labels is not None:
                 if label not in labels:
-                    logger.log(self.name + ': ' + label + u' label does not exist in Deluge we must add it',
-                               logger.DEBUG)
-                    post_data = json.dumps({'method': 'label.add',
-                                            'params': [label],
-                                            'id': 4})
+                    logger.log('{name}: {label} label does not exist in Deluge we must add it'.format
+                               (name=self.name, label=label), logger.DEBUG)
+                    post_data = json.dumps({
+                        'method': 'label.add',
+                        'params': [
+                            label,
+                        ],
+                        'id': 4,
+                    })
 
                     self._request(method='post', data=post_data)
-                    logger.log(self.name + ': ' + label + u' label added to Deluge', logger.DEBUG)
+                    logger.log(u'{name}: {label} label added to Deluge'.format
+                               (name=self.name, label=label), logger.DEBUG)
 
                 # add label to torrent
                 post_data = json.dumps({'method': 'label.set_torrent',
@@ -154,9 +166,11 @@ class DelugeAPI(GenericClient):
                                         'id': 5})
 
                 self._request(method='post', data=post_data)
-                logger.log(self.name + ': ' + label + u' label added to torrent', logger.DEBUG)
+                logger.log(u'{name}: {label} label added to torrent'.format
+                           (name=self.name, label=label), logger.DEBUG)
             else:
-                logger.log(self.name + ': ' + u'label plugin not detected', logger.DEBUG)
+                logger.log(u'{name}: label plugin not detected'.format
+                           (name=self.name), logger.DEBUG)
                 return False
 
         return not self.response.json()['error']

--- a/sickbeard/clients/deluge_client.py
+++ b/sickbeard/clients/deluge_client.py
@@ -34,20 +34,20 @@ class DelugeAPI(GenericClient):
 
     def _get_auth(self):
 
-        post_data = json.dumps({"method": "auth.login",
-                                "params": [self.password],
-                                "id": 1})
+        post_data = json.dumps({'method': 'auth.login',
+                                'params': [self.password],
+                                'id': 1})
 
         try:
             self.response = self.session.post(self.url, data=post_data.encode('utf-8'), verify=sickbeard.TORRENT_VERIFY_CERT)
         except Exception:
             return None
 
-        self.auth = self.response.json()["result"]
+        self.auth = self.response.json()['result']
 
-        post_data = json.dumps({"method": "web.connected",
-                                "params": [],
-                                "id": 10})
+        post_data = json.dumps({'method': 'web.connected',
+                                'params': [],
+                                'id': 10})
 
         try:
             self.response = self.session.post(self.url, data=post_data.encode('utf-8'), verify=sickbeard.TORRENT_VERIFY_CERT)
@@ -57,9 +57,9 @@ class DelugeAPI(GenericClient):
         connected = self.response.json()['result']
 
         if not connected:
-            post_data = json.dumps({"method": "web.get_hosts",
-                                    "params": [],
-                                    "id": 11})
+            post_data = json.dumps({'method': 'web.get_hosts',
+                                    'params': [],
+                                    'id': 11})
             try:
                 self.response = self.session.post(self.url, data=post_data.encode('utf-8'), verify=sickbeard.TORRENT_VERIFY_CERT)
             except Exception:
@@ -70,18 +70,18 @@ class DelugeAPI(GenericClient):
                 logger.log(self.name + u': WebUI does not contain daemons', logger.ERROR)
                 return None
 
-            post_data = json.dumps({"method": "web.connect",
-                                    "params": [hosts[0][0]],
-                                    "id": 11})
+            post_data = json.dumps({'method': 'web.connect',
+                                    'params': [hosts[0][0]],
+                                    'id': 11})
 
             try:
                 self.response = self.session.post(self.url, data=post_data.encode('utf-8'), verify=sickbeard.TORRENT_VERIFY_CERT)
             except Exception:
                 return None
 
-            post_data = json.dumps({"method": "web.connected",
-                                    "params": [],
-                                    "id": 10})
+            post_data = json.dumps({'method': 'web.connected',
+                                    'params': [],
+                                    'id': 10})
 
             try:
                 self.response = self.session.post(self.url, data=post_data.encode('utf-8'), verify=sickbeard.TORRENT_VERIFY_CERT)
@@ -97,9 +97,9 @@ class DelugeAPI(GenericClient):
 
     def _add_torrent_uri(self, result):
 
-        post_data = json.dumps({"method": "core.add_torrent_magnet",
-                                "params": [result.url, {}],
-                                "id": 2})
+        post_data = json.dumps({'method': 'core.add_torrent_magnet',
+                                'params': [result.url, {}],
+                                'id': 2})
 
         self._request(method='post', data=post_data)
 
@@ -109,9 +109,9 @@ class DelugeAPI(GenericClient):
 
     def _add_torrent_file(self, result):
 
-        post_data = json.dumps({"method": "core.add_torrent_file",
-                                "params": [result.name + '.torrent', b64encode(result.content), {}],
-                                "id": 2})
+        post_data = json.dumps({'method': 'core.add_torrent_file',
+                                'params': [result.name + '.torrent', b64encode(result.content), {}],
+                                'id': 2})
 
         self._request(method='post', data=post_data)
 
@@ -130,33 +130,33 @@ class DelugeAPI(GenericClient):
 
         if label:
             # check if label already exists and create it if not
-            post_data = json.dumps({"method": 'label.get_labels',
-                                    "params": [],
-                                    "id": 3})
+            post_data = json.dumps({'method': 'label.get_labels',
+                                    'params': [],
+                                    'id': 3})
 
             self._request(method='post', data=post_data)
             labels = self.response.json()['result']
 
             if labels is not None:
                 if label not in labels:
-                    logger.log(self.name + ': ' + label + u" label does not exist in Deluge we must add it",
+                    logger.log(self.name + ': ' + label + u' label does not exist in Deluge we must add it',
                                logger.DEBUG)
-                    post_data = json.dumps({"method": 'label.add',
-                                            "params": [label],
-                                            "id": 4})
+                    post_data = json.dumps({'method': 'label.add',
+                                            'params': [label],
+                                            'id': 4})
 
                     self._request(method='post', data=post_data)
-                    logger.log(self.name + ': ' + label + u" label added to Deluge", logger.DEBUG)
+                    logger.log(self.name + ': ' + label + u' label added to Deluge', logger.DEBUG)
 
                 # add label to torrent
-                post_data = json.dumps({"method": 'label.set_torrent',
-                                        "params": [result.hash, label],
-                                        "id": 5})
+                post_data = json.dumps({'method': 'label.set_torrent',
+                                        'params': [result.hash, label],
+                                        'id': 5})
 
                 self._request(method='post', data=post_data)
-                logger.log(self.name + ': ' + label + u" label added to torrent", logger.DEBUG)
+                logger.log(self.name + ': ' + label + u' label added to torrent', logger.DEBUG)
             else:
-                logger.log(self.name + ': ' + u"label plugin not detected", logger.DEBUG)
+                logger.log(self.name + ': ' + u'label plugin not detected', logger.DEBUG)
                 return False
 
         return not self.response.json()['error']
@@ -169,9 +169,9 @@ class DelugeAPI(GenericClient):
 
         # blank is default client ratio, so we also shouldn't set ratio
         if ratio and float(ratio) >= 0:
-            post_data = json.dumps({"method": "core.set_torrent_stop_at_ratio",
-                                    "params": [result.hash, True],
-                                    "id": 5})
+            post_data = json.dumps({'method': 'core.set_torrent_stop_at_ratio',
+                                    'params': [result.hash, True],
+                                    'id': 5})
 
             self._request(method='post', data=post_data)
             
@@ -179,9 +179,9 @@ class DelugeAPI(GenericClient):
             if self.response.json()['error']:
                 return False
 
-            post_data = json.dumps({"method": "core.set_torrent_stop_ratio",
-                                    "params": [result.hash, float(ratio)],
-                                    "id": 6})
+            post_data = json.dumps({'method': 'core.set_torrent_stop_ratio',
+                                    'params': [result.hash, float(ratio)],
+                                    'id': 6})
 
             self._request(method='post', data=post_data)
 
@@ -203,15 +203,15 @@ class DelugeAPI(GenericClient):
     def _set_torrent_path(self, result):
 
         if sickbeard.TORRENT_PATH:
-            post_data = json.dumps({"method": "core.set_torrent_move_completed",
-                                    "params": [result.hash, True],
-                                    "id": 7})
+            post_data = json.dumps({'method': 'core.set_torrent_move_completed',
+                                    'params': [result.hash, True],
+                                    'id': 7})
 
             self._request(method='post', data=post_data)
 
-            post_data = json.dumps({"method": "core.set_torrent_move_completed_path",
-                                    "params": [result.hash, sickbeard.TORRENT_PATH],
-                                    "id": 8})
+            post_data = json.dumps({'method': 'core.set_torrent_move_completed_path',
+                                    'params': [result.hash, sickbeard.TORRENT_PATH],
+                                    'id': 8})
 
             self._request(method='post', data=post_data)
 
@@ -222,9 +222,9 @@ class DelugeAPI(GenericClient):
     def _set_torrent_pause(self, result):
 
         if sickbeard.TORRENT_PAUSED:
-            post_data = json.dumps({"method": "core.pause_torrent",
-                                    "params": [[result.hash]],
-                                    "id": 9})
+            post_data = json.dumps({'method': 'core.pause_torrent',
+                                    'params': [[result.hash]],
+                                    'id': 9})
 
             self._request(method='post', data=post_data)
 

--- a/sickbeard/clients/deluge_client.py
+++ b/sickbeard/clients/deluge_client.py
@@ -36,34 +36,45 @@ class DelugeAPI(GenericClient):
 
     def _get_auth(self):
 
-        post_data = json.dumps({'method': 'auth.login',
-                                'params': [self.password],
-                                'id': 1})
+        post_data = json.dumps({
+            'method': 'auth.login',
+            'params': [
+                self.password,
+            ],
+            'id': 1,
+        })
 
         try:
-            self.response = self.session.post(self.url, data=post_data.encode('utf-8'), verify=sickbeard.TORRENT_VERIFY_CERT)
+            self.response = self.session.post(self.url, data=post_data.encode('utf-8'),
+                                              verify=sickbeard.TORRENT_VERIFY_CERT)
         except Exception:
             return None
 
         self.auth = self.response.json()['result']
 
-        post_data = json.dumps({'method': 'web.connected',
-                                'params': [],
-                                'id': 10})
+        post_data = json.dumps({
+            'method': 'web.connected',
+            'params': [],
+            'id': 10,
+        })
 
         try:
-            self.response = self.session.post(self.url, data=post_data.encode('utf-8'), verify=sickbeard.TORRENT_VERIFY_CERT)
+            self.response = self.session.post(self.url, data=post_data.encode('utf-8'),
+                                              verify=sickbeard.TORRENT_VERIFY_CERT)
         except Exception:
             return None
 
         connected = self.response.json()['result']
 
         if not connected:
-            post_data = json.dumps({'method': 'web.get_hosts',
-                                    'params': [],
-                                    'id': 11})
+            post_data = json.dumps({
+                'method': 'web.get_hosts',
+                'params': [],
+                'id': 11,
+            })
             try:
-                self.response = self.session.post(self.url, data=post_data.encode('utf-8'), verify=sickbeard.TORRENT_VERIFY_CERT)
+                self.response = self.session.post(self.url, data=post_data.encode('utf-8'),
+                                                  verify=sickbeard.TORRENT_VERIFY_CERT)
             except Exception:
                 return None
 
@@ -72,21 +83,29 @@ class DelugeAPI(GenericClient):
                 logger.log('{name}: WebUI does not contain daemons'.format(name=self.name), logger.ERROR)
                 return None
 
-            post_data = json.dumps({'method': 'web.connect',
-                                    'params': [hosts[0][0]],
-                                    'id': 11})
+            post_data = json.dumps({
+                'method': 'web.connect',
+                'params': [
+                    hosts[0][0],
+                ],
+                'id': 11,
+            })
 
             try:
-                self.response = self.session.post(self.url, data=post_data.encode('utf-8'), verify=sickbeard.TORRENT_VERIFY_CERT)
+                self.response = self.session.post(self.url, data=post_data.encode('utf-8'),
+                                                  verify=sickbeard.TORRENT_VERIFY_CERT)
             except Exception:
                 return None
 
-            post_data = json.dumps({'method': 'web.connected',
-                                    'params': [],
-                                    'id': 10})
+            post_data = json.dumps({
+                'method': 'web.connected',
+                'params': [],
+                'id': 10,
+            })
 
             try:
-                self.response = self.session.post(self.url, data=post_data.encode('utf-8'), verify=sickbeard.TORRENT_VERIFY_CERT)
+                self.response = self.session.post(self.url, data=post_data.encode('utf-8'),
+                                                  verify=sickbeard.TORRENT_VERIFY_CERT)
             except Exception:
                 return None
 
@@ -99,9 +118,14 @@ class DelugeAPI(GenericClient):
 
     def _add_torrent_uri(self, result):
 
-        post_data = json.dumps({'method': 'core.add_torrent_magnet',
-                                'params': [result.url, {}],
-                                'id': 2})
+        post_data = json.dumps({
+            'method': 'core.add_torrent_magnet',
+            'params': [
+                result.url,
+                {},
+            ],
+            'id': 2,
+        })
 
         self._request(method='post', data=post_data)
 
@@ -139,9 +163,11 @@ class DelugeAPI(GenericClient):
 
         if label:
             # check if label already exists and create it if not
-            post_data = json.dumps({'method': 'label.get_labels',
-                                    'params': [],
-                                    'id': 3})
+            post_data = json.dumps({
+                'method': 'label.get_labels',
+                'params': [],
+                'id': 3,
+            })
 
             self._request(method='post', data=post_data)
             labels = self.response.json()['result']
@@ -163,9 +189,14 @@ class DelugeAPI(GenericClient):
                                (name=self.name, label=label), logger.DEBUG)
 
                 # add label to torrent
-                post_data = json.dumps({'method': 'label.set_torrent',
-                                        'params': [result.hash, label],
-                                        'id': 5})
+                post_data = json.dumps({
+                    'method': 'label.set_torrent',
+                    'params': [
+                        result.hash,
+                        label,
+                    ],
+                    'id': 5,
+                })
 
                 self._request(method='post', data=post_data)
                 logger.log('{name}: {label} label added to torrent'.format
@@ -185,9 +216,14 @@ class DelugeAPI(GenericClient):
 
         # blank is default client ratio, so we also shouldn't set ratio
         if ratio and float(ratio) >= 0:
-            post_data = json.dumps({'method': 'core.set_torrent_stop_at_ratio',
-                                    'params': [result.hash, True],
-                                    'id': 5})
+            post_data = json.dumps({
+                'method': 'core.set_torrent_stop_at_ratio',
+                'params': [
+                    result.hash,
+                    True,
+                ],
+                'id': 5,
+            })
 
             self._request(method='post', data=post_data)
             
@@ -195,9 +231,14 @@ class DelugeAPI(GenericClient):
             if self.response.json()['error']:
                 return False
 
-            post_data = json.dumps({'method': 'core.set_torrent_stop_ratio',
-                                    'params': [result.hash, float(ratio)],
-                                    'id': 6})
+            post_data = json.dumps({
+                'method': 'core.set_torrent_stop_ratio',
+                'params': [
+                    result.hash,
+                    float(ratio),
+                ],
+                'id': 6,
+            })
 
             self._request(method='post', data=post_data)
 
@@ -219,15 +260,25 @@ class DelugeAPI(GenericClient):
     def _set_torrent_path(self, result):
 
         if sickbeard.TORRENT_PATH:
-            post_data = json.dumps({'method': 'core.set_torrent_move_completed',
-                                    'params': [result.hash, True],
-                                    'id': 7})
+            post_data = json.dumps({
+                'method': 'core.set_torrent_move_completed',
+                'params': [
+                    result.hash,
+                    True,
+                ],
+                'id': 7,
+            })
 
             self._request(method='post', data=post_data)
 
-            post_data = json.dumps({'method': 'core.set_torrent_move_completed_path',
-                                    'params': [result.hash, sickbeard.TORRENT_PATH],
-                                    'id': 8})
+            post_data = json.dumps({
+                'method': 'core.set_torrent_move_completed_path',
+                'params': [
+                    result.hash,
+                    sickbeard.TORRENT_PATH,
+                ],
+                'id': 8,
+            })
 
             self._request(method='post', data=post_data)
 
@@ -238,9 +289,13 @@ class DelugeAPI(GenericClient):
     def _set_torrent_pause(self, result):
 
         if sickbeard.TORRENT_PAUSED:
-            post_data = json.dumps({'method': 'core.pause_torrent',
-                                    'params': [[result.hash]],
-                                    'id': 9})
+            post_data = json.dumps({
+                'method': 'core.pause_torrent',
+                'params': [
+                    [result.hash],
+                ],
+                'id': 9,
+            })
 
             self._request(method='post', data=post_data)
 

--- a/sickbeard/clients/deluge_client.py
+++ b/sickbeard/clients/deluge_client.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
+
 import json
 from base64 import b64encode
 
@@ -67,7 +69,7 @@ class DelugeAPI(GenericClient):
 
             hosts = self.response.json()['result']
             if not hosts:
-                logger.log(u'{name}: WebUI does not contain daemons'.format(name=self.name), logger.ERROR)
+                logger.log('{name}: WebUI does not contain daemons'.format(name=self.name), logger.ERROR)
                 return None
 
             post_data = json.dumps({'method': 'web.connect',
@@ -90,7 +92,7 @@ class DelugeAPI(GenericClient):
 
             connected = self.response.json()['result']
             if not connected:
-                logger.log(u'{name}: WebUI could not connect to daemon'.format(name=self.name), logger.ERROR)
+                logger.log('{name}: WebUI could not connect to daemon'.format(name=self.name), logger.ERROR)
                 return None
 
         return self.auth
@@ -131,7 +133,7 @@ class DelugeAPI(GenericClient):
         if result.show.is_anime:
             label = sickbeard.TORRENT_LABEL_ANIME.lower()
         if ' ' in label:
-            logger.log(u'{name}: Invalid label. Label must not contain a space'.format
+            logger.log('{name}: Invalid label. Label must not contain a space'.format
                        (name=self.name), logger.ERROR)
             return False
 
@@ -157,7 +159,7 @@ class DelugeAPI(GenericClient):
                     })
 
                     self._request(method='post', data=post_data)
-                    logger.log(u'{name}: {label} label added to Deluge'.format
+                    logger.log('{name}: {label} label added to Deluge'.format
                                (name=self.name, label=label), logger.DEBUG)
 
                 # add label to torrent
@@ -166,10 +168,10 @@ class DelugeAPI(GenericClient):
                                         'id': 5})
 
                 self._request(method='post', data=post_data)
-                logger.log(u'{name}: {label} label added to torrent'.format
+                logger.log('{name}: {label} label added to torrent'.format
                            (name=self.name, label=label), logger.DEBUG)
             else:
-                logger.log(u'{name}: label plugin not detected'.format
+                logger.log('{name}: label plugin not detected'.format
                            (name=self.name), logger.DEBUG)
                 return False
 

--- a/sickbeard/clients/deluge_client.py
+++ b/sickbeard/clients/deluge_client.py
@@ -22,6 +22,8 @@ from __future__ import unicode_literals
 import json
 from base64 import b64encode
 
+from requests.exceptions import RequestException
+
 import sickbeard
 from sickbeard import logger
 from sickbeard.clients.generic import GenericClient
@@ -47,7 +49,7 @@ class DelugeAPI(GenericClient):
         try:
             self.response = self.session.post(self.url, data=post_data.encode('utf-8'),
                                               verify=sickbeard.TORRENT_VERIFY_CERT)
-        except Exception:
+        except RequestException:
             return None
 
         self.auth = self.response.json()['result']
@@ -61,7 +63,7 @@ class DelugeAPI(GenericClient):
         try:
             self.response = self.session.post(self.url, data=post_data.encode('utf-8'),
                                               verify=sickbeard.TORRENT_VERIFY_CERT)
-        except Exception:
+        except RequestException:
             return None
 
         connected = self.response.json()['result']
@@ -75,7 +77,7 @@ class DelugeAPI(GenericClient):
             try:
                 self.response = self.session.post(self.url, data=post_data.encode('utf-8'),
                                                   verify=sickbeard.TORRENT_VERIFY_CERT)
-            except Exception:
+            except RequestException:
                 return None
 
             hosts = self.response.json()['result']
@@ -94,7 +96,7 @@ class DelugeAPI(GenericClient):
             try:
                 self.response = self.session.post(self.url, data=post_data.encode('utf-8'),
                                                   verify=sickbeard.TORRENT_VERIFY_CERT)
-            except Exception:
+            except RequestException:
                 return None
 
             post_data = json.dumps({
@@ -106,7 +108,7 @@ class DelugeAPI(GenericClient):
             try:
                 self.response = self.session.post(self.url, data=post_data.encode('utf-8'),
                                                   verify=sickbeard.TORRENT_VERIFY_CERT)
-            except Exception:
+            except RequestException:
                 return None
 
             connected = self.response.json()['result']

--- a/sickbeard/clients/deluged_client.py
+++ b/sickbeard/clients/deluged_client.py
@@ -37,10 +37,6 @@ class DelugeDAPI(GenericClient):
         return self.drpc
 
     def _add_torrent_uri(self, result):
-        # label = sickbeard.TORRENT_LABEL
-        # if result.show.is_anime:
-        #     label = sickbeard.TORRENT_LABEL_ANIME
-
         options = {
             'add_paused': sickbeard.TORRENT_PAUSED
         }
@@ -55,10 +51,6 @@ class DelugeDAPI(GenericClient):
         return remote_torrent
 
     def _add_torrent_file(self, result):
-        # label = sickbeard.TORRENT_LABEL
-        # if result.show.is_anime:
-        #     label = sickbeard.TORRENT_LABEL_ANIME
-
         if not result.content:
             result.content = {}
             return None
@@ -150,7 +142,6 @@ class DelugeRPC(object):
         return True
 
     def add_torrent_magnet(self, torrent, options, torrent_hash):
-        torrent_id = False
         try:
             self.connect()
             torrent_id = self.client.core.add_torrent_magnet(torrent, options).get()  # pylint:disable=no-member
@@ -165,7 +156,6 @@ class DelugeRPC(object):
         return torrent_id
 
     def add_torrent_file(self, filename, torrent, options, torrent_hash):
-        torrent_id = False
         try:
             self.connect()
             torrent_id = self.client.core.add_torrent_file(filename, b64encode(torrent), options).get()  # pylint:disable=no-member

--- a/sickbeard/clients/deluged_client.py
+++ b/sickbeard/clients/deluged_client.py
@@ -5,6 +5,8 @@
 # This client script allows connection to Deluge Daemon directly, completely
 # circumventing the requirement to use the WebUI.
 
+from __future__ import unicode_literals
+
 from base64 import b64encode
 
 import sickbeard
@@ -81,7 +83,7 @@ class DelugeDAPI(GenericClient):
         if result.show.is_anime:
             label = sickbeard.TORRENT_LABEL_ANIME.lower()
         if ' ' in label:
-            logger.log(u'{name}: Invalid label. Label must not contain a space'.format
+            logger.log('{name}: Invalid label. Label must not contain a space'.format
                        (name=self.name), logger.ERROR)
             return False
 
@@ -241,7 +243,7 @@ class DelugeRPC(object):
     def _check_torrent(self, torrent_hash):
         torrent_id = self.client.core.get_torrent_status(torrent_hash, {}).get()  # pylint:disable=no-member
         if torrent_id['hash']:
-            logger.log(u'DelugeD: Torrent already exists in Deluge', logger.DEBUG)
+            logger.log('DelugeD: Torrent already exists in Deluge', logger.DEBUG)
             return torrent_hash
         return False
 

--- a/sickbeard/clients/deluged_client.py
+++ b/sickbeard/clients/deluged_client.py
@@ -65,7 +65,8 @@ class DelugeDAPI(GenericClient):
             'add_paused': sickbeard.TORRENT_PAUSED
         }
 
-        remote_torrent = self.drpc.add_torrent_file(result.name + '.torrent', result.content, options, result.hash)
+        remote_torrent = self.drpc.add_torrent_file('{name}.torrent'.format(name=result.name),
+                                                    result.content, options, result.hash)
 
         if not remote_torrent:
             return None
@@ -80,7 +81,8 @@ class DelugeDAPI(GenericClient):
         if result.show.is_anime:
             label = sickbeard.TORRENT_LABEL_ANIME.lower()
         if ' ' in label:
-            logger.log(self.name + u': Invalid label. Label must not contain a space', logger.ERROR)
+            logger.log(u'{name}: Invalid label. Label must not contain a space'.format
+                       (name=self.name), logger.ERROR)
             return False
 
         if label:

--- a/sickbeard/clients/deluged_client.py
+++ b/sickbeard/clients/deluged_client.py
@@ -111,7 +111,7 @@ class DelugeDAPI(GenericClient):
             return self.drpc.pause_torrent(result.hash)
         return True
 
-    def testAuthentication(self):
+    def test_authentication(self):
         if self.connect(True) and self.drpc.test():
             return True, 'Success: Connected and Authenticated'
         else:

--- a/sickbeard/clients/deluged_client.py
+++ b/sickbeard/clients/deluged_client.py
@@ -27,7 +27,7 @@ class DelugeDAPI(GenericClient):
         return True
 
     def connect(self, reconnect=False):
-        hostname = self.host.replace("/", "").split(':')
+        hostname = self.host.replace('/', '').split(':')
 
         if not self.drpc or reconnect:
             self.drpc = DelugeRPC(hostname[1], port=hostname[2], username=self.username, password=self.password)

--- a/sickbeard/clients/deluged_client.py
+++ b/sickbeard/clients/deluged_client.py
@@ -23,10 +23,7 @@ class DelugeDAPI(GenericClient):
         super(DelugeDAPI, self).__init__('DelugeD', host, username, password)
 
     def _get_auth(self):
-        if not self.connect():
-            return None
-
-        return True
+        return True if self.connect() else None
 
     def connect(self, reconnect=False):
         hostname = self.host.replace('/', '').split(':')
@@ -43,12 +40,10 @@ class DelugeDAPI(GenericClient):
 
         remote_torrent = self.drpc.add_torrent_magnet(result.url, options, result.hash)
 
-        if not remote_torrent:
-            return None
+        if remote_torrent:
+            result.hash = remote_torrent
 
-        result.hash = remote_torrent
-
-        return remote_torrent
+        return remote_torrent or None
 
     def _add_torrent_file(self, result):
         if not result.content:
@@ -62,12 +57,10 @@ class DelugeDAPI(GenericClient):
         remote_torrent = self.drpc.add_torrent_file('{name}.torrent'.format(name=result.name),
                                                     result.content, options, result.hash)
 
-        if not remote_torrent:
-            return None
+        if remote_torrent:
+            result.hash = remote_torrent
 
-        result.hash = remote_torrent
-
-        return remote_torrent
+        return remote_torrent or None
 
     def _set_torrent_label(self, result):
 
@@ -79,33 +72,20 @@ class DelugeDAPI(GenericClient):
                        (name=self.name), logger.ERROR)
             return False
 
-        if label:
-            return self.drpc.set_torrent_label(result.hash, label)
-        return True
+        return self.drpc.set_torrent_label(result.hash, label) if label else True
 
     def _set_torrent_ratio(self, result):
-        if result.ratio:
-            ratio = float(result.ratio)
-            return self.drpc.set_torrent_ratio(result.hash, ratio)
-        return True
+        return self.drpc.set_torrent_ratio(result.hash, float(result.ratio)) if result.ratio else True
 
     def _set_torrent_priority(self, result):
-        if result.priority == 1:
-            return self.drpc.set_torrent_priority(result.hash, True)
-        return True
+        return self.drpc.set_torrent_priority(result.hash, True) if result.priority == 1 else True
 
     def _set_torrent_path(self, result):
-
         path = sickbeard.TORRENT_PATH
-        if path:
-            return self.drpc.set_torrent_path(result.hash, path)
-        return True
+        return self.drpc.set_torrent_path(result.hash, path) if path else True
 
     def _set_torrent_pause(self, result):
-
-        if sickbeard.TORRENT_PAUSED:
-            return self.drpc.pause_torrent(result.hash)
-        return True
+        return self.drpc.pause_torrent(result.hash) if sickbeard.TORRENT_PAUSED else True
 
     def test_authentication(self):
         if self.connect(True) and self.drpc.test():
@@ -139,7 +119,8 @@ class DelugeRPC(object):
             self.connect()
         except Exception:
             return False
-        return True
+        else:
+            return True
 
     def add_torrent_magnet(self, torrent, options, torrent_hash):
         try:
@@ -149,11 +130,11 @@ class DelugeRPC(object):
                 torrent_id = self._check_torrent(torrent_hash)
         except Exception:
             return False
+        else:
+            return torrent_id
         finally:
             if self.client:
                 self.disconnect()
-
-        return torrent_id
 
     def add_torrent_file(self, filename, torrent, options, torrent_hash):
         try:
@@ -163,11 +144,11 @@ class DelugeRPC(object):
                 torrent_id = self._check_torrent(torrent_hash)
         except Exception:
             return False
+        else:
+            return torrent_id
         finally:
             if self.client:
                 self.disconnect()
-
-        return torrent_id
 
     def set_torrent_label(self, torrent_id, label):
         try:
@@ -175,10 +156,11 @@ class DelugeRPC(object):
             self.client.label.set_torrent(torrent_id, label).get()  # pylint:disable=no-member
         except Exception:
             return False
+        else:
+            return True
         finally:
             if self.client:
                 self.disconnect()
-        return True
 
     def set_torrent_path(self, torrent_id, path):
         try:
@@ -187,10 +169,11 @@ class DelugeRPC(object):
             self.client.core.set_torrent_move_completed(torrent_id, 1).get()  # pylint:disable=no-member
         except Exception:
             return False
+        else:
+            return True
         finally:
             if self.client:
                 self.disconnect()
-        return True
 
     def set_torrent_priority(self, torrent_ids, priority):
         try:
@@ -199,10 +182,11 @@ class DelugeRPC(object):
                 self.client.core.queue_top([torrent_ids]).get()  # pylint:disable=no-member
         except Exception:
             return False
+        else:
+            return True
         finally:
             if self.client:
                 self.disconnect()
-        return True
 
     def set_torrent_ratio(self, torrent_ids, ratio):
         try:
@@ -211,10 +195,11 @@ class DelugeRPC(object):
             self.client.core.set_torrent_stop_ratio(torrent_ids, ratio).get()  # pylint:disable=no-member
         except Exception:
             return False
+        else:
+            return True
         finally:
             if self.client:
                 self.disconnect()
-        return True
 
     def pause_torrent(self, torrent_ids):
         try:
@@ -222,10 +207,11 @@ class DelugeRPC(object):
             self.client.core.pause_torrent(torrent_ids).get()  # pylint:disable=no-member
         except Exception:
             return False
+        else:
+            return True
         finally:
             if self.client:
                 self.disconnect()
-        return True
 
     def disconnect(self):
         self.client.disconnect()

--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -74,7 +74,7 @@ class DownloadStationAPI(GenericClient):
         self.auth = jdata.get('success')
         if not self.auth:
             error_code = jdata.get('error', {}).get('code')
-            sickbeard.logger.log('{}'.format(self.error_map.get(error_code, jdata)))
+            sickbeard.logger.log('{error}'.format(error=self.error_map.get(error_code, jdata)))
             self.session.cookies.clear()
 
         return self.auth
@@ -137,7 +137,7 @@ class DownloadStationAPI(GenericClient):
         if sickbeard.TORRENT_PATH:
             data['destination'] = sickbeard.TORRENT_PATH
 
-        files = {'file': (result.name + '.torrent', result.content)}
+        files = {'file': ('{name}.torrent'.format(name=result.name), result.content)}
 
         self._request(method='post', data=data, files=files)
         return self._check_response()
@@ -146,7 +146,7 @@ class DownloadStationAPI(GenericClient):
         """
         Validate and set torrent destination
         """
-        
+
         if not (self.auth or self._get_auth()):
             return False
 
@@ -174,7 +174,8 @@ class DownloadStationAPI(GenericClient):
             jdata = self.response.json()
             version_string = jdata.get('data', {}).get('version_string')
             if not version_string:
-                sickbeard.logger.log('Could not get the version_string from DSM: {0}'.format(jdata))
+                sickbeard.logger.log('Could not get the version_string from DSM: {response}'.format
+                                     (response=jdata))
                 return False
 
             if version_string.startswith('DSM 6'):
@@ -204,11 +205,13 @@ class DownloadStationAPI(GenericClient):
                         if destination and os.path.isabs(destination):
                             sickbeard.TORRENT_PATH = re.sub(r'^/volume\d/', '', destination).lstrip('/')
                         else:
-                            sickbeard.logger.log('default_destination could not be determined for DSM6: {0}'.format(jdata))
+                            sickbeard.logger.log('default_destination could not be determined '
+                                                 'for DSM6: {response}'.format(response=jdata))
                             return False
 
         if destination or sickbeard.TORRENT_PATH:
-            sickbeard.logger.log('Destination is now {0}'.format(sickbeard.TORRENT_PATH or destination))
+            sickbeard.logger.log('Destination is now {path}'.format
+                                 (path=sickbeard.TORRENT_PATH or destination))
 
         self.checked_destination = True
         self.destination = sickbeard.TORRENT_PATH

--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -109,6 +109,8 @@ class DownloadStationAPI(GenericClient):
 
     def _add_torrent_uri(self, result):
 
+        torrent_path = sickbeard.TORRENT_PATH
+
         data = {
             'api': 'SYNO.DownloadStation.Task',
             'version': '1',
@@ -120,12 +122,14 @@ class DownloadStationAPI(GenericClient):
         if not self._check_destination():
             return False
 
-        if sickbeard.TORRENT_PATH:
-            data['destination'] = sickbeard.TORRENT_PATH
+        if torrent_path:
+            data['destination'] = torrent_path
         self._request(method='post', data=data)
         return self._check_response()
 
     def _add_torrent_file(self, result):
+
+        torrent_path = sickbeard.TORRENT_PATH
 
         data = {
             'api': 'SYNO.DownloadStation.Task',
@@ -137,8 +141,8 @@ class DownloadStationAPI(GenericClient):
         if not self._check_destination():
             return False
 
-        if sickbeard.TORRENT_PATH:
-            data['destination'] = sickbeard.TORRENT_PATH
+        if torrent_path:
+            data['destination'] = torrent_path
 
         files = {'file': ('{name}.torrent'.format(name=result.name), result.content)}
 
@@ -150,10 +154,12 @@ class DownloadStationAPI(GenericClient):
         Validate and set torrent destination
         """
 
+        torrent_path = sickbeard.TORRENT_PATH
+
         if not (self.auth or self._get_auth()):
             return False
 
-        if self.checked_destination and self.destination == sickbeard.TORRENT_PATH:
+        if self.checked_destination and self.destination == torrent_path:
             return True
 
         params = {
@@ -183,8 +189,8 @@ class DownloadStationAPI(GenericClient):
 
             if version_string.startswith('DSM 6'):
                 #  This is DSM6, lets make sure the location is relative
-                if sickbeard.TORRENT_PATH and os.path.isabs(sickbeard.TORRENT_PATH):
-                    sickbeard.TORRENT_PATH = re.sub(r'^/volume\d/', '', sickbeard.TORRENT_PATH).lstrip('/')
+                if torrent_path and os.path.isabs(torrent_path):
+                    torrent_path = re.sub(r'^/volume\d/', '', torrent_path).lstrip('/')
                 else:
                     #  Since they didn't specify the location in the settings,
                     #  lets make sure the default is relative,
@@ -207,18 +213,18 @@ class DownloadStationAPI(GenericClient):
                         jdata = self.response.json()
                         destination = jdata.get('data', {}).get('default_destination')
                         if destination and os.path.isabs(destination):
-                            sickbeard.TORRENT_PATH = re.sub(r'^/volume\d/', '', destination).lstrip('/')
+                            torrent_path = re.sub(r'^/volume\d/', '', destination).lstrip('/')
                         else:
                             logger.log('Default destination could not be determined '
                                        'for DSM6: {response}'.format(response=jdata))
                             return False
 
-        if destination or sickbeard.TORRENT_PATH:
+        if destination or torrent_path:
             logger.log('Destination is now {path}'.format
-                       (path=sickbeard.TORRENT_PATH or destination))
+                       (path=torrent_path or destination))
 
         self.checked_destination = True
-        self.destination = sickbeard.TORRENT_PATH
+        self.destination = torrent_path
         return True
 
 api = DownloadStationAPI()

--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -28,6 +28,7 @@ import os
 import re
 
 import sickbeard
+from sickbeard import logger
 from sickbeard.clients.generic import GenericClient
 
 
@@ -74,7 +75,7 @@ class DownloadStationAPI(GenericClient):
         self.auth = jdata.get('success')
         if not self.auth:
             error_code = jdata.get('error', {}).get('code')
-            sickbeard.logger.log('{error}'.format(error=self.error_map.get(error_code, jdata)))
+            logger.log('{error}'.format(error=self.error_map.get(error_code, jdata)))
             self.session.cookies.clear()
 
         return self.auth
@@ -174,8 +175,8 @@ class DownloadStationAPI(GenericClient):
             jdata = self.response.json()
             version_string = jdata.get('data', {}).get('version_string')
             if not version_string:
-                sickbeard.logger.log('Could not get the version_string from DSM: {response}'.format
-                                     (response=jdata))
+                logger.log('Could not get the version string from DSM: {response}'.format
+                           (response=jdata))
                 return False
 
             if version_string.startswith('DSM 6'):
@@ -205,13 +206,13 @@ class DownloadStationAPI(GenericClient):
                         if destination and os.path.isabs(destination):
                             sickbeard.TORRENT_PATH = re.sub(r'^/volume\d/', '', destination).lstrip('/')
                         else:
-                            sickbeard.logger.log('default_destination could not be determined '
-                                                 'for DSM6: {response}'.format(response=jdata))
+                            logger.log('Default destination could not be determined '
+                                       'for DSM6: {response}'.format(response=jdata))
                             return False
 
         if destination or sickbeard.TORRENT_PATH:
-            sickbeard.logger.log('Destination is now {path}'.format
-                                 (path=sickbeard.TORRENT_PATH or destination))
+            logger.log('Destination is now {path}'.format
+                       (path=sickbeard.TORRENT_PATH or destination))
 
         self.checked_destination = True
         self.destination = sickbeard.TORRENT_PATH

--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -19,7 +19,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Medusa. If not, see <http://www.gnu.org/licenses/>.
 #
-# Uses the Synology Download Station API: http://download.synology.com/download/Document/DeveloperGuide/Synology_Download_Station_Web_API.pdf
+
+# Uses the Synology Download Station API:
+# http://download.synology.com/download/Document/DeveloperGuide/Synology_Download_Station_Web_API.pdf
 
 from __future__ import unicode_literals
 from requests.compat import urljoin
@@ -184,8 +186,9 @@ class DownloadStationAPI(GenericClient):
                 if sickbeard.TORRENT_PATH and os.path.isabs(sickbeard.TORRENT_PATH):
                     sickbeard.TORRENT_PATH = re.sub(r'^/volume\d/', '', sickbeard.TORRENT_PATH).lstrip('/')
                 else:
-                    #  Since they didnt specify the location in the settings, lets make sure the default is relative,
-                    #  Or forcefully set the location setting in SickRage
+                    #  Since they didn't specify the location in the settings,
+                    #  lets make sure the default is relative,
+                    #  or forcefully set the location setting
                     params.update({
                         'method': 'getconfig',
                         'version': 2

--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -44,7 +44,7 @@ class DownloadStationAPI(GenericClient):
             'login': urljoin(self.host, 'webapi/auth.cgi'),
             'task': urljoin(self.host, 'webapi/DownloadStation/task.cgi'),
             'info': urljoin(self.host, '/webapi/DownloadStation/info.cgi'),
-            'dsminfo': urljoin(self.host, '/webapi/entry.cgi')
+            'dsminfo': urljoin(self.host, '/webapi/entry.cgi'),
         }
 
         self.url = self.urls['task']
@@ -57,7 +57,7 @@ class DownloadStationAPI(GenericClient):
             104: 'The requested version does not support the functionality',
             105: 'The logged in session does not have permission',
             106: 'Session timeout',
-            107: 'Session interrupted by duplicate login'
+            107: 'Session interrupted by duplicate login',
         }
         self.checked_destination = False
         self.destination = sickbeard.TORRENT_PATH
@@ -93,7 +93,7 @@ class DownloadStationAPI(GenericClient):
             'account': self.username,
             'passwd': self.password,
             'session': 'DownloadStation',
-            'format': 'cookie'
+            'format': 'cookie',
         }
 
         try:
@@ -114,7 +114,7 @@ class DownloadStationAPI(GenericClient):
             'version': '1',
             'method': 'create',
             'session': 'DownloadStation',
-            'uri': result.url
+            'uri': result.url,
         }
 
         if not self._check_destination():
@@ -160,7 +160,7 @@ class DownloadStationAPI(GenericClient):
             'api': 'SYNO.DSM.Info',
             'version': 2,
             'method': 'getinfo',
-            'session': 'DownloadStation'
+            'session': 'DownloadStation',
         }
 
         try:
@@ -191,7 +191,7 @@ class DownloadStationAPI(GenericClient):
                     #  or forcefully set the location setting
                     params.update({
                         'method': 'getconfig',
-                        'version': 2
+                        'version': 2,
                     })
 
                     try:

--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -24,10 +24,12 @@
 # http://download.synology.com/download/Document/DeveloperGuide/Synology_Download_Station_Web_API.pdf
 
 from __future__ import unicode_literals
-from requests.compat import urljoin
-from requests.exceptions import RequestException
+
 import os
 import re
+
+from requests.compat import urljoin
+from requests.exceptions import RequestException
 
 import sickbeard
 from sickbeard import logger

--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -33,6 +33,7 @@ from requests.exceptions import RequestException
 
 import sickbeard
 from sickbeard import logger
+from sickbeard.helpers import handle_requests_exception
 from sickbeard.clients.generic import GenericClient
 
 
@@ -102,7 +103,7 @@ class DownloadStationAPI(GenericClient):
             self.response = self.session.get(self.urls['login'], params=params, verify=False)
             self.response.raise_for_status()
         except RequestException as error:
-            sickbeard.helpers.handle_requests_exception(error)
+            handle_requests_exception(error)
             self.session.cookies.clear()
             self.auth = False
             return self.auth
@@ -175,7 +176,7 @@ class DownloadStationAPI(GenericClient):
             self.response = self.session.get(self.urls['dsminfo'], params=params, verify=False, timeout=120)
             self.response.raise_for_status()
         except RequestException as error:
-            sickbeard.helpers.handle_requests_exception(error)
+            handle_requests_exception(error)
             self.session.cookies.clear()
             self.auth = False
             return False
@@ -206,7 +207,7 @@ class DownloadStationAPI(GenericClient):
                         self.response = self.session.get(self.urls['info'], params=params, verify=False, timeout=120)
                         self.response.raise_for_status()
                     except RequestException as error:
-                        sickbeard.helpers.handle_requests_exception(error)
+                        handle_requests_exception(error)
                         self.session.cookies.clear()
                         self.auth = False
                         return False

--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -73,14 +73,14 @@ class DownloadStationAPI(GenericClient):
             self.session.cookies.clear()
             self.auth = False
             return self.auth
+        else:
+            self.auth = jdata.get('success')
+            if not self.auth:
+                error_code = jdata.get('error', {}).get('code')
+                logger.log('{error}'.format(error=self.error_map.get(error_code, jdata)))
+                self.session.cookies.clear()
 
-        self.auth = jdata.get('success')
-        if not self.auth:
-            error_code = jdata.get('error', {}).get('code')
-            logger.log('{error}'.format(error=self.error_map.get(error_code, jdata)))
-            self.session.cookies.clear()
-
-        return self.auth
+            return self.auth
 
     def _get_auth(self):
         if self.session.cookies and self.auth:
@@ -104,8 +104,8 @@ class DownloadStationAPI(GenericClient):
             self.session.cookies.clear()
             self.auth = False
             return self.auth
-
-        return self._check_response()
+        else:
+            return self._check_response()
 
     def _add_torrent_uri(self, result):
 

--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 
+from __future__ import unicode_literals
+
 import re
 import time
 from hashlib import sha1
@@ -38,48 +40,48 @@ class GenericClient(object):
             self._get_auth()
 
         data_str = str(data)
-        logger.log(u'{name}: Requested a {method} connection to {url} with Params: {params} Data: {data}{etc}'.format
+        logger.log('{name}: Requested a {method} connection to {url} with Params: {params} Data: {data}{etc}'.format
                    (name=self.name, method=method.upper(), url=self.url,
                     params=params, data=data_str[0:99],
                     etc='...' if len(data_str) > 99 else ''), logger.DEBUG)
 
         if not self.auth:
-            logger.log(u'{name}: Authentication Failed'.format(name=self.name), logger.WARNING)
+            logger.log('{name}: Authentication Failed'.format(name=self.name), logger.WARNING)
 
             return False
         try:
             self.response = self.session.__getattribute__(method)(self.url, params=params, data=data, files=files, cookies=cookies,
                                                                   timeout=120, verify=False)
         except requests.exceptions.ConnectionError as msg:
-            logger.log(u'{name}: Unable to connect {error}'.format
+            logger.log('{name}: Unable to connect {error}'.format
                        (name=self.name, error=msg), logger.ERROR)
             return False
         except (requests.exceptions.MissingSchema, requests.exceptions.InvalidURL):
-            logger.log(u'{name}: Invalid Host'.format(name=self.name), logger.ERROR)
+            logger.log('{name}: Invalid Host'.format(name=self.name), logger.ERROR)
             return False
         except requests.exceptions.HTTPError as msg:
-            logger.log(u'{name}: Invalid HTTP Request {error}'.format(name=self.name, error=msg), logger.ERROR)
+            logger.log('{name}: Invalid HTTP Request {error}'.format(name=self.name, error=msg), logger.ERROR)
             return False
         except requests.exceptions.Timeout as msg:
-            logger.log(u'{name}: Connection Timeout {error}'.format(name=self.name, error=msg), logger.WARNING)
+            logger.log('{name}: Connection Timeout {error}'.format(name=self.name, error=msg), logger.WARNING)
             return False
         except Exception as msg:
-            logger.log(u'{name}: Unknown exception raised when send torrent to {name} : {error}'.format
+            logger.log('{name}: Unknown exception raised when send torrent to {name} : {error}'.format
                        (name=self.name, error=msg), logger.ERROR)
             return False
 
         if self.response.status_code == 401:
-            logger.log(u'{name}: Invalid Username or Password, check your config'.format
+            logger.log('{name}: Invalid Username or Password, check your config'.format
                        (name=self.name), logger.ERROR)
             return False
 
         code_description = http_code_description(self.response.status_code)
 
         if code_description is not None:
-            logger.log(u'{name}: {code}'.format(name=self.name, code=code_description), logger.INFO)
+            logger.log('{name}: {code}'.format(name=self.name, code=code_description), logger.INFO)
             return False
 
-        logger.log(u'{name}: Response to {method} request is {response}'.format
+        logger.log('{name}: Response to {method} request is {response}'.format
                    (name=self.name, method=method.upper(), response=self.response.text), logger.DEBUG)
 
         return True
@@ -160,8 +162,8 @@ class GenericClient(object):
                 info = torrent_bdecode['info']
                 result.hash = sha1(bencode(info)).hexdigest()
             except (BTFailure, KeyError):
-                logger.log(u'Unable to bdecode torrent. Invalid torrent', logger.WARNING)
-                logger.log(u'Deleting cached result if exists: {result}'.format(result=result.name), logger.DEBUG)
+                logger.log('Unable to bdecode torrent. Invalid torrent', logger.WARNING)
+                logger.log('Deleting cached result if exists: {result}'.format(result=result.name), logger.DEBUG)
                 cache_db_con = db.DBConnection('cache.db')
                 cache_db_con.action(
                     'DELETE FROM [{provider}] '
@@ -177,11 +179,11 @@ class GenericClient(object):
 
         r_code = False
 
-        logger.log(u'Calling {name} Client'.format(name=self.name), logger.DEBUG)
+        logger.log('Calling {name} Client'.format(name=self.name), logger.DEBUG)
 
         if not self.auth:
             if not self._get_auth():
-                logger.log(u'{name}: Authentication Failed'.format(name=self.name), logger.WARNING)
+                logger.log('{name}: Authentication Failed'.format(name=self.name), logger.WARNING)
                 return r_code
 
         try:
@@ -200,30 +202,30 @@ class GenericClient(object):
                 r_code = self._add_torrent_file(result)
 
             if not r_code:
-                logger.log(u'{name}: Unable to send Torrent'.format(name=self.name), logger.WARNING)
+                logger.log('{name}: Unable to send Torrent'.format(name=self.name), logger.WARNING)
                 return False
 
             if not self._set_torrent_pause(result):
-                logger.log(u'{name}: Unable to set the pause for Torrent'.format(name=self.name), logger.ERROR)
+                logger.log('{name}: Unable to set the pause for Torrent'.format(name=self.name), logger.ERROR)
 
             if not self._set_torrent_label(result):
-                logger.log(u'{name}: Unable to set the label for Torrent'.format(name=self.name), logger.ERROR)
+                logger.log('{name}: Unable to set the label for Torrent'.format(name=self.name), logger.ERROR)
 
             if not self._set_torrent_ratio(result):
-                logger.log(u'{name}: Unable to set the ratio for Torrent'.format(name=self.name), logger.ERROR)
+                logger.log('{name}: Unable to set the ratio for Torrent'.format(name=self.name), logger.ERROR)
 
             if not self._set_torrent_seed_time(result):
-                logger.log(u'{name}: Unable to set the seed time for Torrent'.format(name=self.name), logger.ERROR)
+                logger.log('{name}: Unable to set the seed time for Torrent'.format(name=self.name), logger.ERROR)
 
             if not self._set_torrent_path(result):
-                logger.log(u'{name}: Unable to set the path for Torrent'.format(name=self.name), logger.ERROR)
+                logger.log('{name}: Unable to set the path for Torrent'.format(name=self.name), logger.ERROR)
 
             if result.priority != 0 and not self._set_torrent_priority(result):
-                logger.log(u'{name}: Unable to set priority for Torrent'.format(name=self.name), logger.ERROR)
+                logger.log('{name}: Unable to set priority for Torrent'.format(name=self.name), logger.ERROR)
 
         except Exception as msg:
-            logger.log(u'{name}: Failed Sending Torrent'.format(name=self.name), logger.ERROR)
-            logger.log(u'{name}: Exception raised when sending torrent: {result}. Error: {error}'.format
+            logger.log('{name}: Failed Sending Torrent'.format(name=self.name), logger.ERROR)
+            logger.log('{name}: Exception raised when sending torrent: {result}. Error: {error}'.format
                        (name=self.name, result=result, error=msg), logger.DEBUG)
             return r_code
 
@@ -234,18 +236,18 @@ class GenericClient(object):
         try:
             self.response = self.session.get(self.url, timeout=120, verify=False)
         except requests.exceptions.ConnectionError:
-            return False, u'Error: {name} Connection Error'.format(name=self.name)
+            return False, 'Error: {name} Connection Error'.format(name=self.name)
         except (requests.exceptions.MissingSchema, requests.exceptions.InvalidURL):
-            return False, u'Error: Invalid {name} host'.format(name=self.name)
+            return False, 'Error: Invalid {name} host'.format(name=self.name)
 
         if self.response.status_code == 401:
-            return False, u'Error: Invalid {name} Username or Password, check your config!'.format(name=self.name)
+            return False, 'Error: Invalid {name} Username or Password, check your config!'.format(name=self.name)
 
         try:
             self._get_auth()
             if self.response.status_code == 200 and self.auth:
-                return True, u'Success: Connected and Authenticated'
+                return True, 'Success: Connected and Authenticated'
             else:
-                return False, u'Error: Unable to get {name} Authentication, check your config!'.format(name=self.name)
+                return False, 'Error: Unable to get {name} Authentication, check your config!'.format(name=self.name)
         except Exception:
-            return False, u'Error: Unable to connect to {name}'.format(name=self.name)
+            return False, 'Error: Unable to connect to {name}'.format(name=self.name)

--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -50,8 +50,8 @@ class GenericClient(object):
 
             return False
         try:
-            self.response = self.session.__getattribute__(method)(self.url, params=params, data=data, files=files, cookies=cookies,
-                                                                  timeout=120, verify=False)
+            self.response = self.session.__getattribute__(method)(self.url, params=params, data=data, files=files,
+                                                                  cookies=cookies, timeout=120, verify=False)
         except requests.exceptions.ConnectionError as msg:
             logger.log('{name}: Unable to connect {error}'.format
                        (name=self.name, error=msg), logger.ERROR)
@@ -129,7 +129,7 @@ class GenericClient(object):
 
     def _set_torrent_priority(self, result):  # pylint:disable=unused-argument, no-self-use
         """
-        This should be overriden should return the True/False from the client
+        This should be overridden should return the True/False from the client
         when a torrent is set with result.priority (-1 = low, 0 = normal, 1 = high)
         """
         return True

--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -152,13 +152,17 @@ class GenericClient(object):
 
             try:
                 torrent_bdecode = bdecode(result.content)
-                info = torrent_bdecode["info"]
+                info = torrent_bdecode['info']
                 result.hash = sha1(bencode(info)).hexdigest()
             except (BTFailure, KeyError):
                 logger.log(u'Unable to bdecode torrent. Invalid torrent', logger.WARNING)
                 logger.log(u'Deleting cached result if exists: {0}'.format(result.name), logger.DEBUG)
                 cache_db_con = db.DBConnection('cache.db')
-                cache_db_con.action("DELETE FROM [" + result.provider.get_id() + "] WHERE name = ? ", [result.name])
+                cache_db_con.action(
+                    'DELETE FROM [{provider}] '
+                    'WHERE name = ? '.format(provider=result.provider.get_id()),
+                    [result.name]
+                )
             except Exception:
                 logger.log(traceback.format_exc(), logger.ERROR)
 

--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -164,7 +164,7 @@ class GenericClient(object):
 
         return result
 
-    def sendTORRENT(self, result):
+    def send_torrent(self, result):
 
         r_code = False
 
@@ -219,7 +219,7 @@ class GenericClient(object):
 
         return r_code
 
-    def testAuthentication(self):
+    def test_authentication(self):
 
         try:
             self.response = self.session.get(self.url, timeout=120, verify=False)

--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -166,8 +166,8 @@ class GenericClient(object):
                 logger.log('Deleting cached result if exists: {result}'.format(result=result.name), logger.DEBUG)
                 cache_db_con = db.DBConnection('cache.db')
                 cache_db_con.action(
-                    'DELETE FROM [{provider}] '
-                    'WHERE name = ? '.format(provider=result.provider.get_id()),
+                    b'DELETE FROM [{provider}] '
+                    b'WHERE name = ? '.format(provider=result.provider.get_id()),
                     [result.name]
                 )
             except Exception:

--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -6,13 +6,15 @@ import re
 import time
 from hashlib import sha1
 from base64 import b16encode, b32decode
+import traceback
+
+from six.moves.http_cookiejar import CookieJar
+import requests
+from bencode import bencode, bdecode
+from bencode.BTL import BTFailure
 
 import sickbeard
 from sickbeard import logger, helpers, db
-from bencode import bencode, bdecode
-import requests
-import cookielib
-from bencode.BTL import BTFailure
 from sickrage.helper.common import http_code_description
 
 
@@ -31,7 +33,7 @@ class GenericClient(object):
         self.last_time = time.time()
         self.session = helpers.make_session()
         self.session.auth = (self.username, self.password)
-        self.session.cookies = cookielib.CookieJar()
+        self.session.cookies = CookieJar()
 
     def _request(self, method='get', params=None, data=None, files=None, cookies=None):
 
@@ -192,7 +194,7 @@ class GenericClient(object):
 
             # lazy fix for now, I'm sure we already do this somewhere else too
             result = self._get_torrent_hash(result)
-            
+
             if not result.hash:
                 return False
 

--- a/sickbeard/clients/mlnet_client.py
+++ b/sickbeard/clients/mlnet_client.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
+
 from sickbeard.clients.generic import GenericClient
 
 

--- a/sickbeard/clients/mlnet_client.py
+++ b/sickbeard/clients/mlnet_client.py
@@ -41,14 +41,14 @@ class MLNetAPI(GenericClient):
 
     def _add_torrent_uri(self, result):
 
-        self.url = self.host + 'submit'
-        params = {'q': 'dllink ' + result.url}
+        self.url = '{host}submit'.format(host=self.host)
+        params = {'q': 'dllink {url}'.format(url=result.url)}
         return self._request(method='get', params=params)
 
     def _add_torrent_file(self, result):
 
-        self.url = self.host + 'submit'
-        params = {'q': 'dllink ' + result.url}
+        self.url = '{host}submit'.format(host=self.host)
+        params = {'q': 'dllink {url}'.format(url=result.url)}
         return self._request(method='get', params=params)
 
 api = MLNetAPI()

--- a/sickbeard/clients/mlnet_client.py
+++ b/sickbeard/clients/mlnet_client.py
@@ -44,13 +44,17 @@ class MLNetAPI(GenericClient):
     def _add_torrent_uri(self, result):
 
         self.url = '{host}submit'.format(host=self.host)
-        params = {'q': 'dllink {url}'.format(url=result.url)}
+        params = {
+            'q': 'dllink {url}'.format(url=result.url),
+        }
         return self._request(method='get', params=params)
 
     def _add_torrent_file(self, result):
 
         self.url = '{host}submit'.format(host=self.host)
-        params = {'q': 'dllink {url}'.format(url=result.url)}
+        params = {
+            'q': 'dllink {url}'.format(url=result.url),
+        }
         return self._request(method='get', params=params)
 
 api = MLNetAPI()

--- a/sickbeard/clients/mlnet_client.py
+++ b/sickbeard/clients/mlnet_client.py
@@ -21,10 +21,10 @@
 from sickbeard.clients.generic import GenericClient
 
 
-class mlnetAPI(GenericClient):
+class MLNetAPI(GenericClient):
     def __init__(self, host=None, username=None, password=None):
 
-        super(mlnetAPI, self).__init__('mlnet', host, username, password)
+        super(MLNetAPI, self).__init__('mlnet', host, username, password)
 
         self.url = self.host
         # self.session.auth = HTTPDigestAuth(self.username, self.password);
@@ -51,4 +51,4 @@ class mlnetAPI(GenericClient):
         params = {'q': 'dllink ' + result.url}
         return self._request(method='get', params=params)
 
-api = mlnetAPI()
+api = MLNetAPI()

--- a/sickbeard/clients/qbittorrent_client.py
+++ b/sickbeard/clients/qbittorrent_client.py
@@ -35,7 +35,7 @@ class qbittorrentAPI(GenericClient):
     @property
     def api(self):
         try:
-            self.url = self.host + 'version/api'
+            self.url = '{host}version/api'.format(host=self.host)
             version = int(self.session.get(self.url, verify=sickbeard.TORRENT_VERIFY_CERT).content)
         except Exception:
             version = 1
@@ -44,7 +44,7 @@ class qbittorrentAPI(GenericClient):
     def _get_auth(self):
 
         if self.api > 1:
-            self.url = self.host + 'login'
+            self.url = '{host}login'.format(host=self.host)
             data = {'username': self.username, 'password': self.password}
             try:
                 self.response = self.session.post(self.url, data=data)
@@ -65,14 +65,14 @@ class qbittorrentAPI(GenericClient):
 
     def _add_torrent_uri(self, result):
 
-        self.url = self.host + 'command/download'
+        self.url = '{host}command/download'.format(host=self.host)
         data = {'urls': result.url}
         return self._request(method='post', data=data, cookies=self.session.cookies)
 
     def _add_torrent_file(self, result):
 
-        self.url = self.host + 'command/upload'
-        files = {'torrents': (result.name + '.torrent', result.content)}
+        self.url = '{host}command/upload'.format(host=self.host)
+        files = {'torrents': ('{result}.torrent'.format(result=result.name), result.content)}
         return self._request(method='post', files=files, cookies=self.session.cookies)
 
     def _set_torrent_label(self, result):
@@ -82,25 +82,25 @@ class qbittorrentAPI(GenericClient):
             label = sickbeard.TORRENT_LABEL_ANIME
 
         if self.api > 6 and label:
-            self.url = self.host + 'command/setLabel'
+            self.url = '{host}command/setLabel'.format(host=self.host)
             data = {'hashes': result.hash.lower(), 'label': label.replace(' ', '_')}
             return self._request(method='post', data=data, cookies=self.session.cookies)
         return None
 
     def _set_torrent_priority(self, result):
 
-        self.url = self.host + 'command/decreasePrio '
+        self.url = '{host}command/decreasePrio'.format(host=self.host)
         if result.priority == 1:
-            self.url = self.host + 'command/increasePrio'
+            self.url = '{host}command/increasePrio'.format(host=self.host)
 
         data = {'hashes': result.hash.lower()}
         return self._request(method='post', data=data, cookies=self.session.cookies)
 
     def _set_torrent_pause(self, result):
 
-        self.url = self.host + 'command/resume'
+        self.url = '{host}command/resume'.format(host=self.host)
         if sickbeard.TORRENT_PAUSED:
-            self.url = self.host + 'command/pause'
+            self.url = '{host}command/pause'.format(host=self.host)
 
         data = {'hash': result.hash}
         return self._request(method='post', data=data, cookies=self.session.cookies)

--- a/sickbeard/clients/qbittorrent_client.py
+++ b/sickbeard/clients/qbittorrent_client.py
@@ -18,9 +18,12 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
+
+from requests.auth import HTTPDigestAuth
+
 import sickbeard
 from sickbeard.clients.generic import GenericClient
-from requests.auth import HTTPDigestAuth
 
 
 class qbittorrentAPI(GenericClient):

--- a/sickbeard/clients/qbittorrent_client.py
+++ b/sickbeard/clients/qbittorrent_client.py
@@ -48,7 +48,10 @@ class qbittorrentAPI(GenericClient):
 
         if self.api > 1:
             self.url = '{host}login'.format(host=self.host)
-            data = {'username': self.username, 'password': self.password}
+            data = {
+                'username': self.username,
+                'password': self.password,
+            }
             try:
                 self.response = self.session.post(self.url, data=data)
             except Exception:
@@ -69,13 +72,20 @@ class qbittorrentAPI(GenericClient):
     def _add_torrent_uri(self, result):
 
         self.url = '{host}command/download'.format(host=self.host)
-        data = {'urls': result.url}
+        data = {
+            'urls': result.url,
+        }
         return self._request(method='post', data=data, cookies=self.session.cookies)
 
     def _add_torrent_file(self, result):
 
         self.url = '{host}command/upload'.format(host=self.host)
-        files = {'torrents': ('{result}.torrent'.format(result=result.name), result.content)}
+        files = {
+            'torrents': (
+                '{result}.torrent'.format(result=result.name),
+                result.content,
+            ),
+        }
         return self._request(method='post', files=files, cookies=self.session.cookies)
 
     def _set_torrent_label(self, result):
@@ -86,7 +96,10 @@ class qbittorrentAPI(GenericClient):
 
         if self.api > 6 and label:
             self.url = '{host}command/setLabel'.format(host=self.host)
-            data = {'hashes': result.hash.lower(), 'label': label.replace(' ', '_')}
+            data = {
+                'hashes': result.hash.lower(),
+                'label': label.replace(' ', '_'),
+            }
             return self._request(method='post', data=data, cookies=self.session.cookies)
         return None
 
@@ -96,7 +109,9 @@ class qbittorrentAPI(GenericClient):
         if result.priority == 1:
             self.url = '{host}command/increasePrio'.format(host=self.host)
 
-        data = {'hashes': result.hash.lower()}
+        data = {
+            'hashes': result.hash.lower(),
+        }
         return self._request(method='post', data=data, cookies=self.session.cookies)
 
     def _set_torrent_pause(self, result):
@@ -105,7 +120,9 @@ class qbittorrentAPI(GenericClient):
         if sickbeard.TORRENT_PAUSED:
             self.url = '{host}command/pause'.format(host=self.host)
 
-        data = {'hash': result.hash}
+        data = {
+            'hash': result.hash,
+        }
         return self._request(method='post', data=data, cookies=self.session.cookies)
 
 api = qbittorrentAPI()

--- a/sickbeard/clients/qbittorrent_client.py
+++ b/sickbeard/clients/qbittorrent_client.py
@@ -90,9 +90,7 @@ class qbittorrentAPI(GenericClient):
 
     def _set_torrent_label(self, result):
 
-        label = sickbeard.TORRENT_LABEL
-        if result.show.is_anime:
-            label = sickbeard.TORRENT_LABEL_ANIME
+        label = sickbeard.TORRENT_LABEL_ANIME if result.show.is_anime else sickbeard.TORRENT_LABEL
 
         if self.api > 6 and label:
             self.url = '{host}command/setLabel'.format(host=self.host)
@@ -105,21 +103,16 @@ class qbittorrentAPI(GenericClient):
 
     def _set_torrent_priority(self, result):
 
-        self.url = '{host}command/decreasePrio'.format(host=self.host)
-        if result.priority == 1:
-            self.url = '{host}command/increasePrio'.format(host=self.host)
-
+        self.url = '{host}command/{method}Prio'.format(host=self.host,
+                                                       method='increase' if result.priority == 1 else 'decrease')
         data = {
             'hashes': result.hash.lower(),
         }
         return self._request(method='post', data=data, cookies=self.session.cookies)
 
     def _set_torrent_pause(self, result):
-
-        self.url = '{host}command/resume'.format(host=self.host)
-        if sickbeard.TORRENT_PAUSED:
-            self.url = '{host}command/pause'.format(host=self.host)
-
+        self.url = '{host}command/{state}'.format(host=self.host,
+                                                  state='pause' if sickbeard.TORRENT_PAUSED else 'resume')
         data = {
             'hash': result.hash,
         }

--- a/sickbeard/clients/rtorrent_client.py
+++ b/sickbeard/clients/rtorrent_client.py
@@ -32,9 +32,9 @@ from sickbeard import logger, ex
 from sickbeard.clients.generic import GenericClient
 
 
-class rTorrentAPI(GenericClient):  # pylint: disable=invalid-name
+class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
     def __init__(self, host=None, username=None, password=None):
-        super(rTorrentAPI, self).__init__(u'rTorrent', host, username, password)
+        super(RTorrentAPI, self).__init__('rTorrent', host, username, password)
 
     def _get_auth(self):
         self.auth = None
@@ -175,7 +175,7 @@ class rTorrentAPI(GenericClient):  # pylint: disable=invalid-name
 
         return True
 
-    def testAuthentication(self):
+    def test_authentication(self):
         try:
             self._get_auth()
 
@@ -187,4 +187,4 @@ class rTorrentAPI(GenericClient):  # pylint: disable=invalid-name
             return False, u'Error: Unable to connect to {name}'.format(name=self.name)
 
 
-api = rTorrentAPI()  # pylint: disable=invalid-name
+api = RTorrentAPI()  # pylint: disable=invalid-name

--- a/sickbeard/clients/rtorrent_client.py
+++ b/sickbeard/clients/rtorrent_client.py
@@ -104,10 +104,6 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
         if not result:
             return False
 
-            # group_name = 'sb_test'.lower() ##### Use provider instead of _test
-            # if not self._set_torrent_ratio(group_name):
-            # return False
-
         # Send request to rTorrent
         try:
             # Send torrent to rTorrent
@@ -126,9 +122,6 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
             if sickbeard.TORRENT_PATH:
                 torrent.set_directory(sickbeard.TORRENT_PATH)
 
-            # Set Ratio Group
-            # torrent.set_visible(group_name)
-
             # Start torrent
             torrent.start()
 
@@ -140,39 +133,6 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
             return False
 
     def _set_torrent_ratio(self, name):
-
-        # if not name:
-        # return False
-        #
-        # if not self.auth:
-        # return False
-        #
-        # views = self.auth.get_views()
-        #
-        # if name not in views:
-        # self.auth.create_group(name)
-
-        # group = self.auth.get_group(name)
-
-        # ratio = int(float(sickbeard.TORRENT_RATIO) * 100)
-        #
-        # try:
-        # if ratio > 0:
-        #
-        # # Explicitly set all group options to ensure it is setup correctly
-        # group.set_upload('1M')
-        # group.set_min(ratio)
-        # group.set_max(ratio)
-        # group.set_command('d.stop')
-        # group.enable()
-        # else:
-        # # Reset group action and disable it
-        # group.set_command()
-        # group.disable()
-        #
-        # except:
-        # return False
-
         _ = name
 
         return True

--- a/sickbeard/clients/rtorrent_client.py
+++ b/sickbeard/clients/rtorrent_client.py
@@ -24,6 +24,8 @@
 # based on fuzemans work
 # https://github.com/RuudBurger/CouchPotatoServer/blob/develop/couchpotato/core/downloaders/rtorrent/main.py
 
+from __future__ import unicode_literals
+
 from rtorrent import RTorrent  # pylint: disable=import-error
 
 import sickbeard
@@ -90,7 +92,7 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
             return True
 
         except Exception as error:  # pylint: disable=broad-except
-            logger.log(u'Error while sending torrent: {error}'.format  # pylint: disable=no-member
+            logger.log('Error while sending torrent: {error}'.format  # pylint: disable=no-member
                        (error=ex(error)), logger.WARNING)
             return False
 
@@ -133,7 +135,7 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
             return True
 
         except Exception as error:  # pylint: disable=broad-except
-            logger.log(u'Error while sending torrent: {error}'.format  # pylint: disable=no-member
+            logger.log('Error while sending torrent: {error}'.format  # pylint: disable=no-member
                        (error=ex(error)), logger.WARNING)
             return False
 
@@ -180,11 +182,11 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
             self._get_auth()
 
             if self.auth is not None:
-                return True, u'Success: Connected and Authenticated'
+                return True, 'Success: Connected and Authenticated'
             else:
-                return False, u'Error: Unable to get {name} Authentication, check your config!'.format(name=self.name)
+                return False, 'Error: Unable to get {name} Authentication, check your config!'.format(name=self.name)
         except Exception:  # pylint: disable=broad-except
-            return False, u'Error: Unable to connect to {name}'.format(name=self.name)
+            return False, 'Error: Unable to connect to {name}'.format(name=self.name)
 
 
 api = RTorrentAPI()  # pylint: disable=invalid-name

--- a/sickbeard/clients/rtorrent_client.py
+++ b/sickbeard/clients/rtorrent_client.py
@@ -63,10 +63,7 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
 
     def _add_torrent_uri(self, result):
 
-        if not self.auth:
-            return False
-
-        if not result:
+        if not (self.auth or result):
             return False
 
         try:
@@ -88,20 +85,16 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
 
             # Start torrent
             torrent.start()
-
-            return True
-
         except Exception as error:  # pylint: disable=broad-except
             logger.log('Error while sending torrent: {error}'.format  # pylint: disable=no-member
                        (error=ex(error)), logger.WARNING)
             return False
+        else:
+            return True
 
     def _add_torrent_file(self, result):
 
-        if not self.auth:
-            return False
-
-        if not result:
+        if not (self.auth or result):
             return False
 
         # Send request to rTorrent
@@ -124,13 +117,12 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
 
             # Start torrent
             torrent.start()
-
-            return True
-
-        except Exception as error:  # pylint: disable=broad-except
+        except Exception as msg:  # pylint: disable=broad-except
             logger.log('Error while sending torrent: {error}'.format  # pylint: disable=no-member
-                       (error=ex(error)), logger.WARNING)
+                       (error=ex(msg)), logger.WARNING)
             return False
+        else:
+            return True
 
     def _set_torrent_ratio(self, name):
         _ = name
@@ -140,13 +132,12 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
     def test_authentication(self):
         try:
             self._get_auth()
-
-            if self.auth is not None:
-                return True, 'Success: Connected and Authenticated'
-            else:
-                return False, 'Error: Unable to get {name} Authentication, check your config!'.format(name=self.name)
         except Exception:  # pylint: disable=broad-except
             return False, 'Error: Unable to connect to {name}'.format(name=self.name)
-
+        else:
+            if self.auth is None:
+                return False, 'Error: Unable to get {name} Authentication, check your config!'.format(name=self.name)
+            else:
+                return True, 'Success: Connected and Authenticated'
 
 api = RTorrentAPI()  # pylint: disable=invalid-name

--- a/sickbeard/clients/rtorrent_client.py
+++ b/sickbeard/clients/rtorrent_client.py
@@ -39,8 +39,6 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
         super(RTorrentAPI, self).__init__('rTorrent', host, username, password)
 
     def _get_auth(self):
-        self.auth = None
-
         if self.auth is not None:
             return self.auth
 
@@ -131,6 +129,7 @@ class RTorrentAPI(GenericClient):  # pylint: disable=invalid-name
 
     def test_authentication(self):
         try:
+            self.auth = None
             self._get_auth()
         except Exception:  # pylint: disable=broad-except
             return False, 'Error: Unable to connect to {name}'.format(name=self.name)

--- a/sickbeard/clients/transmission_client.py
+++ b/sickbeard/clients/transmission_client.py
@@ -78,7 +78,7 @@ class TransmissionAPI(GenericClient):
 
         self._request(method='post', data=post_data)
 
-        return self.response.json()['result'] == "success"
+        return self.response.json()['result'] == 'success'
 
     def _add_torrent_file(self, result):
 
@@ -95,7 +95,7 @@ class TransmissionAPI(GenericClient):
 
         self._request(method='post', data=post_data)
 
-        return self.response.json()['result'] == "success"
+        return self.response.json()['result'] == 'success'
 
     def _set_torrent_ratio(self, result):
 
@@ -121,7 +121,7 @@ class TransmissionAPI(GenericClient):
 
         self._request(method='post', data=post_data)
 
-        return self.response.json()['result'] == "success"
+        return self.response.json()['result'] == 'success'
 
     def _set_torrent_seed_time(self, result):
 
@@ -136,7 +136,7 @@ class TransmissionAPI(GenericClient):
 
             self._request(method='post', data=post_data)
 
-            return self.response.json()['result'] == "success"
+            return self.response.json()['result'] == 'success'
         else:
             return True
 
@@ -161,7 +161,7 @@ class TransmissionAPI(GenericClient):
 
         self._request(method='post', data=post_data)
 
-        return self.response.json()['result'] == "success"
+        return self.response.json()['result'] == 'success'
 
 
 api = TransmissionAPI()

--- a/sickbeard/clients/transmission_client.py
+++ b/sickbeard/clients/transmission_client.py
@@ -25,6 +25,8 @@ import re
 import json
 from base64 import b64encode
 
+from requests.compat import urljoin
+
 import sickbeard
 from sickbeard.clients.generic import GenericClient
 
@@ -34,16 +36,8 @@ class TransmissionAPI(GenericClient):
 
         super(TransmissionAPI, self).__init__('Transmission', host, username, password)
 
-        if not self.host.endswith('/'):
-            self.host += '/'
-
-        if self.rpcurl.startswith('/'):
-            self.rpcurl = self.rpcurl[1:]
-
-        if self.rpcurl.endswith('/'):
-            self.rpcurl = self.rpcurl[:-1]
-
-        self.url = self.host + self.rpcurl + '/rpc'
+        self.rpcurl = self.rpcurl.strip('/')
+        self.url = urljoin(self.host, self.rpcurl + '/rpc')
 
     def _get_auth(self):
 

--- a/sickbeard/clients/transmission_client.py
+++ b/sickbeard/clients/transmission_client.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
+
 import os
 import re
 import json

--- a/sickbeard/clients/transmission_client.py
+++ b/sickbeard/clients/transmission_client.py
@@ -47,7 +47,9 @@ class TransmissionAPI(GenericClient):
 
     def _get_auth(self):
 
-        post_data = json.dumps({'method': 'session-get', })
+        post_data = json.dumps({
+            'method': 'session-get',
+        })
 
         try:
             self.response = self.session.post(self.url, data=post_data.encode('utf-8'), timeout=120,
@@ -59,8 +61,10 @@ class TransmissionAPI(GenericClient):
         self.session.headers.update({'x-transmission-session-id': self.auth})
 
         # Validating Transmission authorization
-        post_data = json.dumps({'arguments': {},
-                                'method': 'session-get'})
+        post_data = json.dumps({
+            'arguments': {},
+            'method': 'session-get',
+        })
 
         self._request(method='post', data=post_data)
 
@@ -75,8 +79,10 @@ class TransmissionAPI(GenericClient):
         if os.path.isabs(sickbeard.TORRENT_PATH):
             arguments['download-dir'] = sickbeard.TORRENT_PATH
 
-        post_data = json.dumps({'arguments': arguments,
-                                'method': 'torrent-add'})
+        post_data = json.dumps({
+            'arguments': arguments,
+            'method': 'torrent-add',
+        })
 
         self._request(method='post', data=post_data)
 
@@ -92,8 +98,10 @@ class TransmissionAPI(GenericClient):
         if os.path.isabs(sickbeard.TORRENT_PATH):
             arguments['download-dir'] = sickbeard.TORRENT_PATH
 
-        post_data = json.dumps({'arguments': arguments,
-                                'method': 'torrent-add'})
+        post_data = json.dumps({
+            'arguments': arguments,
+            'method': 'torrent-add',
+        })
 
         self._request(method='post', data=post_data)
 
@@ -114,12 +122,16 @@ class TransmissionAPI(GenericClient):
                 ratio = float(ratio)
                 mode = 1  # Stop seeding at seedRatioLimit
 
-        arguments = {'ids': [result.hash],
-                     'seedRatioLimit': ratio,
-                     'seedRatioMode': mode}
+        arguments = {
+            'ids': [result.hash],
+            'seedRatioLimit': ratio,
+            'seedRatioMode': mode,
+        }
 
-        post_data = json.dumps({'arguments': arguments,
-                                'method': 'torrent-set'})
+        post_data = json.dumps({
+            'arguments': arguments,
+            'method': 'torrent-set',
+        })
 
         self._request(method='post', data=post_data)
 
@@ -129,12 +141,16 @@ class TransmissionAPI(GenericClient):
 
         if sickbeard.TORRENT_SEED_TIME and sickbeard.TORRENT_SEED_TIME != -1:
             time = int(60 * float(sickbeard.TORRENT_SEED_TIME))
-            arguments = {'ids': [result.hash],
-                         'seedIdleLimit': time,
-                         'seedIdleMode': 1}
+            arguments = {
+                'ids': [result.hash],
+                'seedIdleLimit': time,
+                'seedIdleMode': 1,
+            }
 
-            post_data = json.dumps({'arguments': arguments,
-                                    'method': 'torrent-set'})
+            post_data = json.dumps({
+                'arguments': arguments,
+                'method': 'torrent-set',
+            })
 
             self._request(method='post', data=post_data)
 
@@ -158,8 +174,10 @@ class TransmissionAPI(GenericClient):
         else:
             arguments['priority-normal'] = []
 
-        post_data = json.dumps({'arguments': arguments,
-                                'method': 'torrent-set'})
+        post_data = json.dumps({
+            'arguments': arguments,
+            'method': 'torrent-set',
+        })
 
         self._request(method='post', data=post_data)
 

--- a/sickbeard/clients/utorrent_client.py
+++ b/sickbeard/clients/utorrent_client.py
@@ -38,8 +38,13 @@ class UTorrentAPI(GenericClient):
     def _request(self, method='get', params=None, data=None, files=None):
 
         # Workaround for uTorrent 2.2.1
-        # Need a odict but only supported in 2.7+ and sickrage is 2.6+
-        ordered_params = {'token': self.auth}
+        # Need an OrderedDict but only supported in 2.7+
+        # Medusa is no longer 2.6+
+
+        # TOD0: Replace this with an OrderedDict
+        ordered_params = {
+            'token': self.auth,
+        }
 
         for k, v in params.iteritems() or {}:
             ordered_params.update({k: v})

--- a/sickbeard/clients/utorrent_client.py
+++ b/sickbeard/clients/utorrent_client.py
@@ -24,10 +24,10 @@ import sickbeard
 from sickbeard.clients.generic import GenericClient
 
 
-class uTorrentAPI(GenericClient):
+class UTorrentAPI(GenericClient):
     def __init__(self, host=None, username=None, password=None):
 
-        super(uTorrentAPI, self).__init__('uTorrent', host, username, password)
+        super(UTorrentAPI, self).__init__('uTorrent', host, username, password)
 
         self.url = self.host + 'gui/'
 
@@ -40,7 +40,7 @@ class uTorrentAPI(GenericClient):
         for k, v in params.iteritems() or {}:
             ordered_params.update({k: v})
 
-        return super(uTorrentAPI, self)._request(method=method, params=ordered_params, data=data, files=files)
+        return super(UTorrentAPI, self)._request(method=method, params=ordered_params, data=data, files=files)
 
     def _get_auth(self):
 
@@ -139,4 +139,4 @@ class uTorrentAPI(GenericClient):
         return self._request(params=params)
 
 
-api = uTorrentAPI()
+api = UTorrentAPI()

--- a/sickbeard/clients/utorrent_client.py
+++ b/sickbeard/clients/utorrent_client.py
@@ -63,7 +63,10 @@ class UTorrentAPI(GenericClient):
 
     def _add_torrent_uri(self, result):
 
-        params = {'action': 'add-url', 's': result.url}
+        params = {
+            'action': 'add-url',
+            's': result.url,
+        }
         return self._request(params=params)
 
     def _add_torrent_file(self, result):
@@ -86,10 +89,12 @@ class UTorrentAPI(GenericClient):
         if result.show.is_anime and sickbeard.TORRENT_LABEL_ANIME:
             label = sickbeard.TORRENT_LABEL_ANIME
 
-        params = {'action': 'setprops',
-                  'hash': result.hash,
-                  's': 'label',
-                  'v': label}
+        params = {
+            'action': 'setprops',
+            'hash': result.hash,
+            's': 'label',
+            'v': label,
+        }
 
         return self._request(params=params)
 
@@ -100,16 +105,20 @@ class UTorrentAPI(GenericClient):
             ratio = result.ratio
 
         if ratio:
-            params = {'action': 'setprops',
-                      'hash': result.hash,
-                      's': 'seed_override',
-                      'v': '1'}
+            params = {
+                'action': 'setprops',
+                'hash': result.hash,
+                's': 'seed_override',
+                'v': '1',
+            }
 
             if self._request(params=params):
-                params = {'action': 'setprops',
-                          'hash': result.hash,
-                          's': 'seed_ratio',
-                          'v': float(ratio) * 10}
+                params = {
+                    'action': 'setprops',
+                    'hash': result.hash,
+                    's': 'seed_ratio',
+                    'v': float(ratio) * 10,
+                }
 
                 return self._request(params=params)
             else:
@@ -121,16 +130,20 @@ class UTorrentAPI(GenericClient):
 
         if sickbeard.TORRENT_SEED_TIME:
             time = 3600 * float(sickbeard.TORRENT_SEED_TIME)
-            params = {'action': 'setprops',
-                      'hash': result.hash,
-                      's': 'seed_override',
-                      'v': '1'}
+            params = {
+                'action': 'setprops',
+                'hash': result.hash,
+                's': 'seed_override',
+                'v': '1',
+            }
 
             if self._request(params=params):
-                params = {'action': 'setprops',
-                          'hash': result.hash,
-                          's': 'seed_time',
-                          'v': time}
+                params = {
+                    'action': 'setprops',
+                    'hash': result.hash,
+                    's': 'seed_time',
+                    'v': time,
+                }
 
                 return self._request(params=params)
             else:
@@ -141,7 +154,10 @@ class UTorrentAPI(GenericClient):
     def _set_torrent_priority(self, result):
 
         if result.priority == 1:
-            params = {'action': 'queuetop', 'hash': result.hash}
+            params = {
+                'action': 'queuetop',
+                'hash': result.hash,
+            }
             return self._request(params=params)
         else:
             return True
@@ -149,9 +165,15 @@ class UTorrentAPI(GenericClient):
     def _set_torrent_pause(self, result):
 
         if sickbeard.TORRENT_PAUSED:
-            params = {'action': 'pause', 'hash': result.hash}
+            params = {
+                'action': 'pause',
+                'hash': result.hash,
+            }
         else:
-            params = {'action': 'start', 'hash': result.hash}
+            params = {
+                'action': 'start',
+                'hash': result.hash,
+            }
 
         return self._request(params=params)
 

--- a/sickbeard/clients/utorrent_client.py
+++ b/sickbeard/clients/utorrent_client.py
@@ -18,6 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
+
+import logging
 import re
 
 from requests.compat import urljoin

--- a/sickbeard/clients/utorrent_client.py
+++ b/sickbeard/clients/utorrent_client.py
@@ -46,7 +46,7 @@ class UTorrentAPI(GenericClient):
 
         try:
             self.response = self.session.get(self.url + 'token.html', verify=False)
-            self.auth = re.findall("<div.*?>(.*?)</", self.response.text)[0]
+            self.auth = re.findall('<div.*?>(.*?)</', self.response.text)[0]
         except Exception:
             return None
 

--- a/sickbeard/clients/utorrent_client.py
+++ b/sickbeard/clients/utorrent_client.py
@@ -28,6 +28,9 @@ from requests.compat import urljoin
 import sickbeard
 from sickbeard.clients.generic import GenericClient
 
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
 
 class UTorrentAPI(GenericClient):
     def __init__(self, host=None, username=None, password=None):
@@ -35,7 +38,11 @@ class UTorrentAPI(GenericClient):
         super(UTorrentAPI, self).__init__('uTorrent', host, username, password)
         self.url = urljoin(self.host, 'gui/')
 
-    def _request(self, method='get', params=None, data=None, files=None):
+    def _request(self, method='get', params=None, data=None, files=None, cookies=None):
+
+        if cookies:
+            log.debug('{name}: Received unused argument {arg}: {value}'.format
+                      (name=self.name, arg='cookies', value=cookies))
 
         # Workaround for uTorrent 2.2.1
         # Need an OrderedDict but only supported in 2.7+

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -23,6 +23,7 @@ import io
 import ctypes
 import re
 import socket
+import ssl
 import stat
 import tempfile
 import time
@@ -1532,6 +1533,54 @@ def download_file(url, filename, session=None, headers=None, **kwargs):  # pylin
         return False
 
     return True
+
+
+def handle_requests_exception(requests_exception):  # pylint: disable=too-many-branches, too-many-statements
+    default = "Request failed: {0}"
+    try:
+        raise requests_exception
+    except requests.exceptions.SSLError as error:
+        if ssl.OPENSSL_VERSION_INFO < (1, 0, 1, 5):
+            logger.log("SSL Error requesting url: '{0}' You have {1}, try upgrading OpenSSL to 1.0.1e+".format(
+                error.request.url, ssl.OPENSSL_VERSION))
+        if sickbeard.SSL_VERIFY:
+            logger.log(
+                "SSL Error requesting url: '{0}' Try disabling Cert Verification on the advanced tab of /config/general")
+        logger.log(default.format(error), logger.DEBUG)
+        logger.log(traceback.format_exc(), logger.DEBUG)
+
+    except requests.exceptions.HTTPError as error:
+        logger.log(default.format(error))
+    except requests.exceptions.TooManyRedirects as error:
+        logger.log(default.format(error))
+    except requests.exceptions.ConnectTimeout as error:
+        logger.log(default.format(error))
+    except requests.exceptions.ReadTimeout as error:
+        logger.log(default.format(error))
+    except requests.exceptions.ProxyError as error:
+        logger.log(default.format(error))
+    except requests.exceptions.ConnectionError as error:
+        logger.log(default.format(error))
+    except requests.exceptions.ContentDecodingError as error:
+        logger.log(default.format(error))
+        logger.log(traceback.format_exc(), logger.DEBUG)
+    except requests.exceptions.ChunkedEncodingError as error:
+        logger.log(default.format(error))
+    except requests.exceptions.InvalidURL as error:
+        logger.log(default.format(error))
+    except requests.exceptions.InvalidSchema as error:
+        logger.log(default.format(error))
+    except requests.exceptions.MissingSchema as error:
+        logger.log(default.format(error))
+    except requests.exceptions.RetryError as error:
+        logger.log(default.format(error))
+    except requests.exceptions.StreamConsumedError as error:
+        logger.log(default.format(error))
+    except requests.exceptions.URLRequired as error:
+        logger.log(default.format(error))
+    except Exception as error:
+        logger.log(default.format(error), logger.ERROR)
+        logger.log(traceback.format_exc(), logger.DEBUG)
 
 
 def get_size(start_path='.'):

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1549,34 +1549,7 @@ def handle_requests_exception(requests_exception):  # pylint: disable=too-many-b
         logger.log(default.format(error), logger.DEBUG)
         logger.log(traceback.format_exc(), logger.DEBUG)
 
-    except requests.exceptions.HTTPError as error:
-        logger.log(default.format(error))
-    except requests.exceptions.TooManyRedirects as error:
-        logger.log(default.format(error))
-    except requests.exceptions.ConnectTimeout as error:
-        logger.log(default.format(error))
-    except requests.exceptions.ReadTimeout as error:
-        logger.log(default.format(error))
-    except requests.exceptions.ProxyError as error:
-        logger.log(default.format(error))
-    except requests.exceptions.ConnectionError as error:
-        logger.log(default.format(error))
-    except requests.exceptions.ContentDecodingError as error:
-        logger.log(default.format(error))
-        logger.log(traceback.format_exc(), logger.DEBUG)
-    except requests.exceptions.ChunkedEncodingError as error:
-        logger.log(default.format(error))
-    except requests.exceptions.InvalidURL as error:
-        logger.log(default.format(error))
-    except requests.exceptions.InvalidSchema as error:
-        logger.log(default.format(error))
-    except requests.exceptions.MissingSchema as error:
-        logger.log(default.format(error))
-    except requests.exceptions.RetryError as error:
-        logger.log(default.format(error))
-    except requests.exceptions.StreamConsumedError as error:
-        logger.log(default.format(error))
-    except requests.exceptions.URLRequired as error:
+    except requests.exceptions.RequestException as error:
         logger.log(default.format(error))
     except Exception as error:
         logger.log(default.format(error), logger.ERROR)

--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -23,7 +23,7 @@ normal_regexes = [
     ('standard_repeat',
      # Show.Name.S01E02.S01E03.Source.Quality.Etc-Group
      # Show Name - S01E02 - S01E03 - S01E04 - Ep Name
-     r'''
+     r"""
      ^(?P<series_name>.+?)[. _-]+                # Show_Name and separator
      s(?P<season_num>\d+)[. _-]*                 # S01 and optional separator
      e(?P<ep_num>\d+)                            # E02 and separator
@@ -32,11 +32,11 @@ normal_regexes = [
      [. _-]*((?P<extra_info>.+?)                 # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$              # Group
-     '''),
+     """),
     ('fov_repeat',
      # Show.Name.1x02.1x03.Source.Quality.Etc-Group
      # Show Name - 1x02 - 1x03 - 1x04 - Ep Name
-     r'''
+     r"""
      ^(?P<series_name>.+?)[. _-]+                # Show_Name and separator
      (?P<season_num>\d+)x                        # 1x
      (?P<ep_num>\d+)                             # 02 and separator
@@ -45,7 +45,7 @@ normal_regexes = [
      [. _-]*((?P<extra_info>.+?)                 # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$              # Group
-     '''),
+     """),
     ('standard',
      # Show.Name.S01E02.Source.Quality.Etc-Group
      # Show Name - S01E02 - My Ep Name
@@ -53,7 +53,7 @@ normal_regexes = [
      # Show.Name.S01E02E03.Source.Quality.Etc-Group
      # Show Name - S01E02-03 - My Ep Name
      # Show.Name.S01.E02.E03
-     r'''
+     r"""
      ^((?P<series_name>.+?)[. _-]+)?             # Show_Name and separator
      \(?s(?P<season_num>\d+)[. _-]*              # S01 and optional separator
      e(?P<ep_num>\d+)\)?                         # E02 and separator
@@ -62,24 +62,24 @@ normal_regexes = [
      ([. _,-]+((?P<extra_info>.+?)                 # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?)?$              # Group
-     '''),
+     """),
     ('newpct',
      # American Horror Story - Temporada 4 HDTV x264[Cap.408_409]SPANISH AUDIO -NEWPCT
      # American Horror Story - Temporada 4 [HDTV][Cap.408][Espanol Castellano]
      # American Horror Story - Temporada 4 HDTV x264[Cap.408]SPANISH AUDIO –NEWPCT)
-     r'''
+     r"""
      (?P<series_name>.+?).-.+\d{1,2}[ ,.]       # Show name: American Horror Story
      (?P<extra_info>.+)\[Cap\.                   # Quality: HDTV x264, [HDTV], HDTV x264
      (?P<season_num>\d{1,2})                     # Season Number: 4
      (?P<ep_num>\d{2})                           # Episode Number: 08
      ((_\d{1,2}(?P<extra_ep_num>\d{2}))|.*\])     # Episode number2: 09
-     '''),
+     """),
     ('fov',
      # Show_Name.1x02.Source_Quality_Etc-Group
      # Show Name - 1x02 - My Ep Name
      # Show_Name.1x02x03x04.Source_Quality_Etc-Group
      # Show Name - 1x02-03-04 - My Ep Name
-     r'''
+     r"""
      ^((?P<series_name>.+?)[\[. _-]+)?           # Show_Name and separator
      (?P<season_num>\d+)x                        # 1x
      (?P<ep_num>\d+)                             # 02 and separator
@@ -90,60 +90,60 @@ normal_regexes = [
      [\]. _-]*((?P<extra_info>.+?)               # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$              # Group
-     '''),
+     """),
     ('scene_date_format',
      # Show.Name.2010.11.23.Source.Quality.Etc-Group
      # Show Name - 2010-11-23 - Ep Name
-     r'''
+     r"""
      ^((?P<series_name>.+?)[. _-]+)?             # Show_Name and separator
      (?P<air_date>(\d+[. _-]\d+[. _-]\d+)|(\d+\w+[. _-]\w+[. _-]\d+))
      [. _-]*((?P<extra_info>.+?)                 # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$              # Group
-     '''),
+     """),
     ('scene_sports_format',
      # Show.Name.100.Event.2010.11.23.Source.Quality.Etc-Group
      # Show.Name.2010.11.23.Source.Quality.Etc-Group
      # Show Name - 2010-11-23 - Ep Name
-     r'''
+     r"""
      ^(?P<series_name>.*?(UEFA|MLB|ESPN|WWE|MMA|UFC|TNA|EPL|NASCAR|NBA|NFL|NHL|NRL|PGA|SUPER LEAGUE|FORMULA|FIFA|NETBALL|MOTOGP).*?)[. _-]+
      ((?P<series_num>\d{1,3})[. _-]+)?
      (?P<air_date>(\d+[. _-]\d+[. _-]\d+)|(\d+\w+[. _-]\w+[. _-]\d+))[. _-]+
      ((?P<extra_info>.+?)((?<![. _-])
      (?<!WEB)-(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$
-     '''),
+     """),
     ('stupid',
      # tpz-abc102
-     r'''
+     r"""
      (?P<release_group>.+?)(?<!WEB)-\w+?[\. ]?           # tpz-abc
      (?!264)                                     # don't count x264
      (?P<season_num>\d{1,2})                     # 1
      (?P<ep_num>\d{2})$                          # 02
-     '''),
+     """),
     ('verbose',
      # Show Name Season 1 Episode 2 Ep Name
-     r'''
+     r"""
      ^(?P<series_name>.+?)[. _-]+                # Show Name and separator
      (season|series)[. _-]+                      # season and separator
      (?P<season_num>\d+)[. _-]+                  # 1
      episode[. _-]+                              # episode and separator
      (?P<ep_num>\d+)[. _-]+                      # 02 and separator
      (?P<extra_info>.+)$                         # Source_Quality_Etc-
-     '''),
+     """),
     ('season_only',
      # Show.Name.S01.Source.Quality.Etc-Group
-     r'''
+     r"""
      ^((?P<series_name>.+?)[. _-]+)?             # Show_Name and separator
      s(eason[. _-])?                             # S01/Season 01
      (?P<season_num>\d+)[. _-]*                  # S01 and optional separator
      [. _-]*((?P<extra_info>.+?)                 # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$              # Group
-     '''),
+     """),
     ('no_season_multi_ep',
      # Show.Name.E02-03
      # Show.Name.E02.2010
-     r'''
+     r"""
      ^((?P<series_name>.+?)[. _-]+)?             # Show_Name and separator
      (e(p(isode)?)?|part|pt)[. _-]?              # e, ep, episode, or part
      (?P<ep_num>(\d+|(?<!e)[ivx]+))                    # first ep num
@@ -152,12 +152,12 @@ normal_regexes = [
      ([. _-]*(?P<extra_info>.+?)                 # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$              # Group
-     '''),
+     """),
     ('no_season_general',
      # Show.Name.E23.Test
      # Show.Name.Part.3.Source.Quality.Etc-Group
      # Show.Name.Part.1.and.Part.2.Blah-Group
-     r'''
+     r"""
      ^((?P<series_name>.+?)[. _-]+)?             # Show_Name and separator
      (e(p(isode)?)?|part|pt)[. _-]?              # e, ep, episode, or part
      (?P<ep_num>(\d+|((?<!e)[ivx]+(?=[. _-]))))                    # first ep num
@@ -168,21 +168,21 @@ normal_regexes = [
      ([. _-]*(?P<extra_info>.+?)                 # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$              # Group
-     '''),
+     """),
     ('bare',
      # Show.Name.102.Source.Quality.Etc-Group
-     r'''
+     r"""
      ^(?P<series_name>.+?)[. _-]+                # Show_Name and separator
      (?P<season_num>\d{1,2})                     # 1
      (?P<ep_num>\d{2})                           # 02 and separator
      ([. _-]+(?P<extra_info>(?!\d{3}[. _-]+)[^-]+) # Source_Quality_Etc-
      (-(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$                # Group
-     '''),
+     """),
     ('no_season',
      # Show Name - 01 - Ep Name
      # 01 - Ep Name
      # 01 - Ep Name
-     r'''
+     r"""
      ^((?P<series_name>.+?)(?:[. _-]{2,}|[. _]))?    # Show_Name and separator
      (?P<ep_num>\d{1,3})                             # 02
      (?:-(?P<extra_ep_num>\d{1,3}))*                 # -03-04-05 etc
@@ -190,13 +190,13 @@ normal_regexes = [
      [. _-]+((?P<extra_info>.+?)                     # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                            # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$  # Group
-     '''),
+     """),
 ]
 
 anime_regexes = [
     ('anime_horriblesubs',
      # [HorribleSubs] Maria the Virgin Witch - 01 [720p].mkv
-     r'''
+     r"""
      ^(?:\[(?P<release_group>HorribleSubs)\][\s\.])
      (?:(?P<series_name>.+?)[\s\.]-[\s\.])
      (?P<ep_ab_num>((?!(1080|720|480)[pi]))\d{1,3})
@@ -205,9 +205,9 @@ anime_regexes = [
      (?:[\w\.\s]*)
      (?:(?:(?:[\[\(])(?P<extra_info>\d{3,4}[xp]?\d{0,4}[\.\w\s-]*)(?:[\]\)]))|(?:\d{3,4}[xp]))
      .*?
-     '''),
+     """),
     ('anime_ultimate',
-     r'''
+     r"""
      ^(?:\[(?P<release_group>.+?)\][ ._-]*)
      (?P<series_name>.+?)[ ._-]+
      (?P<ep_ab_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3})
@@ -217,7 +217,7 @@ anime_regexes = [
      (?:(?:(?:[\[\(])(?P<extra_info>\d{3,4}[xp]?\d{0,4}[\.\w\s-]*)(?:[\]\)]))|(?:\d{3,4}[xp]))
      (?:[ ._]?\[(?P<crc>\w+)\])?
      .*?
-     '''),
+     """),
     ('anime_french_fansub',
      # [Kaerizaki-Fansub]_One_Piece_727_[VOSTFR][HD_1280x720].mp4
      # [Titania-Fansub]_Fairy_Tail_269_[VOSTFR]_[720p]_[1921E00C].mp4
@@ -231,7 +231,7 @@ anime_regexes = [
      # Detective Conan 804 vostfr HD
      # Active Raid 04 vostfr [1080p]
      # Sekko Boys 04 vostfr [720p]
-     r'''
+     r"""
      ^(\[(?P<release_group>.+?)\][ ._-]*)?                                                     # Release Group and separator (Optional)
      ((\[|\().+?(\]|\))[ ._-]*)?                                                               # Extra info (Optionnal)
      (?P<series_name>.+?)[ ._-]+                                                               # Show_Name and separator
@@ -243,7 +243,7 @@ anime_regexes = [
      ((\[|\()((FHD|HD|SD)*([ ._-])*((?P<extra_info>\d{3,4}[xp*]?\d{0,4}[\.\w\s-]*)))(\]|\)))?  # Source_Quality_Etc-
      ([ ._-]*\[(?P<crc>\w{8})\])?                                                              # CRC (Optional)
      .*                                                                                        # Separator and EOL
-     '''),
+     """),
     ('anime_standard',
      # [Group Name] Show Name.13-14
      # [Group Name] Show Name - 13-14
@@ -251,7 +251,7 @@ anime_regexes = [
      # [Group Name] Show Name.13
      # [Group Name] Show Name - 13
      # Show Name 13
-     r'''
+     r"""
      ^(\[(?P<release_group>.+?)\][ ._-]*)?                        # Release Group and separator
      (?P<series_name>.+?)[ ._-]+                                 # Show_Name and separator
      (?P<ep_ab_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3})                                       # E01
@@ -260,11 +260,11 @@ anime_regexes = [
      [ ._-]+\[(?P<extra_info>\d{3,4}[xp]?\d{0,4}[\.\w\s-]*)\]       # Source_Quality_Etc-
      (\[(?P<crc>\w{8})\])?                                        # CRC
      .*?                                                          # Separator and EOL
-     '''),
+     """),
     ('anime_standard_round',
      # [Stratos-Subs]_Infinite_Stratos_-_12_(1280x720_H.264_AAC)_[379759DB]
      # [ShinBunBu-Subs] Bleach - 02-03 (CX 1280x720 x264 AAC)
-     r'''
+     r"""
      ^(\[(?P<release_group>.+?)\][ ._-]*)?                                    # Release Group and separator
      (?P<series_name>.+?)[ ._-]+                                              # Show_Name and separator
      (?P<ep_ab_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3})                                                   # E01
@@ -273,10 +273,10 @@ anime_regexes = [
      [ ._-]+\((?P<extra_info>(CX[ ._-]?)?\d{3,4}[xp]?\d{0,4}[\.\w\s-]*)\)     # Source_Quality_Etc-
      (\[(?P<crc>\w{8})\])?                                                    # CRC
      .*?                                                                      # Separator and EOL
-     '''),
+     """),
     ('anime_slash',
      # [SGKK] Bleach 312v1 [720p/MKV]
-     r'''
+     r"""
      ^(\[(?P<release_group>.+?)\][ ._-]*)? # Release Group and separator
      (?P<series_name>.+?)[ ._-]+           # Show_Name and separator
      (?P<ep_ab_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3})                # E01
@@ -285,12 +285,12 @@ anime_regexes = [
      [ ._-]+\[(?P<extra_info>\d{3,4}p)     # Source_Quality_Etc-
      (\[(?P<crc>\w{8})\])?                 # CRC
      .*?                                   # Separator and EOL
-     '''),
+     """),
     ('anime_standard_codec',
      # [Ayako]_Infinite_Stratos_-_IS_-_07_[H264][720p][EB7838FC]
      # [Ayako] Infinite Stratos - IS - 07v2 [H264][720p][44419534]
      # [Ayako-Shikkaku] Oniichan no Koto Nanka Zenzen Suki Janain Dakara ne - 10 [LQ][h264][720p] [8853B21C]
-     r'''
+     r"""
      ^(\[(?P<release_group>.+?)\][ ._-]*)?                        # Release Group and separator
      (?P<series_name>.+?)[ ._]*                                   # Show_Name and separator
      ([ ._-]+-[ ._-]+[A-Z]+[ ._-]+)?[ ._-]+                       # funny stuff, this is sooo nuts ! this will kick me in the butt one day
@@ -301,16 +301,16 @@ anime_regexes = [
      [ ._-]*\[(?P<extra_info>(\d{3,4}[xp]?\d{0,4})?[\.\w\s-]*)\]    # Source_Quality_Etc-
      (\[(?P<crc>\w{8})\])?
      .*?                                                          # Separator and EOL
-     '''),
+     """),
     ('anime_codec_crc',
-     r'''
+     r"""
      ^(?:\[(?P<release_group>.*?)\][ ._-]*)?
      (?:(?P<series_name>.*?)[ ._-]*)?
      (?:(?P<ep_ab_num>(((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3}))[ ._-]*).+?
      (?:\[(?P<codec>.*?)\][ ._-]*)
      (?:\[(?P<crc>\w{8})\])?
      .*?
-     '''),
+     """),
     ('anime_SxxExx',
      # Show.Name.S01E02.Source.Quality.Etc-Group
      # Show Name - S01E02 - My Ep Name
@@ -318,7 +318,7 @@ anime_regexes = [
      # Show.Name.S01E02E03.Source.Quality.Etc-Group
      # Show Name - S01E02-03 - My Ep Name
      # Show.Name.S01.E02.E03
-     r'''
+     r"""
      ^((?P<series_name>.+?)[. _-]+)?             # Show_Name and separator
      (\()?s(?P<season_num>\d+)[. _-]*            # S01 and optional separator
      e(?P<ep_num>\d+)(\))?                       # E02 and separator
@@ -327,12 +327,12 @@ anime_regexes = [
      [. _-]*((?P<extra_info>.+?)                 # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$              # Group
-     '''),
+     """),
     ('anime_and_normal',
      # Bleach - s16e03-04 - 313-314
      # Bleach.s16e03-04.313-314
      # Bleach s16e03e04 313-314
-     r'''
+     r"""
      ^(?P<series_name>.+?)[ ._-]+                 # start of string and series name and non optinal separator
      [sS](?P<season_num>\d+)[. _-]*               # S01 and optional separator
      [eE](?P<ep_num>\d+)                          # epipisode E02
@@ -343,12 +343,12 @@ anime_regexes = [
      (-(?P<extra_ab_ep_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3}))?             # "-" as separator and anditional absolute number, all optinal
      (v(?P<version>[0-9]))?                       # the version e.g. "v2"
      .*?
-     '''),
+     """),
     ('anime_and_normal_x',
      # Bleach - s16e03-04 - 313-314
      # Bleach.s16e03-04.313-314
      # Bleach s16e03e04 313-314
-     r'''
+     r"""
      ^(?P<series_name>.+?)[ ._-]+                 # start of string and series name and non optinal separator
      (?P<season_num>\d+)[. _-]*               # S01 and optional separator
      [xX](?P<ep_num>\d+)                          # epipisode E02
@@ -359,10 +359,10 @@ anime_regexes = [
      (-(?P<extra_ab_ep_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3}))?             # "-" as separator and anditional absolute number, all optinal
      (v(?P<version>[0-9]))?                       # the version e.g. "v2"
      .*?
-     '''),
+     """),
     ('anime_and_normal_reverse',
      # Bleach - 313-314 - s16e03-04
-     r'''
+     r"""
      ^(?P<series_name>.+?)[ ._-]+                 # start of string and series name and non optinal separator
      (?P<ep_ab_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3})                       # absolute number
      (-(?P<extra_ab_ep_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3}))?             # "-" as separator and anditional absolute number, all optinal
@@ -373,10 +373,10 @@ anime_regexes = [
      (([. _-]*e|-)                                # linking e/- char
      (?P<extra_ep_num>\d+))*                      # additional E03/etc
      .*?
-     '''),
+     """),
     ('anime_and_normal_front',
      # 165.Naruto Shippuuden.s08e014
-     r'''
+     r"""
      ^(?P<ep_ab_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3})                       # start of string and absolute number
      (-(?P<extra_ab_ep_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3}))?              # "-" as separator and anditional absolute number, all optinal
      (v(?P<version>[0-9]))?[ ._-]+                 # the version e.g. "v2"
@@ -386,9 +386,9 @@ anime_regexes = [
      (([. _-]*e|-)                               # linking e/- char
      (?P<extra_ep_num>\d+))*                      # additional E03/etc
      .*?
-     '''),
+     """),
     ('anime_ep_name',
-     r'''
+     r"""
      ^(?:\[(?P<release_group>.+?)\][ ._-]*)
      (?P<series_name>.+?)[ ._-]+
      (?P<ep_ab_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3})
@@ -398,22 +398,22 @@ anime_regexes = [
      \[(?P<extra_info>\w+)\][ ._-]?
      (?:\[(?P<crc>\w{8})\])?
      .*?
-     '''),
+     """),
     ('anime_WarB3asT',
      # 003. Show Name - Ep Name.ext
      # 003-004. Show Name - Ep Name.ext
-     r'''
+     r"""
      ^(?P<ep_ab_num>\d{3,4})(-(?P<extra_ab_ep_num>\d{3,4}))?\.\s+(?P<series_name>.+?)\s-\s.*
-     '''),
+     """),
     ('anime_bare',
      # One Piece - 102
      # [ACX]_Wolf's_Spirit_001.mkv
-     r'''
+     r"""
      ^(\[(?P<release_group>.+?)\][ ._-]*)?
      (?P<series_name>.+?)[ ._-]+                         # Show_Name and separator
      (?P<ep_ab_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3})            # E01
      (-(?P<extra_ab_ep_num>((?!(1080|720|480)[pi])|(?![hx].?264))\d{1,3}))?  # E02
      (v(?P<version>[0-9]))?                                                  # v2
      .*?                                                                     # Separator and EOL
-     ''')
+     """)
 ]

--- a/sickbeard/notifiers/boxcar2.py
+++ b/sickbeard/notifiers/boxcar2.py
@@ -35,7 +35,7 @@ class Notifier(object):
         return self._sendBoxcar2('This is a test notification from Medusa', title, accesstoken)
 
     def _sendBoxcar2(self, msg, title, accesstoken):
-        '''
+        """
         Sends a boxcar2 notification to the address provided
 
         msg: The message to send
@@ -43,7 +43,7 @@ class Notifier(object):
         accesstoken: to send to this device
 
         returns: True if the message succeeded, False otherwise
-        '''
+        """
         # http://blog.boxcar.io/post/93211745502/boxcar-api-update-boxcar-api-update-icon-and
 
         post_data = {
@@ -86,13 +86,13 @@ class Notifier(object):
         self._notifyBoxcar2(title, update_text.format(ipaddress))
 
     def _notifyBoxcar2(self, title, message, accesstoken=None):
-        '''
+        """
         Sends a boxcar2 notification based on the provided info or SB config
 
         title: The title of the notification to send
         message: The message string to send
         accesstoken: to send to this device
-        '''
+        """
 
         if not sickbeard.USE_BOXCAR2:
             logger.log('Notification for Boxcar2 not enabled, skipping this notification', logger.DEBUG)

--- a/sickbeard/notifiers/emailnotify.py
+++ b/sickbeard/notifiers/emailnotify.py
@@ -56,12 +56,12 @@ class Notifier(object):
         return self._sendmail(host, port, smtp_from, use_tls, user, pwd, [to], msg, True)
 
     def notify_snatch(self, ep_name, title='Snatched:'):  # pylint: disable=unused-argument
-        '''
+        """
         Send a notification that an episode was snatched
 
         ep_name: The name of the episode that was snatched
         title: The title of the notification (optional)
-        '''
+        """
         ep_name = ss(ep_name)
 
         if sickbeard.USE_EMAIL and sickbeard.EMAIL_NOTIFY_ONSNATCH:
@@ -102,12 +102,12 @@ class Notifier(object):
                     logger.log('Snatch notification error: {}'.format(self.last_err), logger.WARNING)
 
     def notify_download(self, ep_name, title='Completed:'):  # pylint: disable=unused-argument
-        '''
+        """
         Send a notification that an episode was downloaded
 
         ep_name: The name of the episode that was downloaded
         title: The title of the notification (optional)
-        '''
+        """
         ep_name = ss(ep_name)
 
         if sickbeard.USE_EMAIL and sickbeard.EMAIL_NOTIFY_ONDOWNLOAD:
@@ -148,12 +148,12 @@ class Notifier(object):
                     logger.log('Download notification error: {}'.format(self.last_err), logger.WARNING)
 
     def notify_subtitle_download(self, ep_name, lang, title='Downloaded subtitle:'):  # pylint: disable=unused-argument
-        '''
+        """
         Send a notification that an subtitle was downloaded
 
         ep_name: The name of the episode that was downloaded
         lang: Subtitle language wanted
-        '''
+        """
         ep_name = ss(ep_name)
 
         if sickbeard.USE_EMAIL and sickbeard.EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD:
@@ -193,10 +193,10 @@ class Notifier(object):
                     logger.log('Download notification error: {}'.format(self.last_err), logger.WARNING)
 
     def notify_git_update(self, new_version='??'):
-        '''
+        """
         Send a notification that Medusa was updated
         new_version: The commit Medusa was updated to
-        '''
+        """
         if sickbeard.USE_EMAIL:
             to = self._generate_recipients(None)
             if not to:
@@ -230,10 +230,10 @@ class Notifier(object):
                     logger.log('Update notification error: {}'.format(self.last_err), logger.WARNING)
 
     def notify_login(self, ipaddress=''):
-        '''
+        """
         Send a notification that Medusa was logged into remotely
         ipaddress: The ip Medusa was logged into from
-        '''
+        """
         if sickbeard.USE_EMAIL:
             to = self._generate_recipients(None)
             if not to:

--- a/sickbeard/notifiers/pushalot.py
+++ b/sickbeard/notifiers/pushalot.py
@@ -102,9 +102,9 @@ class Notifier(object):
             returns='json'
         ) or {}
 
-        '''
+        """
         {'Status': 200, 'Description': 'The request has been completed successfully.', 'Success': True}
-        '''
+        """
 
         success = jdata.pop('Success', False)
         if success:

--- a/sickbeard/nzbget.py
+++ b/sickbeard/nzbget.py
@@ -33,12 +33,12 @@ from sickrage.helper.common import try_int
 
 
 def sendNZB(nzb, proper=False):  # pylint: disable=too-many-locals, too-many-statements, too-many-branches, too-many-return-statements
-    '''
+    """
     Sends NZB to NZBGet client
 
     :param nzb: nzb object
     :param proper: True if this is a Proper download, False if not. Defaults to False
-    '''
+    """
     if sickbeard.NZBGET_HOST is None:
         logger.log('No NZBget host found in configuration. Please configure it.', logger.WARNING)
         return False

--- a/sickbeard/providers/norbits.py
+++ b/sickbeard/providers/norbits.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-'''A Norbits (https://norbits.net) provider'''
+"""A Norbits (https://norbits.net) provider"""
 
 # URL: https://sickrage.github.io
 #
@@ -34,10 +34,10 @@ except ImportError:
 
 
 class NorbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
-    '''Main provider object'''
+    """Main provider object"""
 
     def __init__(self):
-        ''' Initialize the class '''
+        """ Initialize the class """
         TorrentProvider.__init__(self, 'Norbits')
 
         self.username = None
@@ -60,7 +60,7 @@ class NorbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
         return True
 
     def _checkAuthFromData(self, parsed_json):  # pylint: disable=invalid-name
-        ''' Check that we are authenticated. '''
+        """ Check that we are authenticated. """
 
         if 'status' in parsed_json and 'message' in parsed_json:
             if parsed_json.get('status') == 3:
@@ -70,7 +70,7 @@ class NorbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
         return True
 
     def search(self, search_params, age=0, ep_obj=None):  # pylint: disable=too-many-locals
-        ''' Do the actual searching and JSON parsing'''
+        """ Do the actual searching and JSON parsing"""
 
         results = []
 

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -29,11 +29,11 @@ session = helpers.make_session()
 
 
 def sendNZB(nzb):  # pylint:disable=too-many-return-statements, too-many-branches, too-many-statements
-    '''
+    """
     Sends an NZB to SABnzbd via the API.
 
     :param nzb: The NZBSearchResult object to send to SAB
-    '''
+    """
 
     category = sickbeard.SAB_CATEGORY
     if nzb.show.is_anime:
@@ -82,12 +82,12 @@ def sendNZB(nzb):  # pylint:disable=too-many-return-statements, too-many-branche
 
 
 def _checkSabResponse(jdata):
-    '''
+    """
     Check response from SAB
 
     :param jdata: Response from requests api call
     :return: a list of (Boolean, string) which is True if SAB is not reporting an error
-    '''
+    """
     if 'error' in jdata:
         logger.log(jdata['error'], logger.ERROR)
         return False, jdata['error']
@@ -96,7 +96,7 @@ def _checkSabResponse(jdata):
 
 
 def getSabAccesMethod(host=None):
-    '''
+    """
     Find out how we should connect to SAB
 
     :param host: hostname where SAB lives
@@ -104,7 +104,7 @@ def getSabAccesMethod(host=None):
     :param password: password to use
     :param apikey: apikey to use
     :return: (boolean, string) with True if method was successful
-    '''
+    """
     params = {'mode': 'auth', 'output': 'json'}
     url = urljoin(host, 'api')
     data = helpers.getURL(url, params=params, session=session, returns='json', verify=False)
@@ -115,7 +115,7 @@ def getSabAccesMethod(host=None):
 
 
 def testAuthentication(host=None, username=None, password=None, apikey=None):
-    '''
+    """
     Sends a simple API request to SAB to determine if the given connection information is connect
 
     :param host: The host where SAB is running (incl port)
@@ -123,7 +123,7 @@ def testAuthentication(host=None, username=None, password=None, apikey=None):
     :param password: The password to use for the HTTP request
     :param apikey: The API key to provide to SAB
     :return: A tuple containing the success boolean and a message
-    '''
+    """
 
     # build up the URL parameters
     params = {

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -141,8 +141,8 @@ def snatchEpisode(result, endStatus=SNATCHED):  # pylint: disable=too-many-branc
                     result.content = result.provider.get_url(result.url, returns='content')
 
             if result.content or result.url.startswith('magnet'):
-                client = clients.getClientIstance(sickbeard.TORRENT_METHOD)()
-                dlResult = client.sendTORRENT(result)
+                client = clients.get_client_instance(sickbeard.TORRENT_METHOD)()
+                dlResult = client.send_torrent(result)
             else:
                 logger.log(u"Torrent file content is empty", logger.WARNING)
                 dlResult = False
@@ -238,19 +238,19 @@ def pickBestResult(results, show):  # pylint: disable=too-many-branches
         # If doesnt have min seeders OR min leechers then discard it
         if cur_result.seeders not in (-1, None) and cur_result.leechers not in (-1, None) \
             and hasattr(cur_result.provider, 'minseed') and hasattr(cur_result.provider, 'minleech') \
-            and (int(cur_result.seeders) < int(cur_result.provider.minseed) or 
+            and (int(cur_result.seeders) < int(cur_result.provider.minseed) or
                  int(cur_result.leechers) < int(cur_result.provider.minleech)):
             logger.log(u"Discarding torrent because it doesn't meet the minimum provider setting \
                         S:{0} L:{1}. Result has S:{2} L:{3}".format(cur_result.provider.minseed,
                         cur_result.provider.minleech, cur_result.seeders, cur_result.leechers))
             continue
-        
+
         show_words = show_name_helpers.show_words(cur_result.show)
         ignore_words = show_words.ignore_words
         require_words = show_words.require_words
         found_ignore_word = show_name_helpers.containsAtLeastOneWord(cur_result.name, ignore_words)
-        found_require_word = show_name_helpers.containsAtLeastOneWord(cur_result.name, require_words)        
-        
+        found_require_word = show_name_helpers.containsAtLeastOneWord(cur_result.name, require_words)
+
         if ignore_words and found_ignore_word:
             logger.log(u"Ignoring " + cur_result.name + " based on ignored words filter: " + found_ignore_word,
                        logger.INFO)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -2245,13 +2245,13 @@ class TVEpisode(object):  # pylint: disable=too-many-instance-attributes, too-ma
 
             season_format = sep = ep_sep = ep_format = None
 
-            season_ep_regex = r'''
+            season_ep_regex = r"""
                                 (?P<pre_sep>[ _.-]*)
                                 ((?:s(?:eason|eries)?\s*)?%0?S(?![._]?N))
                                 (.*?)
                                 (%0?E(?![._]?N))
                                 (?P<post_sep>[ _.-]*)
-                              '''
+                              """
             ep_only_regex = r'(E?%0?E(?![._]?N))'
 
             # try the normal way

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -822,9 +822,9 @@ class Home(WebRoot):
 
         host = config.clean_url(host)
 
-        client = clients.getClientIstance(torrent_method)
+        client = clients.get_client_instance(torrent_method)
 
-        _, accesMsg = client(host, username, password).testAuthentication()
+        _, accesMsg = client(host, username, password).test_authentication()
 
         return accesMsg
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Always make sure the PR has a clear description of why,how, and what your trying to fix. The same goes for improvements or new features. Also if you refering to an issue, make sure a summary is available in the PR.
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

I know this seems like a large PR, but the majority of the changes are fairly minor and have been grouped into similar commits to make review easier.

The majority of this PR is just simple style changes to `sickbeard/clients`:
* Fix triple-quoted strings
* Refactor non-pythonic names
* Use single-quoted strings
* Standardize string formatting
* Use unicode literals
* Use b'' for SQL
* Remove unused variables and code
* Clean up logging
* Clean up comments
* Prettify literal indentation
* Fix line too long
* Simplify url init
* Minimize global usage in code

The meat of the PR is the changes below:
* Fix too broad exceptions
 * Catch `RequestException` instead of `Exception`
* Clean up conditional/exceptional statements
 * Mostly a style change to conditionals and exceptional statements.  Included as part of the "meat" since it touches application logic
* Streamline return statements
 * Same as above
* `UTorrentAPI._request' does not accept all arguments from the overridden method.
 * This adds the `cookies` arg with a default value of `None`.  If `cookies` are passed to `_request`, it will log a debug message with the value passed.
* Fix `UTorrentAPI._request()` arguments not matching
* Fix `RTorrentAPI._get_auth` invalidating authentication every call.
* `RTorrentAPI.auth` is set to `None` each time `_get_auth()` is called.
 * This is likely unintended, as the next line returns `self.auth` if it's not `None`.  This moves the invalidation of `self.auth` to `test_authentication()` to make sure the authentication test is actually performed.
* Add missing import
  * Mostly optimizing imports, but adds the missing `import traceback` in `generic.py`
* Add missing method used in DSM client
  * `handle_requests_exception` from `sickbeard/helpers.py` did not exist
* Streamlined `handle_requests_exception`
  * Simplify requests exception handler by catching RequestException instead of all the individual sub-classes.