### PR TITLE
Fix label in deluge, needs to be lower case

### DIFF
--- a/sickbeard/clients/deluge_client.py
+++ b/sickbeard/clients/deluge_client.py
@@ -121,9 +121,9 @@ class DelugeAPI(GenericClient):
 
     def _set_torrent_label(self, result):
 
-        label = sickbeard.TORRENT_LABEL
+        label = sickbeard.TORRENT_LABEL.lower()
         if result.show.is_anime:
-            label = sickbeard.TORRENT_LABEL_ANIME
+            label = sickbeard.TORRENT_LABEL_ANIME.lower()
         if ' ' in label:
             logger.log(self.name + u': Invalid label. Label must not contain a space', logger.ERROR)
             return False

--- a/sickbeard/clients/deluged_client.py
+++ b/sickbeard/clients/deluged_client.py
@@ -76,9 +76,9 @@ class DelugeDAPI(GenericClient):
 
     def _set_torrent_label(self, result):
 
-        label = sickbeard.TORRENT_LABEL
+        label = sickbeard.TORRENT_LABEL.lower()
         if result.show.is_anime:
-            label = sickbeard.TORRENT_LABEL_ANIME
+            label = sickbeard.TORRENT_LABEL_ANIME.lower()
         if ' ' in label:
             logger.log(self.name + u': Invalid label. Label must not contain a space', logger.ERROR)
             return False


### PR DESCRIPTION
When labels are uppercase, SR fails to set them as deluge(d) doesn't support uppercase labels
Issue from old repo

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Always make sure the PR has a clear description of why,how, and what your trying to fix. The same goes for improvements or new features. Also if you refering to an issue, make sure a summary is available in the PR.
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)