### PR TITLE
Don't call clear_non_release_groups for non media files

### DIFF
--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -665,11 +665,12 @@ def delete_unwanted_subtitles(dirpath, filename):
             logger.info(u"Couldn't delete subtitle: %s. Error: %s", filename, ex(error))
 
 
-def clear_non_release_groups(filepath):
+def clear_non_release_groups(filename, filepath):
     """Remove non release groups from the name of the given file path.
 
     It also renames/moves the file to the path
 
+    :param filename: the file name
     :param filepath: the file path
     :type filepath: str
     :return: the new file path
@@ -677,14 +678,14 @@ def clear_non_release_groups(filepath):
     """
     try:
         # Remove non release groups from video file. Needed to match subtitles
-        new_filepath = remove_non_release_groups(filepath)
-        if new_filepath != filepath:
-            os.rename(filepath, new_filepath)
-            filepath = new_filepath
+        new_filename = remove_non_release_groups(filename)
+        if new_filename != filename:
+            os.rename(os.path.join(filepath, filename), os.path.join(new_filepath, new_filename))
+            filename = new_filename
     except Exception as error:
         logger.debug(u"Couldn't remove non release groups from video file. Error: %s", ex(error))
 
-    return filepath
+    return filename
 
 
 class SubtitlesFinder(object):
@@ -723,7 +724,7 @@ class SubtitlesFinder(object):
                 if not isMediaFile(filename):
                     continue
                 
-                filename = clear_non_release_groups(os.path.join(root, filename))
+                filename = clear_non_release_groups(root, filename)
 
                 if processTV.subtitles_enabled(filename) is False:
                     logger.debug(u'Subtitle disabled for show: %s', filename)

--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -717,13 +717,13 @@ class SubtitlesFinder(object):
         run_post_process = False
         for root, _, files in os.walk(sickbeard.TV_DOWNLOAD_DIR, topdown=False):
             for filename in sorted(files):
-                filename = clear_non_release_groups(filename)
-
                 # Delete unwanted subtitles before downloading new ones
                 delete_unwanted_subtitles(root, filename)
 
                 if not isMediaFile(filename):
                     continue
+                
+                filename = clear_non_release_groups(os.path.join(root, filename))
 
                 if processTV.subtitles_enabled(filename) is False:
                     logger.debug(u'Subtitle disabled for show: %s', filename)

--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -665,13 +665,13 @@ def delete_unwanted_subtitles(dirpath, filename):
             logger.info(u"Couldn't delete subtitle: %s. Error: %s", filename, ex(error))
 
 
-def clear_non_release_groups(filename, filepath):
+def clear_non_release_groups(filepath, filename):
     """Remove non release groups from the name of the given file path.
 
     It also renames/moves the file to the path
 
-    :param filename: the file name
     :param filepath: the file path
+    :param filename: the file name
     :type filepath: str
     :return: the new file path
     :rtype: str
@@ -680,7 +680,7 @@ def clear_non_release_groups(filename, filepath):
         # Remove non release groups from video file. Needed to match subtitles
         new_filename = remove_non_release_groups(filename)
         if new_filename != filename:
-            os.rename(os.path.join(filepath, filename), os.path.join(new_filepath, new_filename))
+            os.rename(os.path.join(filepath, filename), os.path.join(filepath, new_filename))
             filename = new_filename
     except Exception as error:
         logger.debug(u"Couldn't remove non release groups from video file. Error: %s", ex(error))
@@ -725,12 +725,12 @@ class SubtitlesFinder(object):
                     continue
                 
                 filename = clear_non_release_groups(root, filename)
+                video_path = os.path.join(root, filename)
 
-                if processTV.subtitles_enabled(filename) is False:
+                if processTV.subtitles_enabled(video_path) is False:
                     logger.debug(u'Subtitle disabled for show: %s', filename)
                     continue
 
-                video_path = os.path.join(root, filename)
                 release_name = os.path.splitext(filename)[0]
                 found_subtitles = download_best_subs(video_path, root, release_name, languages, subtitles=False,
                                                      embedded_subtitles=False, provider_pool=pool)


### PR DESCRIPTION
@ratoaq2 also you weren't passing full path creating error:

`Couldn't remove non release groups from video file. Error: error 2 : The system cannot find the file specified`

@medariox 