### PR TITLE
 Fix invalid literal for int() with base 10 when parsing metadata

### DIFF
--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -924,9 +924,9 @@ class GenericMetadata(object):
 
             name = showXML.findtext('title')
 
-            if showXML.findtext('tvdbid') is not None:
+            if showXML.findtext('tvdbid'):
                 indexer_id = int(showXML.findtext('tvdbid'))
-            elif showXML.findtext('id') is not None:
+            elif showXML.findtext('id'):
                 indexer_id = int(showXML.findtext('id'))
             else:
                 logger.log(u"Empty <id> or <tvdbid> field in NFO, unable to find a ID", logger.WARNING)
@@ -937,7 +937,7 @@ class GenericMetadata(object):
                 return empty_return
 
             indexer = None
-            if showXML.find('episodeguide/url') is not None:
+            if showXML.find('episodeguide/url'):
                 epg_url = showXML.findtext('episodeguide/url').lower()
                 if str(indexer_id) in epg_url:
                     if 'thetvdb.com' in epg_url:


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

When adding existing shows, an empty string can raise the above error.