### PR TITLE
Fixed cache_retention granularity.

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -934,7 +934,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
 
         CACHE_TRIMMING = bool(check_setting_int(CFG, 'General', 'cache_trimming', 0))
 
-        MAX_CACHE_AGE = check_setting_float(CFG, 'General', 'max_cache_age', 30.0)
+        MAX_CACHE_AGE = check_setting_int(CFG, 'General', 'max_cache_age', 30)
 
         AUTOPOSTPROCESSOR_FREQUENCY = check_setting_int(CFG, 'General', 'autopostprocessor_frequency',
                                                         DEFAULT_AUTOPOSTPROCESSOR_FREQUENCY)
@@ -1747,7 +1747,7 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
     new_config['General']['torrent_method'] = TORRENT_METHOD
     new_config['General']['usenet_retention'] = int(USENET_RETENTION)
     new_config['General']['cache_trimming'] = int(CACHE_TRIMMING)
-    new_config['General']['max_cache_age'] = float(MAX_CACHE_AGE)
+    new_config['General']['max_cache_age'] = int(MAX_CACHE_AGE)
     new_config['General']['autopostprocessor_frequency'] = int(AUTOPOSTPROCESSOR_FREQUENCY)
     new_config['General']['dailysearch_frequency'] = int(DAILYSEARCH_FREQUENCY)
     new_config['General']['backlog_frequency'] = int(BACKLOG_FREQUENCY)

--- a/sickbeard/server/web/config/search.py
+++ b/sickbeard/server/web/config/search.py
@@ -69,7 +69,7 @@ class ConfigSearch(Config):
         sickbeard.BACKLOG_DAYS = try_int(backlog_days, 7)
 
         sickbeard.CACHE_TRIMMING = config.checkbox_to_value(cache_trimming)
-        sickbeard.MAX_CACHE_AGE = float(max_cache_age)
+        sickbeard.MAX_CACHE_AGE = try_int(max_cache_age)
 
         sickbeard.USE_NZBS = config.checkbox_to_value(use_nzbs)
         sickbeard.USE_TORRENTS = config.checkbox_to_value(use_torrents)

--- a/sickbeard/server/web/config/search.py
+++ b/sickbeard/server/web/config/search.py
@@ -69,7 +69,7 @@ class ConfigSearch(Config):
         sickbeard.BACKLOG_DAYS = try_int(backlog_days, 7)
 
         sickbeard.CACHE_TRIMMING = config.checkbox_to_value(cache_trimming)
-        sickbeard.MAX_CACHE_AGE = try_int(max_cache_age)
+        sickbeard.MAX_CACHE_AGE = try_int(max_cache_age, 0)
 
         sickbeard.USE_NZBS = config.checkbox_to_value(use_nzbs)
         sickbeard.USE_TORRENTS = config.checkbox_to_value(use_torrents)


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

* Should be cast to int, as we want to step by day, not tenth of day.

@labrys ?
I've changed it because else in config you get to see 30,0. While stepping did change, saving did not.