### PR TITLE
Fixes a 404 on mass changing episode statuses.

### DIFF
--- a/gui/slick/views/manage_episodeStatuses.mako
+++ b/gui/slick/views/manage_episodeStatuses.mako
@@ -3,11 +3,6 @@
     from sickbeard import common
     import sickbeard
 %>
-<%block name="scripts">
-% if whichStatus or (whichStatus and ep_counts):
-<script type="text/javascript" src="${srRoot}/js/manageEpisodeStatuses.js?${sbPID}"></script>
-% endif:
-</%block>
 <%block name="content">
 <div id="content960">
 % if not header is UNDEFINED:

--- a/sickbeard/server/web/manage/handler.py
+++ b/sickbeard/server/web/manage/handler.py
@@ -146,9 +146,8 @@ class Manage(Home, WebRoot):
                     b'AND showid = ?'.format(statuses=','.join(['?'] * len(status_list))),
                     status_list + [cur_indexer_id]
                 )
-                all_eps = ['{season}x{episode}'.format(season=x[b'season'],
-                                                       episode=x[b'episode'])
-                           for x in all_eps_results]
+
+                all_eps = ['{season}x{episode}'.format(season=x[b'season'], episode=x[b'episode']) for x in all_eps_results]
                 to_change[cur_indexer_id] = all_eps
 
             self.setStatus(cur_indexer_id, '|'.join(to_change[cur_indexer_id]), newStatus, direct=True)

--- a/sickbeard/server/web/manage/handler.py
+++ b/sickbeard/server/web/manage/handler.py
@@ -146,7 +146,9 @@ class Manage(Home, WebRoot):
                     b'AND showid = ?'.format(statuses=','.join(['?'] * len(status_list))),
                     status_list + [cur_indexer_id]
                 )
-                all_eps = [str(x['season']) + 'x' + str(x['episode']) for x in all_eps_results]
+                all_eps = ['{season}x{episode}'.format(season=x[b'season'],
+                                                       episode=x[b'episode'])
+                           for x in all_eps_results]
                 to_change[cur_indexer_id] = all_eps
 
             self.setStatus(cur_indexer_id, '|'.join(to_change[cur_indexer_id]), newStatus, direct=True)


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

* Also removed a js script include, as that script doesn't exist anymore.

You can reproduce through going to Manage -> episode status management page. And change status for a number of episodes.