### PR TITLE
Playing with guessit 2

### DIFF
--- a/lib/guessit/rules/properties/release_group.py
+++ b/lib/guessit/rules/properties/release_group.py
@@ -49,7 +49,7 @@ def clean_groupname(string):
 
 
 _scene_previous_names = ['video_codec', 'format', 'video_api', 'audio_codec', 'audio_profile', 'video_profile',
-                         'audio_channels', 'screen_size']
+                         'audio_channels', 'screen_size', 'other', 'container', 'language']
 
 _scene_previous_tags = ['release-group-prefix']
 
@@ -114,7 +114,7 @@ class SceneReleaseGroup(Rule):
                     last_hole.name = 'release_group'
                     last_hole.tags = ['scene']
 
-                    # if hole is insed a group marker with same value, remove [](){} ...
+                    # if hole is inside a group marker with same value, remove [](){} ...
                     group = matches.markers.at_match(last_hole, lambda marker: marker.name == 'group', 0)
                     if group:
                         group.formatter = clean_groupname

--- a/lib/guessit/test/episodes.yml
+++ b/lib/guessit/test/episodes.yml
@@ -992,7 +992,7 @@
 : other: Complete
   season: 1
   title: Something
-  episode_title: FlexGet  # 1.x guess this as release_group, but it's better to guess it as episode_title
+  release_group: FlexGet
 
 ? FlexGet.US.S2013E14.Title.Here.720p.HDTV.AAC5.1.x264-NOGRP
 : audio_channels: '5.1'
@@ -1777,3 +1777,70 @@
   title: Homeland
   type: episode
   video_codec: h264
+
+? Breaking.Bad.S01E01.2008.BluRay.VC1.1080P.5.1.WMV-NOVO
+: title: Breaking Bad
+  season: 1
+  episode: 1
+  year: 2008
+  format: BluRay
+  screen_size: 1080p
+  audio_channels: '5.1'
+  container: WMV
+  release_group: NOVO
+  type: episode
+
+? Cosmos.A.Space.Time.Odyssey.S01E02.HDTV.x264.PROPER-LOL
+: title: Cosmos A Space Time Odyssey
+  season: 1
+  episode: 2
+  format: HDTV
+  video_codec: h264
+  other: Proper
+  proper_count: 1
+  release_group: LOL
+  type: episode
+
+? Fear.The.Walking.Dead.S02E01.HDTV.x264.AAC.MP4-k3n
+: title: Fear The Walking Dead
+  season: 2
+  episode: 1
+  format: HDTV
+  video_codec: h264
+  audio_codec: AAC
+  container: MP4
+  release_group: k3n
+  type: episode
+
+? Elementary.S01E01.Pilot.DVDSCR.x264.PREAiR-NoGRP
+: title: Elementary
+  season: 1
+  episode: 1
+  episode_details: Pilot
+  episode_title: Pilot
+  format: DVD
+  video_codec: h264
+  other: [Screener, Preair]
+  release_group: NoGRP
+  type: episode
+
+? Once.Upon.a.Time.S05E19.HDTV.x264.REPACK-LOL[ettv]
+: title: Once Upon a Time
+  season: 5
+  episode: 19
+  format: HDTV
+  video_codec: h264
+  other: Proper
+  proper_count: 1
+  release_group: LOL[ettv]
+  type: episode
+
+? Show.Name.S01E03.WEB-DL.x264.HUN-nIk
+: title: Show Name
+  season: 1
+  episode: 3
+  format: WEB-DL
+  video_codec: h264
+  language: hu
+  release_group: nIk
+  type: episode

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     tests_require=[
         'coveralls',
         'nose',
+        'nose-parameterized',
         'rednose',
         'mock',
     ],

--- a/sickbeard/name_parser/guessit_parser.py
+++ b/sickbeard/name_parser/guessit_parser.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Guessit Name Parser
+"""
+import guessit
+
+
+class GuessitNameParser(object):
+    """
+    Guessit Name Parser
+    """
+
+    expected_titles = {
+        # guessit doesn't add dots for this show
+        '11.22.63',
+
+        # guessit gets confused because of the numbers (only in some special cases)
+        # (?<![^/\\]) means -> it matches nothing but path separators  (negative lookbehind)
+        r're:(?<![^/\\])12 Monkeys\b',
+        r're:(?<![^/\\])500 Bus Stops\b',
+        r're:(?<![^/\\])60 Minutes\b',
+        r're:(?<![^/\\])Star Trek DS9\b',
+        r're:(?<![^/\\])The 100\b',
+
+        # https://github.com/guessit-io/guessit/issues/298
+        # guessit identifies as website
+        r're:(?<![^/\\])\w+ Net\b',
+
+        # guessit: conflicts with italian language
+        r're:(?<![^/\\])\w+ it\b',
+    }
+
+    # release group exception list
+    expected_groups = {
+        # https://github.com/guessit-io/guessit/issues/297
+        # guessit blacklists parts of the name for the following groups
+        r're:\bbyEMP\b',
+        r're:\bELITETORRENT\b',
+        r're:\bNovaRip\b',
+        r're:\bPARTiCLE\b',
+        r're:\bPOURMOi\b',
+        r're:\bRipPourBox\b',
+        r're:\bRiPRG\b',
+
+        # https://github.com/guessit-io/guessit/issues/316
+        r're:\bCDP\b',
+        r're:\bCDD\b',
+
+        # https://github.com/guessit-io/guessit/issues/317
+        r're:\bHDD\b',
+
+        # release groups with numbers
+        r're:\b4EVERHD\b',  # remove after guessit #313 is fixed
+        r're:\bF4ST3R\b',
+        r're:\bF4ST\b',
+        r're:\bPtM\b',
+        r're:\bTGNF4ST\b',
+        r're:\bTV2LAX9\b',
+    }
+
+    allowed_languages = {
+        'de',
+        'en',
+        'es',
+        'fr',
+        'hu',
+        'it',
+        'iw',
+        'nl',
+        'pt',
+        'ro',
+        'ru',
+        'sv',
+    }
+
+    allowed_countries = {
+        'us',
+        'uk',
+    }
+
+    allow_multi_season = False
+
+    def guess(self, name, show_type=None):
+        """
+        Given a release name, it guesses the episode information
+
+        :param name: the release name
+        :type name: str
+        :param show_type: None, regular or anime
+        :type show_type: str
+        :return: the guessed properties
+        :rtype: dict
+        """
+        options = dict(type='episode', implicit=True, expected_title=self.expected_titles, show_type=show_type,
+                       expected_group=self.expected_groups, episode_prefer_number=show_type == 'anime',
+                       allowed_languages=self.allowed_languages, allowed_countries=self.allowed_countries)
+        return guessit.guessit(name, options=options)
+
+    def parse(self, name, show_type=None):
+        """
+        Same as self.guess(..) method but returns a dictionary with keys and values according to ParseResult
+        :param name:
+        :type name: str
+        :param show_type: 'regular' or 'anime'
+        :type show_type: str
+        :return:
+        :rtype: dict
+        """
+        guess = self.guess(name, show_type=show_type)
+
+        result = {
+            'original_name': name,
+            'series_name': guess.get('extended_title') or guess.get('title'),
+            'season_number': single_or_list(guess.get('season'), self.allow_multi_season),
+            'release_group': guess.get('release_group'),
+            'air_date': guess.get('date'),
+            'version': guess.get('version', -1),
+            'extra_info': ' '.join(ensure_list(guess.get('other'))) if guess.get('other') else None,
+            'episode_numbers': ensure_list(guess.get('episode')),
+            'ab_episode_numbers': ensure_list(guess.get('absolute_episode'))
+        }
+
+        return result
+
+
+def single_or_list(value, allow_multi):
+    if not isinstance(value, list):
+        return value
+
+    if allow_multi:
+        return sorted(value)
+
+
+def ensure_list(value):
+    return sorted(value) if isinstance(value, list) else [value] if value is not None else []
+
+parser = GuessitNameParser()

--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -26,11 +26,16 @@ import sickbeard
 from sickbeard.name_parser import regexes
 
 from sickbeard import logger, helpers, scene_numbering, common, scene_exceptions, db
+from sickbeard.name_parser.guessit_parser import parser as guessit_parser
 from sickrage.helper.common import remove_extension
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex
 from sickbeard.helpers import remove_non_release_groups
 import dateutil
+
+
+pre_cleanup_re = re.compile(r'(\.vol\d+\+\d+)?((\.par2\b)|(\.nzb\b)|(\.mkv\b)).*((\d+\.of\.\d+)|(\(\d+/\d+\))).*$',
+                            flags=re.IGNORECASE)
 
 
 class NameParser(object):
@@ -39,20 +44,24 @@ class NameParser(object):
     ANIME_REGEX = 2
 
     def __init__(self, file_name=True, showObj=None, tryIndexers=False,  # pylint: disable=too-many-arguments
-                 naming_pattern=False, parse_method=None):
+                 naming_pattern=False, parse_method=None, use_guessit=True):
 
         self.file_name = file_name
         self.showObj = showObj
         self.tryIndexers = tryIndexers
 
         self.naming_pattern = naming_pattern
+        self.use_guessit = use_guessit
 
         if (self.showObj and not self.showObj.is_anime) or parse_method == 'normal':
             self._compile_regexes(self.NORMAL_REGEX)
+            self.show_type = 'regular'
         elif (self.showObj and self.showObj.is_anime) or parse_method == 'anime':
             self._compile_regexes(self.ANIME_REGEX)
+            self.show_type = 'anime'
         else:
             self._compile_regexes(self.ALL_REGEX)
+            self.show_type = None
 
     @staticmethod
     def clean_series_name(series_name):
@@ -106,90 +115,99 @@ class NameParser(object):
 
         matches = []
         bestResult = None
-        
-        # Remove non release groups from filename
-        name = remove_non_release_groups(name)
 
-        for (cur_regex_num, cur_regex_name, cur_regex) in self.compiled_regexes:
-            match = cur_regex.match(name)
-
-            if not match:
-                continue
-
-            result = ParseResult(name)
-            result.which_regex = [cur_regex_name]
-            result.score = 0 - cur_regex_num
-
-            named_groups = match.groupdict().keys()
-
-            if 'series_name' in named_groups:
-                result.series_name = match.group('series_name')
-                if result.series_name:
-                    result.series_name = self.clean_series_name(result.series_name)
-                    result.score += 1
-
-            if 'series_num' in named_groups and match.group('series_num'):
-                result.score += 1
-
-            if 'season_num' in named_groups:
-                tmp_season = int(match.group('season_num'))
-                if cur_regex_name == 'bare' and tmp_season in (19, 20):
-                    continue
-                result.season_number = tmp_season
-                result.score += 1
-
-            if 'ep_num' in named_groups:
-                ep_num = self._convert_number(match.group('ep_num'))
-                if 'extra_ep_num' in named_groups and match.group('extra_ep_num'):
-                    result.episode_numbers = range(ep_num, self._convert_number(match.group('extra_ep_num')) + 1)
-                    result.score += 1
-                else:
-                    result.episode_numbers = [ep_num]
-                result.score += 1
-
-            if 'ep_ab_num' in named_groups:
-                ep_ab_num = self._convert_number(match.group('ep_ab_num'))
-                if 'extra_ab_ep_num' in named_groups and match.group('extra_ab_ep_num'):
-                    result.ab_episode_numbers = range(ep_ab_num,
-                                                      self._convert_number(match.group('extra_ab_ep_num')) + 1)
-                    result.score += 1
-                else:
-                    result.ab_episode_numbers = [ep_ab_num]
-                result.score += 1
-
-            if 'air_date' in named_groups:
-                air_date = match.group('air_date')
-                try:
-                    result.air_date = dateutil.parser.parse(air_date, fuzzy_with_tokens=True)[0].date()
-                    result.score += 1
-                except Exception:
-                    continue
-
-            if 'extra_info' in named_groups:
-                tmp_extra_info = match.group('extra_info')
-
-                # Show.S04.Special or Show.S05.Part.2.Extras is almost certainly not every episode in the season
-                if tmp_extra_info and cur_regex_name == 'season_only' and re.search(
-                        r'([. _-]|^)(special|extra)s?\w*([. _-]|$)', tmp_extra_info, re.I):
-                    continue
-                result.extra_info = tmp_extra_info
-                result.score += 1
-
-            if 'release_group' in named_groups:
-                result.release_group = match.group('release_group')
-                result.score += 1
-
-            if 'version' in named_groups:
-                # assigns version to anime file if detected using anime regex. Non-anime regex receives -1
-                version = match.group('version')
-                if version:
-                    result.version = version
-                else:
-                    result.version = 1
-            else:
-                result.version = -1
+        if self.use_guessit:
+            guess = guessit_parser.parse(name, show_type=self.show_type)
+            result = ParseResult(guess['original_name'])
+            for key, value in guess.iteritems():
+                setattr(result, key, value)
 
             matches.append(result)
+
+        # Remove non release groups from filename
+        else:
+            name = remove_non_release_groups(name)
+
+            for (cur_regex_num, cur_regex_name, cur_regex) in self.compiled_regexes:
+                match = cur_regex.match(name)
+
+                if not match:
+                    continue
+
+                result = ParseResult(name)
+                result.which_regex = [cur_regex_name]
+                result.score = 0 - cur_regex_num
+
+                named_groups = match.groupdict().keys()
+
+                if 'series_name' in named_groups:
+                    result.series_name = match.group('series_name')
+                    if result.series_name:
+                        result.series_name = self.clean_series_name(result.series_name)
+                        result.score += 1
+
+                if 'series_num' in named_groups and match.group('series_num'):
+                    result.score += 1
+
+                if 'season_num' in named_groups:
+                    tmp_season = int(match.group('season_num'))
+                    if cur_regex_name == 'bare' and tmp_season in (19, 20):
+                        continue
+                    result.season_number = tmp_season
+                    result.score += 1
+
+                if 'ep_num' in named_groups:
+                    ep_num = self._convert_number(match.group('ep_num'))
+                    if 'extra_ep_num' in named_groups and match.group('extra_ep_num'):
+                        result.episode_numbers = range(ep_num, self._convert_number(match.group('extra_ep_num')) + 1)
+                        result.score += 1
+                    else:
+                        result.episode_numbers = [ep_num]
+                    result.score += 1
+
+                if 'ep_ab_num' in named_groups:
+                    ep_ab_num = self._convert_number(match.group('ep_ab_num'))
+                    if 'extra_ab_ep_num' in named_groups and match.group('extra_ab_ep_num'):
+                        result.ab_episode_numbers = range(ep_ab_num,
+                                                          self._convert_number(match.group('extra_ab_ep_num')) + 1)
+                        result.score += 1
+                    else:
+                        result.ab_episode_numbers = [ep_ab_num]
+                    result.score += 1
+
+                if 'air_date' in named_groups:
+                    air_date = match.group('air_date')
+                    try:
+                        result.air_date = dateutil.parser.parse(air_date, fuzzy_with_tokens=True)[0].date()
+                        result.score += 1
+                    except Exception:
+                        continue
+
+                if 'extra_info' in named_groups:
+                    tmp_extra_info = match.group('extra_info')
+
+                    # Show.S04.Special or Show.S05.Part.2.Extras is almost certainly not every episode in the season
+                    if tmp_extra_info and cur_regex_name == 'season_only' and re.search(
+                            r'([. _-]|^)(special|extra)s?\w*([. _-]|$)', tmp_extra_info, re.I):
+                        continue
+                    result.extra_info = tmp_extra_info
+                    result.score += 1
+
+                if 'release_group' in named_groups:
+                    result.release_group = match.group('release_group')
+                    result.score += 1
+
+                if 'version' in named_groups:
+                    # assigns version to anime file if detected using anime regex. Non-anime regex receives -1
+                    version = match.group('version')
+                    if version:
+                        result.version = version
+                    else:
+                        result.version = 1
+                else:
+                    result.version = -1
+
+                matches.append(result)
 
         if matches:
             # pick best match with highest score based on placement
@@ -286,6 +304,10 @@ class NameParser(object):
                 for epNo in bestResult.episode_numbers:
                     s = bestResult.season_number
                     e = epNo
+
+                    # guessit might return more than one season. Not supported yet!
+                    if isinstance(s, list):
+                        s = s[0] if len(s) == 1 else None
 
                     if bestResult.show.is_scene:
                         (s, e) = scene_numbering.get_indexer_numbering(bestResult.show.indexerid,
@@ -404,6 +426,7 @@ class NameParser(object):
 
     def parse(self, name, cache_result=True):
         name = self._unicodify(name)
+        name = pre_cleanup_re.sub('', name)
 
         if self.naming_pattern:
             cache_result = False
@@ -413,7 +436,7 @@ class NameParser(object):
             return cached
 
         # break it into parts if there are any (dirname, file name, extension)
-        dir_name, file_name = ek(os.path.split, name)
+        dir_name, file_name = ek(os.path.split, name) if not self.use_guessit else ('', name)
 
         if self.file_name:
             base_file_name = remove_extension(file_name)
@@ -567,6 +590,10 @@ class ParseResult(object):  # pylint: disable=too-many-instance-attributes
         if self.ab_episode_numbers:
             return True
         return False
+
+    @property
+    def is_proper(self):
+        return re.search(r'(^|[\. _-])(proper|repack)([\. _-]|$)', self.extra_info, re.I) is not None if self.extra_info else False
 
 
 class NameParserCache(object):

--- a/sickbeard/name_parser/rules/__init__.py
+++ b/sickbeard/name_parser/rules/__init__.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Guessit customization
+"""
+from guessit.api import default_api
+from sickbeard.name_parser.rules.properties import (audio_codec, format_, language, other, size, screen_size,
+                                                    subtitle_language)
+from sickbeard.name_parser.rules.rules import rules
+
+
+default_api.rebulk.rebulk(format_())
+default_api.rebulk.rebulk(screen_size())
+default_api.rebulk.rebulk(audio_codec())
+default_api.rebulk.rebulk(other())
+default_api.rebulk.rebulk(size())
+default_api.rebulk.rebulk(language())
+default_api.rebulk.rebulk(subtitle_language())
+default_api.rebulk.rebulk(rules())

--- a/sickbeard/name_parser/rules/rules.py
+++ b/sickbeard/name_parser/rules/rules.py
@@ -1,0 +1,2194 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Rules: This section contains rules that enhances guessit behaviour
+
+Coding guidelines:
+For each rule:
+  - Provide an explanation
+  - An example of the guessit output without it
+  - An example of the guessit output with it
+  - Each rule should handle only one issue
+  - Remember that the input might be a filepath: /Show Name/Season 1/Show Name S01E02.ext
+  - Use rule.priority = POST_PROCESSOR (DO NOT change this*)
+  - DO NOT use rule.dependency**
+  - DO NOT change match.value. Just remove the match and append a new one with the amended value***
+  - Try to avoid using `private`, `parent` and `children` matches.
+    Their behaviour might change a lot in each new version
+
+Rebulk API is really powerful. It's always good to spend some time reading about it: https://github.com/Toilal/rebulk
+
+The main idea about the rules in this section is to navigate between the `matches` and `holes` and change the matches
+according to our needs
+
+* Our rules should run only after all standard and default guessit rules have finished (not before that!).
+** Adding several dependencies to our rules will make an implicit execution order. It could be hard to debug. Better to
+have a fixed execution order, that's why the rules() method should add the rules in the correct order (explicit).
+*** Rebulk API relies on the match.value, if you change them you'll get exceptions
+"""
+import copy
+import re
+
+from guessit.rules.common import seps
+from guessit.rules.common.comparators import marker_sorted
+from guessit.rules.common.formatters import cleanup
+from guessit.rules.common.validators import int_coercable
+from guessit.rules.properties.release_group import clean_groupname
+from rebulk.processors import POST_PROCESS
+from rebulk.rebulk import Rebulk
+from rebulk.rules import Rule, AppendMatch, RemoveMatch, RenameMatch
+
+
+simple_separator = ('.', 'and', ',.', '.,', '.,.', ',')
+range_separator = ('-', '~', '_-_', '.to.', 'to')
+season_range_separator = range_separator + ('_-_s', '-s', '.to.s')
+episode_range_separator = range_separator + ('_-_e', '-e', '.to.e')
+
+
+class FixAnimeReleaseGroup(Rule):
+    """
+    Anime release group is at the beginning and inside square brackets. If this pattern is found at the start of the
+    filepart, use it as a release group
+
+    guessit -t episode "[RealGroup].Show.Name.-.462.[720p].[10bit].[SOMEPERSON].[Something]"
+
+    without this fix:
+        For: [RealGroup].Show.Name.-.462.[720p].[10bit].[SOMEPERSON].[Something]
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 4,
+            "episode": 62,
+            "screen_size": "720p",
+            "video_profile": "10bit",
+            "release_group": "[SOMEPERSON].[Something]",
+            "type": "episode"
+        }
+
+    with this fix:
+        For: [RealGroup].Show.Name.-.462.[720p].[10bit].[SOMEPERSON].[Something]
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 4,
+            "episode": 62,
+            "screen_size": "720p",
+            "video_profile": "10bit",
+            "release_group": "RealGroup",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    release_group_re = re.compile(r'^\[(?P<release_group>\w+(\-\w+)?)\]$', flags=re.IGNORECASE)
+    blacklist = ('private', 'req')
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        if context.get('show_type') == 'regular':
+            return
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            # get the group (e.g.: [abc]) at the beginning of this filepart
+            group = matches.markers.at_index(filepart.start, index=0, predicate=lambda marker: marker.name == 'group')
+
+            # if there's no group or there's already a match at this position, skip it...
+            if not group or matches.at_match(group):
+                continue
+
+            m = self.release_group_re.match(group.raw)
+            # if the group matches the anime's release group pattern and it's not blacklisted
+            if m and m.group('release_group').lower() not in self.blacklist:
+                new_release_group = copy.copy(group)
+                new_release_group.marker = None
+                new_release_group.name = 'release_group'
+                new_release_group.value = m.group('release_group')
+                new_release_group.tags = ['anime']
+
+                to_append = new_release_group
+                to_remove = matches.named('release_group')
+
+                # remove the old release_group, append the new one
+                return to_remove, to_append
+
+
+class SpanishNewpctReleaseName(Rule):
+    """
+    This rule is to handle the newpct release name style
+
+    e.g.: Show.Name.-.Temporada.1.720p.HDTV.x264[Cap.102]SPANISH.AUDIO-NEWPCT
+
+    guessit -t episode "Show.Name.-.Temporada.1.720p.HDTV.x264[Cap.102]SPANISH.AUDIO-NEWPCT"
+
+    without this rule:
+        For: Show.Name.-.Temporada.1.720p.HDTV.x264[Cap.102]SPANISH.AUDIO-NEWPCT
+        GuessIt found: {
+            "title": "Show Name",
+            "alternative_title": "Temporada",
+            "episode": [
+                1,
+                2
+            ],
+            "screen_size": "720p",
+            "format": "HDTV",
+            "video_codec": "h264",
+            "season": 1,
+            "language": "Spanish",
+            "episode_title": "AUDIO-NEWPCT",
+            "type": "episode"
+        }
+
+
+    with this rule:
+        For: Show.Name.-.Temporada.1.720p.HDTV.x264[Cap.102]SPANISH.AUDIO-NEWPCT
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 1,
+            "episode": 2
+            "screen_size": "720p",
+            "format": "HDTV",
+            "video_codec": "h264",
+            "language": "Spanish",
+            "release_group": "NEWPCT"
+            "type": "episode"
+        }
+
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    season_re = re.compile(r'^tem(p|porada)?\W*\d*$', flags=re.IGNORECASE)
+    prefix = '[cap.'
+    episode_re = re.compile(r'^\[cap\.(?P<season>\d{1,2})(?P<episode>\d{2})'
+                            r'(_((?P<end_season>\d{1,2})(?P<end_episode>\d{2})))?.*\]', flags=re.IGNORECASE)
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        season = matches.named('season', index=0)
+        if not season:
+            return
+
+        alternative_titles = matches.named('alternative_title', predicate=
+                                           lambda match: self.season_re.match(match.value.lower()))
+        episode_titles = matches.named('episode_title', predicate=
+                                       lambda match: self.season_re.match(match.value.lower()))
+
+        # skip if there isn't an alternative_title or episode_title with the word season in spanish
+        if not alternative_titles and not episode_titles:
+            return
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            # retrieve all groups
+            groups = matches.markers.range(filepart.start, filepart.end, predicate=lambda mk: mk.name == 'group')
+            for group in groups:
+                # then search the season and episode numbers: [Cap.102_103]
+                m = self.episode_re.search(group.raw)
+                g = m.groupdict() if m else None
+                # if found and the season numbers match...
+                if not g or int(g['season']) != season.value or (
+                        g['end_season'] and int(g['end_season']) != season.value):
+                    continue
+
+                if not context.get('show_type'):
+                    # fix the show_type as this is not anime
+                    context['show_type'] = 'regular'
+
+                to_remove = []
+                to_append = []
+
+                # remove "[Cap.] match, if any
+                to_remove.extend(matches.range(group.start, group.start + len(self.prefix)))
+                # remove the wrong alternative title
+                to_remove.extend(alternative_titles)
+                # remove the wrong episode title
+                to_remove.extend(episode_titles)
+                to_remove.extend(matches.range(filepart.start, filepart.end, predicate=lambda match:
+                                               match.name == 'episode_title' and
+                                               match.value.lower() == 'audio'))
+                # remove all episode matches, since we're rebuild them
+                to_remove.extend(matches.named('episode'))
+
+                first_ep_num = int(g['episode'])
+                last_ep_num = int(g['end_episode']) if g['end_episode'] else first_ep_num
+                if 0 <= first_ep_num <= last_ep_num < 100:
+                    start_index = group.start + len(g['season']) + len(self.prefix)
+
+                    # rebuild all episode matches
+                    for ep_num in range(first_ep_num, last_ep_num + 1):
+                        new_episode = copy.copy(season)
+                        new_episode.name = 'episode'
+                        new_episode.tags = ['newpct']
+                        new_episode.value = ep_num
+                        if ep_num == first_ep_num:
+                            new_episode.start = start_index
+                            new_episode.end = new_episode.start + len(g['episode'])
+                        elif ep_num != last_ep_num:
+                            new_episode.start = start_index + len(g['episode'])
+                            new_episode.end = new_episode.start + 1
+                        else:
+                            new_episode.start = start_index + len(g['episode']) + len(g['end_season']) + 1
+                            new_episode.end = new_episode.start + len(g['end_episode'])
+                        to_append.append(new_episode)
+
+                return to_remove, to_append
+
+
+class FixSeasonAndEpisodeConflicts(Rule):
+    """
+    - Fix release group conflict with episode and or season
+    - Certain release names contains a conflicting screen_size (e.g.: 720 without p). It confuses guessit: the guessed
+    season and episode needs to be removed.
+    Bug: https://github.com/guessit-io/guessit/issues/308
+
+    e.g.: "Show.Name.S02.REPACK.720p.BluRay.DD5.1.x264-4EVERHD"
+          "[SuperGroup].Show.Name.-.06.[720.Hi10p][1F5578AC]"
+
+    guessit -t episode -G 4EVERHD "Show.Name.S02.REPACK.720p.BluRay.DD5.1.x264-4EVERHD"
+    guessit -t episode "[SuperGroup].Show.Name.-.06.[720.Hi10p][1F5578AC]"
+
+    without this fix:
+        For: [SuperGroup].Show.Name.-.06.[720.Hi10p][1F5578AC]
+        GuessIt found: {
+            "release_group": "SuperGroup",
+            "title": "Show Name",
+            "episode": [
+                6,
+                20
+            ],
+            "season": 7,
+            "screen_size": "720p",
+            "video_profile": "10bit",
+            "crc32": "1F5578AC",
+            "type": "episode"
+        }
+
+    with this fix:
+        For: [SuperGroup].Show.Name.-.06.[720.Hi10p][1F5578AC]
+        GuessIt found: {
+            "release_group": "SuperGroup",
+            "title": "Show Name",
+            "episode": 6,
+            "screen_size": "720p",
+            "video_profile": "10bit",
+            "crc32": "1F5578AC",
+            "type": "episode"
+        }
+
+    """
+    priority = POST_PROCESS
+    consequence = RemoveMatch
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_remove = []
+
+        screen_sizes = matches.named('screen_size')
+        for screen_size in screen_sizes:
+            to_remove.extend(matches.at_match(screen_size, predicate=lambda match: match.name in ('season', 'episode')))
+
+        release_groups = matches.named('release_group')
+        for group in release_groups:
+            to_remove.extend(matches.at_match(group, predicate=lambda match: match.name in ('season', 'episode')))
+
+        return to_remove
+
+
+class FixInvalidTitleOrAlternativeTitle(Rule):
+    """
+    Some release names have season/episode defined twice (relative and absolute), and one of them becomes an
+    alternative_title or a suffix in the title. This fix will remove the invalid alternative_title or the
+    invalid title's suffix
+
+    e.g.: "Show Name - 313-314 - s16e03-04"
+
+    guessit -t episode "Show Name - 313-314 - s16e03-04"
+
+    without this fix:
+        For: Show Name - 313-314 - s16e03-04
+        GuessIt found: {
+            "title": "Show Name",
+            "alternative_title": "313-314",
+            "season": 16,
+            "episode": [
+                3,
+                4
+            ],
+            "type": "episode"
+        }
+
+
+    with this fix:
+        For: Show Name - 313-314 - s16e03-04
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 16,
+            "absolute_episode": [
+                313,
+                314
+            ],
+            "episode": [
+                3,
+                4
+            ],
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    absolute_re = re.compile(r'([\W|_]*)(?P<absolute_episode_start>\d{3,4})\-(?P<absolute_episode_end>\d{3,4})\W*$')
+    properties = ('title', 'alternative_title', 'episode_title')
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        episodes = matches.named('episode')
+        if not episodes:
+            return
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            # retrieve all problematic titles
+            problematic_titles = matches.range(filepart.start, filepart.end, predicate=
+                                               lambda match: match.name in self.properties)
+
+            to_remove = []
+            to_append = []
+
+            for title in problematic_titles:
+                m = self.absolute_re.search(title.raw)
+                if not m:
+                    continue
+
+                # Remove the problematic title
+                to_remove.append(title)
+
+                # Remove the title suffix
+                new_value = title.raw[0: m.start()]
+                if new_value:
+                    # Add the correct title
+                    new_title = copy.copy(title)
+                    new_title.value = cleanup(new_value)
+                    new_title.end = m.start()
+                    to_append.append(new_title)
+
+                # and add the absolute episode range
+                g = m.groupdict()
+                absolute_episode_start = int(g['absolute_episode_start'])
+                absolute_episode_end = int(g['absolute_episode_end'])
+                for i in range(absolute_episode_start, absolute_episode_end + 1):
+                    episode = copy.copy(episodes[0])
+                    episode.name = 'absolute_episode'
+                    episode.value = i
+                    if i == absolute_episode_start:
+                        episode.start = title.start + m.start('absolute_episode_start')
+                        episode.end = title.start + m.end('absolute_episode_start')
+                    elif i < absolute_episode_end:
+                        episode.start = title.start + m.end('absolute_episode_start')
+                        episode.end = title.start + m.start('absolute_episode_end')
+                    else:
+                        episode.start = title.start + m.start('absolute_episode_end')
+                        episode.end = title.start + m.end('absolute_episode_end')
+                    to_append.append(episode)
+
+                return to_remove, to_append
+
+
+class FixWrongTitleDueToFilmTitle(Rule):
+    """
+    Work-around for https://github.com/guessit-io/guessit/issues/294
+    TODO: Remove when this bug is fixed
+
+    e.g.: "Show.Name.S03E16.1080p.WEB-DL.DD5.1.H.264-GOLF68"
+
+    guessit -t episode "Show.Name.S03E16.1080p.WEB-DL.DD5.1.H.264-GOLF68"
+
+    without this fix:
+    For: Show.Name.S03E16.1080p.WEB-DL.DD5.1.H.264-GOLF68
+        GuessIt found: {
+            "film_title": "Show Name",
+            "season": 3,
+            "episode": 16,
+            "screen_size": "1080p",
+            "format": "WEB-DL",
+            "audio_codec": "DolbyDigital",
+            "audio_channels": "5.1",
+            "video_codec": "h264",
+            "title": "GOL",
+            "film": 68,
+            "type": "episode"
+        }
+
+    with this fix:
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 3,
+            "episode": 16,
+            "screen_size": "1080p",
+            "format": "WEB-DL",
+            "audio_codec": "DolbyDigital",
+            "audio_channels": "5.1",
+            "video_codec": "h264",
+            "release_group": "GOLF68",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch, RenameMatch('title'), RenameMatch('episode')]
+    blacklist = ('special', 'season', 'multi')
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_remove = []
+        to_append = []
+        to_rename = []
+        to_rename_ep = []
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            film_title = matches.range(filepart.start, filepart.end, index=0, predicate=
+                                       lambda match: match.name == 'film_title' and not match.raw.isdigit())
+            if film_title:
+                title = matches.range(filepart.start, filepart.end,
+                                      predicate=lambda match: match.name == 'title', index=0)
+
+                if title:
+                    if title.value.lower() in self.blacklist:
+                        to_remove.append(title)
+                    if title.value.isdigit() and matches.previous(title, predicate=lambda m: m.name == 'episode'):
+                        title.value = int(title.value)
+                        to_rename_ep.append(title)
+
+                to_rename.append(film_title)
+
+            film = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'film', index=-1)
+            if not film or not film.raw.isdigit():
+                continue
+
+            previous = matches.previous(film, predicate=lambda match: match.start >= filepart.start, index=0)
+            if not previous:
+                continue
+
+            to_remove.append(film)
+            hole = matches.holes(previous.end, film.start, index=0)
+            if not hole or hole.value.lower() != 'f':
+                continue
+
+            new_property = copy.copy(previous)
+            new_property.value = cleanup(previous.raw + hole.value + film.raw)
+            new_property.end = film.end
+            if previous.name == 'title':
+                new_property.name = 'release_group'
+                new_property.tags = []
+                to_remove.extend(matches.named('release_group'))
+
+            if previous.name != 'release_group':
+                release_groups = matches.range(filepart.start, filepart.end,
+                                               predicate=lambda match: match.name == 'release_group')
+                to_remove.extend(release_groups)
+            to_remove.append(previous)
+
+            to_append.append(new_property)
+
+        return to_remove, to_append, to_rename, to_rename_ep
+
+
+class CreateExtendedTitleWithAlternativeTitles(Rule):
+    """
+    ExtendedTitle: 'extended_title' - post processor to add alternative titles the existing title.
+
+    e.g.: [SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
+
+    guessit -t episode "[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]"
+
+    without this rule:
+        For: [SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
+        GuessIt found: {
+            "release_group": "SuperGroup",
+            "title": "Show Name",
+            "alternative_title": [
+                "Still",
+                "Name"
+            ],
+            "episode": 11,
+            "screen_size": "1080p",
+            "type": "episode"
+        }
+
+    with this rule:
+        For: [SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
+        GuessIt found: {
+            "release_group": "SuperGroup",
+            "title": "Show Name",
+            "alternative_title": [
+                "Still",
+                "Name"
+            ],
+            "extended_title": "Show Name - Still+Name"
+            "episode": 11,
+            "screen_size": "1080p",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = AppendMatch
+    blacklist = ('temporada', 'temp', 'tem')
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        # Do not concatenate the titles if it's not an anime and there are languages
+        if not matches.tagged('anime') and matches.named('language'):
+            return
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            title = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'title', index=0)
+            if not title:
+                continue
+
+            if matches.range(filepart.start, filepart.end, predicate=
+                             lambda match: match.name == 'alternative_title' and match.value.lower() in self.blacklist):
+                continue
+
+            alternative_titles = matches.range(filepart.start, filepart.end, predicate=
+                                               lambda match: match.name == 'alternative_title')
+            if not alternative_titles:
+                continue
+
+            previous = title
+            extended_title = copy.copy(title)
+            extended_title.name = 'extended_title'
+            extended_title.value = title.value
+
+            # extended title is the concatenation between title and all alternative titles
+            for alternative_title in alternative_titles:
+                holes = matches.holes(start=previous.end, end=alternative_title.start)
+                # if the separator is a dash, add an extra space before and after
+                separators = [' ' + h.value + ' ' if h.value == '-' else h.value for h in holes]
+                separator = ' '.join(separators) if separators else ' '
+                extended_title.value += separator + alternative_title.value
+
+                previous = alternative_title
+
+            extended_title.end = previous.end
+            return extended_title
+
+
+class CreateExtendedTitleWithCountryOrYear(Rule):
+    """
+    ExtendedTitle: 'extended_title' - post processor to add country or year to the existing title.
+
+    e.g.: Show.Name.US.S03.720p.BluRay.x264-SuperGroup
+
+    guessit -t episode "Show.Name.US.S03.720p.BluRay.x264-SuperGroup"
+
+    without this rule:
+        For: Show.Name.US.S03.720p.BluRay.x264-SuperGroup
+        GuessIt found: {
+            "title": "Show Name",
+            "country": "UNITED STATES",
+            "season": 3,
+            "screen_size": "720p",
+            "format": "BluRay",
+            "video_codec": "h264",
+            "release_group": "SuperGroup",
+            "type": "episode"
+        }
+
+    with this rule:
+        For: Show.Name.US.S03.720p.BluRay.x264-SuperGroup
+        GuessIt found: {
+            "title": "Show Name",
+            "extended_title": "Show Name US"
+            "country": "UNITED STATES",
+            "season": 3,
+            "screen_size": "720p",
+            "format": "BluRay",
+            "video_codec": "h264",
+            "release_group": "SuperGroup",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = AppendMatch
+    affected_names = ('country', 'year')
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            title = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'title', index=0)
+            if not title:
+                continue
+
+            after_title = matches.next(title, index=0, predicate=
+                                       lambda match: match.end <= filepart.end and match.name in self.affected_names)
+
+            # only if there's a country or year
+            if not after_title:
+                continue
+
+            # Only add country or year if the next match is season, episode or date
+            next_match = matches.next(after_title, index=0, predicate=
+                                      lambda match: match.name in ('season', 'episode', 'date'))
+            if next_match:
+                extended_title = copy.copy(title)
+                extended_title.name = 'extended_title'
+                extended_title.value = extended_title.value + ' ' + re.sub(r'\W*', '', str(after_title.raw))
+                extended_title.end = after_title.end
+                extended_title.raw_end = after_title.raw_end
+                return extended_title
+
+
+class FixWrongTitlesWithCompleteKeyword(Rule):
+    """
+    Guessit bug: https://github.com/guessit-io/guessit/issues/310
+
+    e.g.: Show.Name.COMPLETE.SERIES.DVDRip.XviD-GROUP
+
+    guessit -t episode "Show.Name.COMPLETE.SERIES.DVDRip.XviD-GROUP"
+
+    without this fix:
+        For: Show.Name.COMPLETE.SERIES.DVDRip.XviD-GROUP
+        GuessIt found: {
+            "title": "Show Name COMPLETE SERIES",
+            "format": "DVD",
+            "video_codec": "XviD",
+            "release_group": "GROUP",
+            "type": "episode"
+        }
+
+    with this fix:
+        For: Show.Name.COMPLETE.SERIES.DVDRip.XviD-GROUP
+        GuessIt found: {
+            "title": "Show Name",
+            "other": "Complete",
+            "format": "DVD",
+            "video_codec": "XviD",
+            "release_group": "GROUP",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    complete_re = re.compile(r'(\W+The)?\W+complete(\W+(series|seasons?))?\W*$', flags=re.IGNORECASE)
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_remove = []
+        to_append = []
+
+        titles = []
+        titles.extend(matches.named('title'))
+        titles.extend(matches.named('alternative_title'))
+        titles.extend(matches.named('episode_titles'))
+
+        for title in titles:
+            complete = matches.next(title, index=0, predicate=
+                                    lambda match: match.name == 'other' and match.value.lower() == 'complete')
+            title_raw = title.raw + complete.raw if complete else title.raw
+            m = self.complete_re.search(title_raw)
+            if not m:
+                continue
+
+            new_title = copy.copy(title)
+            new_title.value = cleanup(title.raw[:m.start()])
+            new_title.end = m.start()
+
+            if not complete:
+                other = copy.copy(title)
+                other.name = 'other'
+                other.value = 'Complete'
+                other.tags = []
+                other.start = m.start()
+                other.end = m.end()
+                to_append.append(other)
+
+            to_remove.append(title)
+            to_append.append(new_title)
+
+        return to_remove, to_append
+
+
+class FixTvChaosUkWorkaround(Rule):
+    """
+    Medusa adds .hdtv.x264 to tv chaos uk releases. The video_codec might conflict with existing video_codec in the
+    original release name.
+
+    e.g.: Show.Name.Season.1.XviD.hdtv.x264
+
+    guessit -t episode "Show.Name.Season.1.XviD.hdtv.x264"
+
+    without this fix:
+        For: Show.Name.Season.1.XviD.hdtv.x264
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 1,
+            "video_codec": [
+                "XviD",
+                "h264"
+            ],
+            "format": "HDTV",
+            "type": "episode"
+        }
+
+    with this fix:
+        For: Show.Name.Season.1.XviD.hdtv.x264
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 1,
+            "video_codec": "XviD",
+            "format": "HDTV",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = RemoveMatch
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_remove = []
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            video_codecs = matches.range(filepart.start, filepart.end, predicate=
+                                         lambda match: match.name == 'video_codec')
+            formats = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'format')
+            if len(video_codecs) != 2 or len(formats) != 1:
+                continue
+
+            m_x264 = video_codecs[-1]
+            m_hdtv = matches.previous(m_x264, index=0)
+
+            if m_x264.end != filepart.end or m_x264.value != 'h264' or m_hdtv.name != 'format' \
+                    or m_hdtv.value != 'HDTV':
+                continue
+
+            to_remove.append(m_x264)
+            m_hdtv.tags.append('tvchaosuk')
+
+        return to_remove
+
+
+class FixTitlesContainsNumber(Rule):
+    """
+    There are shows where the title contains a number and the part after the number is incorrectly detected as
+    episode title.
+
+    e.g.: [Group].Show.Name.2.The.Big.Show.-.11.[1080p]
+
+    guessit -t episode "[Group].Show.Name.2.The.Big.Show.-.11.[1080p]"
+
+    without this fix:
+        For: [Group].Show.Name.2.The.Big.Show.-.11.[1080p]
+        GuessIt found: {
+            "release_group": "Group",
+            "title": "Show Name",
+            "episode_title": "The Big Show",
+            "episode": 11,
+            "screen_size": "1080p",
+            "type": "episode"
+        }
+
+
+    with this fix:
+        For: [Group].Show.Name.2.The.Big.Show.-.11.[1080p]
+        GuessIt found: {
+            "release_group": "Group",
+            "title": "Show Name 2 The Big Show",
+            "episode": 11,
+            "screen_size": "1080p",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            title = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'title', index=0)
+            if not title:
+                continue
+
+            # and after the title there's an episode_title match...
+            episode_title = matches.next(title, index=0, predicate=
+                                         lambda match: match.name == 'episode_title' and match.end <= filepart.end)
+
+            if not episode_title:
+                continue
+
+            holes = matches.holes(start=title.end, end=episode_title.start)
+            number = holes[0] if len(holes) == 1 else None
+            # and between the title and episode_title, there's one hole...
+            if number and number.raw.isdigit():
+                # join all three matches into one new title
+                new_title = copy.copy(title)
+                new_title.value = ' '.join([new_title.value, number.value, episode_title.value])
+                new_title.end = episode_title.end
+
+                # remove the old title and episode title; and append the new title
+                return [title, episode_title], [new_title]
+
+
+class AnimeWithSeasonAbsoluteEpisodeNumbers(Rule):
+    """
+    There are animes where the title contains the season number.
+
+    Medusa rule:
+    - The season should be part of the series name
+    - The episode should still use absolute numbering
+
+    e.g.: [Group].Show.Name.S2.-.19.[1080p]
+
+    guessit -t episode "[Group].Show.Name.S2.-.19.[1080p]"
+
+    without this rule:
+        For: [Group].Show.Name.S2.-.19.[1080p]
+        GuessIt found: {
+            "release_group": "Group",
+            "title": "Show Name",
+            "season": 2,
+            "episode_title": "19",
+            "screen_size": "1080p",
+            "type": "episode"
+        }
+
+    with this rule:
+        For: [Group].Show.Name.S2.-.19.[1080p]
+        GuessIt found: {
+            "release_group": "Group",
+            "title": "Show Name S2",
+            "absolute_episode": "19",
+            "screen_size": "1080p",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        if context.get('show_type') == 'regular' or not matches.tagged('anime') or matches.tagged('newpct'):
+            return
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            seasons = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'season')
+            for season in seasons:
+                if not season.parent or not season.parent.private:
+                    continue
+
+                title = matches.previous(season, index=-1, predicate=
+                                         lambda match: match.name == 'title' and match.end <= filepart.end)
+                episode_title = matches.next(season, index=0, predicate=
+                                             lambda match: (match.name == 'episode_title' and
+                                                            match.end <= filepart.end and
+                                                            match.value.isdigit()))
+
+                # the previous match before the season is the series name and
+                # the match after season is episode title and episode title is a number
+                if not title or not episode_title:
+                    continue
+
+                to_remove = []
+                to_append = []
+
+                # adjust title to append the series name.
+                # Only the season.parent contains the S prefix in its value
+                new_title = copy.copy(title)
+                new_title.value = ' '.join([title.value, season.parent.value])
+                new_title.end = season.end
+
+                # other fileparts might have the same season to be removed from the matches
+                # e.g.: /Show.Name.S2/[Group].Show.Name.S2.-.19.[1080p]
+                to_remove.extend(matches.named('season', predicate=lambda match: match.value == season.value))
+                to_remove.append(title)
+                to_append.append(new_title)
+
+                # move episode_title to absolute_episode
+                absolute_episode = copy.copy(episode_title)
+                absolute_episode.name = 'absolute_episode'
+                absolute_episode.value = int(episode_title.value)
+                to_remove.append(episode_title)
+                to_append.append(absolute_episode)
+                return to_remove, to_append
+
+
+class AnimeAbsoluteEpisodeNumbers(Rule):
+    """
+    Medusa rule: If it's an anime, prefer absolute episode numbers
+
+    e.g.: [Group].Show.Name.-.102.[720p]
+
+    guessit -t episode "[Group].Show.Name.-.102.[720p]"
+
+    without this rule:
+        For: [Group].Show.Name.-.102.[720p]
+        GuessIt found: {
+            "release_group": "Group",
+            "title": "Show Name",
+            "season": 1,
+            "episode": 2,
+            "screen_size": "720p",
+            "type": "episode"
+        }
+
+    with this rule:
+        For: [Group].Show.Name.-.102.[720p]
+        GuessIt found: {
+            "release_group": "Group",
+            "title": "Show Name",
+            "absolute_episode": 102,
+            "screen_size": "720p",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        # only for shows that seems to be animes
+        if context.get('show_type') == 'regular' or not matches.tagged('anime') or \
+                not matches.tagged('weak-duplicate') or matches.tagged('newpct'):
+            return
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            season = matches.range(filepart.start, filepart.end, index=0, predicate=
+                                   lambda match: match.name == 'season' and match.raw.isdigit())
+            episode = matches.next(season, index=0, predicate=
+                                   lambda match: (match.name == 'episode' and
+                                                  match.end <= filepart.end and
+                                                  match.raw.isdigit()))
+
+            # there should be season and episode and the episode should start right after the season and both raw values
+            # should be digit
+            if season and episode and season.end == episode.start:
+                # then make them an absolute episode:
+                absolute_episode = copy.copy(episode)
+                absolute_episode.name = 'absolute_episode'
+                # raw value contains the season and episode altogether
+                absolute_episode.value = int(episode.parent.raw if episode.parent else episode.raw)
+                to_remove = [season, episode]
+                to_append = [absolute_episode]
+                return to_remove, to_append
+
+
+class AbsoluteEpisodeNumbers(Rule):
+    """
+    Medusa absolute episode numbers rule. For animes without season, prefer absolute numbers.
+
+    e.g.: Show.Name.10.720p
+
+    guessit -t episode "Show.Name.10.720p"
+
+    without this rule:
+        For: Show.Name.10.720p
+        GuessIt found: {
+            "title": "Show Name",
+            "episode": 10,
+            "screen_size": "720p",
+            "type": "episode"
+        }
+
+    with this rule:
+        For: Show.Name.10.720p
+        GuessIt found: {
+            "title": "Show Name",
+            "absolute_episode": 10,
+            "screen_size": "720p",
+            "type": "episode"
+        }
+
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, RenameMatch('absolute_episode')]
+    non_words_re = re.compile(r'\W')
+    episode_words = ('e', 'episode', 'ep')
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        # if it seems to be anime and it doesn't have season
+        if context.get('show_type') != 'regular' and not matches.named('season') and not matches.tagged('newpct'):
+            episodes = matches.named('episode')
+            to_remove = []
+            to_rename = []
+            for episode in episodes:
+                # And there's no episode count
+                if matches.named('episode_count'):
+                    # Some.Show.1of8..Title.x264.AAC.Group
+                    # not absolute episode
+                    return
+
+                previous = matches.previous(episode, index=-1)
+                if previous:
+                    hole = matches.holes(start=previous.end, end=episode.start, index=0)
+                    # and the hole is not an 'episode' word (e.g.: e, ep, episode)
+                    if previous.name != 'episode':
+                        if hole and self.non_words_re.sub('', hole.value).lower() in self.episode_words:
+                            # Some.Show.E07.1080p.HDTV.x265-GROUP
+                            # Some.Show.Episode.10.Some.Title.720p
+                            # not absolute episode
+                            return
+                    elif hole and hole.value == '.':
+                        # [GroupName].Show.Name.-.02.5.(Special).[BD.1080p]
+                        # 5 is not absolute, and not an episode BTW
+                        to_remove.append(episode)
+                        continue
+
+                to_rename.append(episode)
+
+            return to_remove, to_rename
+
+
+class PartsAsEpisodeNumbers(Rule):
+    """
+    Medusa rule: Parts are treated as episodes
+
+    e.g.: Show.Name.Part.3.720p.HDTV.x264-Group
+
+    guessit -t episode "Show.Name.Part.3.720p.HDTV.x264-Group"
+
+    without the rule:
+        For: Show.Name.Part.3.720p.HDTV.x264-Group
+        GuessIt found: {
+            "title": "Show Name",
+            "part": 3,
+            "screen_size": "720p",
+            "format": "HDTV",
+            "video_codec": "h264",
+            "release_group": "Group",
+            "type": "episode"
+        }
+
+    without the rule:
+        For: Show.Name.Part.3.720p.HDTV.x264-Group
+        GuessIt found: {
+            "title": "Show Name",
+            "episode": 3,
+            "screen_size": "720p",
+            "format": "HDTV",
+            "video_codec": "h264",
+            "release_group": "Group",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = RenameMatch('episode')
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        # only if there's no season and no episode
+        if not matches.named('season') and not matches.named('episode') and not matches.named('date'):
+            return matches.named('part')
+
+
+class FixSeasonEpisodeDetection(Rule):
+    """
+    Work-around for https://github.com/guessit-io/guessit/issues/295
+    TODO: Remove when this bug is fixed
+
+    e.g.: "Some.Show.S02E14.X264.1080p.HDTV"
+
+    guessit -t episode "Some.Show.S02E14.X264.1080p.HDTV"
+
+    without the fix:
+        For: Some.Show.S02E14.X264.1080p.HDTV
+        GuessIt found: {
+            "title": "Some Show",
+            "season": [
+                2,
+                14
+            ],
+            "video_codec": "h264",
+            "screen_size": "1080p",
+            "format": "HDTV",
+            "type": "episode"
+        }
+
+    with the fix:
+        For: Some.Show.S02E14.X264.1080p.HDTV
+        GuessIt found: {
+            "title": "Some Show",
+            "season": 2,
+            "episode": 14,
+            "video_codec": "h264",
+            "screen_size": "1080p",
+            "format": "HDTV",
+            "type": "episode"
+        }
+
+    """
+    priority = POST_PROCESS
+    consequence = RenameMatch('episode')
+    codec_names = ('h264', 'h265')
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_rename = []
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            seasons = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'season')
+            # bug happens when there are 2 seasons...
+            if not seasons or len(seasons) != 2:
+                continue
+
+            # ... and no episodes
+            if not matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'episode'):
+                second_season = seasons[-1]
+                next_match = matches.range(second_season.end, filepart.end, index=0)
+                # guessit gets confused when the next match is x264 or x265
+                if next_match and next_match.name == 'video_codec' and next_match.value in self.codec_names:
+                    # rename the second season to episode
+                    episode = second_season
+                    to_rename.append(episode)
+
+        return to_rename
+
+
+class FixSeasonNotDetected(Rule):
+    """
+    Work-around for https://github.com/guessit-io/guessit/issues/306
+    TODO: Remove file_title when this bug is fixed
+
+    e.g.: Show.Name.-.Season.3.-.720p.BluRay.-.x264.-.Group
+
+    guessit -t episode "Show.Name.-.Season.3.-.720p.BluRay.-.x264.-.Group"
+
+    without this fix:
+        For: Show.Name.-.Season.3.-.720p.BluRay.-.x264.-.Group
+        GuessIt found: {
+            "title": "Show Name",
+            "alternative_title": "Season",
+            "episode": 3,
+            "screen_size": "720p",
+            "format": "BluRay",
+            "video_codec": "h264",
+            "release_group": "Group",
+            "type": "episode"
+        }
+
+    with this fix:
+        For: Show.Name.-.Season.3.-.720p.BluRay.-.x264.-.Group
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 3,
+            "screen_size": "720p",
+            "format": "BluRay",
+            "video_codec": "h264",
+            "release_group": "Group",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    season_re = re.compile(r'\b(season|series)\W*$', flags=re.IGNORECASE)
+    consequence = [RemoveMatch, AppendMatch, RenameMatch('season')]
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            episodes = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'episode')
+            for episode in episodes:
+                previous = matches.previous(episode, index=0)
+                m = self.season_re.search(previous.raw) if previous else None
+                if not m or matches.holes(previous.end, episode.start, index=0):
+                    continue
+
+                to_remove = []
+                to_append = []
+                to_rename = []
+
+                new_value = cleanup(previous.raw[:m.start()])
+                # if there's a new value (e.g.: 'Show Name Season' became 'Show Name'), keep it
+                if new_value:
+                    new_match = copy.copy(previous)
+                    new_match.value = new_value
+                    new_match.end = m.start()
+                    to_append.append(new_match)
+
+                matches.next(episode, index=0, predicate=lambda match: match.name == 'episode')
+
+                to_remove.append(previous)
+                to_rename.append(episode)
+
+                return to_remove, to_append, to_rename
+
+
+class FixWrongSeasonRangeDetectionDueToEpisode(Rule):
+    """
+    e.g.: Show.Name.-.Season.1.to.3.-.Mp4.1080p
+          Show.Name.-.Season.1-3.-.Mp4.1080p
+
+    guessit -t episode "Show.Name.-.Season.1.to.3.-.Mp4.1080p"
+
+    without this fix:
+        For: Show.Name.-.Season.1.to.3.-.Mp4.1080p
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 1,
+            "episode_title": "to",
+            "episode": 3,
+            "container": "MP4",
+            "screen_size": "1080p",
+            "type": "episode"
+        }
+
+
+    with this fix:
+        For: Show.Name.-.Season.1.to.3.-.Mp4.1080p
+        GuessIt found: {
+            "title": "Show Name",
+            "season": [1, 2, 3],
+            "container": "MP4",
+            "screen_size": "1080p",
+            "type": "episode"
+        }
+
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch, RenameMatch('season')]
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_remove = []
+        to_append = []
+        to_rename = []
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            seasons = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'season')
+            if len(seasons) != 1:
+                continue
+
+            # and no season or episodes on any next fileparts
+            if matches.range(filepart.end, predicate=lambda match: match.name in ('season', 'episode')):
+                continue
+
+            current_season = seasons[0]
+            while current_season:
+                next_match = matches.next(current_season, index=0, predicate= lambda match:
+                                          (match.end <= filepart.end and match.name in ('episode', 'episode_title')))
+
+                if not next_match:
+                    break
+
+                if next_match.name == 'episode_title':
+                    separator = next_match
+                    next_season = matches.next(next_match, index=0, predicate=
+                                               lambda match: match.end <= filepart.end and match.name == 'episode')
+                elif next_match.name == 'episode':
+                    separator = matches.holes(current_season.end, next_match.start, index=0)
+                    next_season = next_match
+
+                if not next_season or not separator:
+                    break
+
+                if separator.value in simple_separator:
+                    to_rename.append(next_season)
+                    if separator.name == 'episode_title':
+                        to_remove.append(next_match)
+
+                    current_season = next_season
+                elif separator.value in season_range_separator and 0 < current_season.value < next_season.value < 100:
+                    to_rename.append(next_season)
+                    if separator.name == 'episode_title':
+                        to_remove.append(next_match)
+
+                    # then create the season range
+                    for i in range(current_season.value + 1, next_season.value):
+                        new_season = copy.copy(current_season)
+                        new_season.value = i
+                        new_season.start = separator.start
+                        new_season.end = separator.end
+                        to_append.append(new_season)
+
+                    current_season = next_season
+                else:
+                    break
+
+        return to_remove, to_append, to_rename
+
+
+class FixWrongSeasonAndReleaseGroup(Rule):
+    """
+    Work-around for https://github.com/guessit-io/guessit/issues/303
+    TODO: Remove when this bug is fixed
+
+    e.g.: Show.Name.S06E04.1080i.HDTV.DD5.1.H264.BS666.rartv
+
+    guessit -t episode "Show.Name.S06E04.1080i.HDTV.DD5.1.H264.BS666.rartv"
+
+    without this fix:
+        For: Show.Name.S06E04.1080i.HDTV.DD5.1.H264.BS666.rartv
+        GuessIt found: {
+            "title": "Show Name",
+            "season": [
+                6,
+                666
+            ],
+            "episode": 4,
+            "screen_size": "1080i",
+            "format": "HDTV",
+            "audio_codec": "DolbyDigital",
+            "audio_channels": "5.1",
+            "video_codec": "h264",
+            "release_group": "B",
+            "type": "episode"
+        }
+
+    with this fix:
+        For: Show.Name.S06E04.1080i.HDTV.DD5.1.H264.BS666
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 6,
+            "episode": 4,
+            "screen_size": "1080i",
+            "format": "HDTV",
+            "audio_codec": "DolbyDigital",
+            "audio_channels": "5.1",
+            "video_codec": "h264",
+            "release_group": "BS666",
+            "type": "episode"
+        }
+
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    previous_properties = ('video_codec', 'format', 'release_group')
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_remove = []
+        to_append = []
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            seasons = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'season')
+            # only when there are 2 seasons
+            last_season = seasons[-1] if len(seasons) == 2 else None
+            previous = matches.previous(last_season, index=-1) if last_season else None
+            if previous and previous.start >= filepart.start:
+                holes = matches.holes(start=previous.end, end=last_season.start)
+                hole = holes[0] if len(holes) == 1 else None
+                # there's only 1 hole before the season
+                if not hole:
+                    continue
+
+                prefix = previous.value if previous.name == 'release_group' else ''
+                correct_release_group = prefix + hole.raw + last_season.raw
+
+                if matches.previous(last_season, predicate=lambda match: match.name in self.previous_properties):
+                    new_release_group = copy.copy(previous)
+                    new_release_group.value = correct_release_group
+
+                    to_remove.append(last_season)
+                    to_remove.append(previous)
+                    to_append.append(new_release_group)
+
+        return to_remove, to_append
+
+
+class FixSeasonRangeDetection(Rule):
+    """
+    Work-around for https://github.com/guessit-io/guessit/issues/287
+    TODO: Remove when this bug is fixed
+
+    e.g.: show name s01-s04
+
+    guessit -t episode "show name s01-s04"
+
+    without this fix:
+        For: show name s01-s04
+        GuessIt found: {
+            "title": "show name",
+            "season": [
+                1,
+                4
+            ],
+            "type": "episode"
+        }
+
+    with this fix:
+        For: show name s01-s04
+        GuessIt found: {
+            "title": "show name",
+            "season": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_remove = []
+        to_append = []
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            seasons = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'season')
+            # only when there are 2 seasons
+            start_season = seasons[0] if len(seasons) == 2 else None
+            end_season = seasons[-1] if len(seasons) == 2 else None
+
+            # and no season or episodes on any next fileparts
+            if matches.range(filepart.end, predicate=lambda match: match.name in ('season', 'episode')):
+                continue
+
+            # and first season is lesser than the second and both are between 1 and 99
+            if start_season and end_season and 0 < start_season.value < end_season.value < 100:
+                season_separator = matches.input_string[start_season.end:end_season.start]
+                # and they are separated by a 'season range separator'
+                if season_separator.lower() in season_range_separator:
+                    episode_title = matches.next(start_season, index=0)
+                    if episode_title and episode_title.name == 'episode_title' and episode_title.value.lower() == 'to':
+                        to_remove.append(episode_title)
+
+                    # then create the missing numbers
+                    for i in range(start_season.value + 1, end_season.value):
+                        new_season = copy.copy(start_season)
+                        new_season.value = i
+                        new_season.start = start_season.end
+                        new_season.end = end_season.start
+                        to_append.append(new_season)
+
+        return to_remove, to_append
+
+
+class FixEpisodeRangeDetection(Rule):
+    """
+    Work-around for https://github.com/guessit-io/guessit/issues/287
+    TODO: Remove when this bug is fixed
+
+    e.g.: show name s02e01-e04
+
+    guessit -t episode "show name s02e01-e04"
+
+    without this fix:
+        For: show name s02e01-e04
+        GuessIt found: {
+            "title": "show name",
+            "season": 2
+            "episode": [
+                1,
+                4
+            ],
+            "type": "episode"
+        }
+
+    with this fix:
+        For: show name s02e01-e04
+        GuessIt found: {
+            "title": "show name",
+            "season" 2
+            "episode": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch, RenameMatch('episode')]
+    separator_re = re.compile(r'(?P<separator>[^\d]+)\d+')
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_append = []
+        to_remove = []
+        to_rename = []
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            episodes = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'episode')
+
+            next_match = matches.next(episodes[0], index=0) if len(episodes) == 1 else None
+            if next_match and next_match.name in ('episode_count', 'episode_title') and (
+                    isinstance(next_match.value, int) or next_match.value.isdigit()) and next_match.end <= filepart.end:
+                episodes.append(next_match)
+
+            # only when there are 2 episodes
+            start_episode = episodes[0] if len(episodes) == 2 else None
+            end_episode = episodes[-1] if len(episodes) == 2 else None
+
+            # and no episodes on any next fileparts
+            if matches.range(filepart.end, predicate=lambda match: match.name == 'episode'):
+                continue
+
+            # and first episode is lesser than the second and both are between 1 and 99
+            if start_episode and end_episode and 0 < start_episode.value < int(end_episode.value) < 100:
+                separators = self.separator_re.findall(end_episode.raw)
+                if separators:
+                    separator = separators[0]
+                else:
+                    holes = matches.holes(start=start_episode.end, end=end_episode.start)
+                    separator = holes[0].value if len(holes) == 1 else None
+
+                # and they are separated by a 'range separator'
+                if not separator:
+                    continue
+
+                is_simple_separator = separator.lower() in simple_separator
+                is_range = separator.lower() in episode_range_separator
+                if is_range:
+                    # then create the missing numbers
+                    for i in range(start_episode.value + 1, int(end_episode.value)):
+                        new_episode = copy.copy(start_episode)
+                        new_episode.value = i
+                        new_episode.start = start_episode.end
+                        new_episode.end = end_episode.start
+                        to_append.append(new_episode)
+
+                if is_range or is_simple_separator:
+                    if end_episode.name == 'episode_count':
+                        to_rename.append(end_episode)
+                    elif end_episode.name == 'episode_title':
+                        to_remove.append(end_episode)
+
+                        end_episode = copy.copy(end_episode)
+                        end_episode.name = 'episode'
+                        end_episode.value = int(end_episode.value)
+                        end_episode.tags = []
+                        to_append.append(end_episode)
+
+        return to_remove, to_append, to_rename
+
+
+class FixEpisodeRangeWithSeasonDetection(Rule):
+    """
+    Work-around for https://github.com/guessit-io/guessit/issues/287
+    TODO: Remove when this if this scenario is fixed upstream
+
+    e.g.: Show.Name.S01E01-S01E21
+
+    guessit -t episode "Show.Name.S01E01-S01E21"
+
+    without this fix:
+        For: Show.Name.S01E01-S01E04
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 1,
+            "episode": [
+                1,
+                4
+            ],
+            "type": "episode"
+        }
+
+
+    with this fix:
+        For: Show.Name.S01E01-S01E04
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 1,
+            "episode": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_remove = []
+        to_append = []
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            seasons = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'season')
+            # only when there are 2 seasons
+            start_season = seasons[0] if len(seasons) == 2 else None
+            end_season = seasons[-1] if len(seasons) == 2 else None
+
+            # and no episodes on any next fileparts
+            if matches.range(filepart.end, predicate=lambda match: match.name == 'episode'):
+                continue
+
+            # and first season is lesser than the second and both are between 1 and 99
+            if start_season and end_season and start_season.value == end_season.value:
+                first_episode = matches.next(start_season, index=0)
+                end_episode = matches.next(end_season, index=0)
+
+                if first_episode and end_episode and first_episode.name == end_episode.name == 'episode' \
+                        and 0 < first_episode.value < end_episode.value < 100:
+                    season_separator = matches.input_string[first_episode.end:end_season.start]
+                    # and they are separated by a 'season range separator'
+                    if season_separator.lower() in season_range_separator:
+                        episode_title = matches.next(start_season, index=0)
+                        if episode_title and episode_title.name == 'episode_title' \
+                                and episode_title.value.lower() == 'to':
+                            to_remove.append(episode_title)
+
+                        # then create the missing numbers
+                        for i in range(first_episode.value + 1, end_episode.value):
+                            new_episode = copy.copy(first_episode)
+                            new_episode.value = i
+                            new_episode.start = first_episode.end
+                            new_episode.end = end_episode.start
+                            to_append.append(new_episode)
+
+        return to_remove, to_append
+
+
+class FixWrongEpisodeDetectionInSeasonRange(Rule):
+    """
+    Work-around for https://github.com/guessit-io/guessit/issues/304
+    TODO: Remove when this bug is fixed
+
+    e.g.: "Show.season_1-10.(DVDrip)"
+
+    guessit -t episode "Show.season_1-10.(DVDrip)"
+
+    without the fix:
+        For: Show.season_1-10.(DVDrip)
+        GuessIt found: {
+            "title": "Show",
+            "season": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "episode": 10,
+            "format": "DVD",
+            "type": "episode"
+        }
+
+
+    with the fix:
+        For: Show.season_1-10.(DVDrip)
+        GuessIt found: {
+            "title": "Show",
+            "season": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "format": "DVD",
+            "type": "episode"
+        }
+
+    """
+    priority = POST_PROCESS
+    consequence = RemoveMatch
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_remove = []
+
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            seasons = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'season')
+            episodes = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'episode')
+            # bug happens when there are more than 1 season and exactly 1 episode
+            if seasons and episodes and len(seasons) > 1 and len(episodes) == 1:
+                episode = episodes[0]
+                conflict = matches.at_match(episode, predicate=
+                                            lambda match: not match.private and match.name == 'season')
+                if conflict:
+                    to_remove.append(episode)
+
+        return to_remove
+
+
+class ExpectedTitlePostProcessor(Rule):
+    """
+    Expected title post processor to replace dots with spaces (needed when expected title is a regex)
+
+    e.g.: Show.Net.S01E06.720p
+
+    guessit -t episode -T "re:^\w+ Net\b" "Show.Net.S01E06.720p"
+
+    without this rule:
+        For: Show.Net.S01E06.720p
+        GuessIt found: {
+            "title": "Show.Net",
+            "season": 1,
+            "episode": 6,
+            "screen_size": "720p",
+            "type": "episode"
+        }
+
+    with this rule:
+        For: Show.Net.S01E06.720p
+        GuessIt found: {
+            "title": "Show Net",
+            "season": 1,
+            "episode": 6,
+            "screen_size": "720p",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        # All titles that matches because of a expected title was tagged as 'expected'
+        # and title.value is not in the expected list, it's a regex
+        titles = matches.tagged('expected', predicate=lambda match: match.value not in context.get('expected_title'))
+
+        to_remove = []
+        to_append = []
+
+        for title in titles:
+            # Remove all dots from the title
+            new_title = copy.copy(title)  # IMPORTANT - never change the value. Better to remove and add it
+            new_title.value = cleanup(title.value)
+            to_remove.append(title)
+            to_append.append(new_title)
+
+        return to_remove, to_append
+
+
+class FixMultipleTitles(Rule):
+    """
+    Probably a guessit bug, guessit might return more than one title instead of alternative_titles
+    bug: https://github.com/guessit-io/guessit/issues/309
+
+    e.g.: /shows/Show.Name.S01E05.WEBRip.x264-GROUP__gYDfLA/Show.Name.S01E05.WEBRip.x264-GROUP
+
+    guessit -t episode "/shows/Show.Name.S01E05.WEBRip.x264-GROUP__gYDfLA/Show.Name.S01E05.WEBRip.x264-GROUP"
+
+    without this rule:
+        For: /shows/Show.Name.S01E05.WEBRip.x264-GROUP__gYDfLA/Show.Name.S01E05.WEBRip.x264-GROUP
+        GuessIt found: {
+            "title": [
+                "Show Name",
+                "GROUP gYDfLA"
+            ],
+            "season": 1,
+            "episode": 5,
+            "format": "WEBRip",
+            "video_codec": "h264",
+            "release_group": "GROUP",
+            "type": "episode"
+        }
+
+    with this rule:
+        For: /shows/Show.Name.S01E05.WEBRip.x264-GROUP__gYDfLA/Show.Name.S01E05.WEBRip.x264-GROUP
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 1,
+            "episode": 5,
+            "format": "WEBRip",
+            "video_codec": "h264",
+            "release_group": "GROUP",
+            "type": "episode"
+        }
+
+    """
+    priority = POST_PROCESS
+    consequence = RemoveMatch
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        # In case of duplicated titles, keep only the first one
+        titles = matches.named('title')
+
+        to_remove = titles[1:]
+
+        return to_remove
+
+
+class EnhanceReleaseGroupDetection(Rule):
+    """
+    Some release groups are not detected when there's when they appear after subtitle_language or size.
+    Bug: https://github.com/guessit-io/guessit/issues/313
+
+    e.g.: Show.Name.S01E01.2008.BluRay.VC1.1080P.5.1.WMV-NOVO
+          Show.Name.S01E02.HDTV.x264.PROPER-LOL
+
+    without this fix:
+        For: Show.Name.S01E02.HDTV.x264.PROPER-LOL
+        GuessIt found: {
+            "title": "Cosmos A Space Time Odyssey",
+            "season": 1,
+            "episode": 2,
+            "format": "HDTV",
+            "video_codec": "h264",
+            "other": "Proper",
+            "proper_count": 1,
+            "type": "episode"
+        }
+
+    with this fix:
+        For: Show.Name.S01E02.HDTV.x264.PROPER-LOL
+        GuessIt found: {
+            "title": "Cosmos A Space Time Odyssey",
+            "season": 1,
+            "episode": 2,
+            "format": "HDTV",
+            "video_codec": "h264",
+            "other": "Proper",
+            "proper_count": 1,
+            "release_group": "LOL",
+            "type": "episode"
+        }
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    scene_previous_names = ['subtitle_language', 'size']
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        if matches.tagged('newpct') or matches.tagged('tvchaosuk'):
+            return
+
+        to_append = []
+        to_remove = []
+
+        for filepart in marker_sorted(matches.markers.named('path'), matches):
+            start, end = filepart.span
+
+            release_group = matches.range(start, end, predicate=lambda match: match.name == 'release_group', index=0)
+            if release_group and ('anime', 'scene') not in release_group.tags:
+                continue
+
+            last_hole = matches.holes(start, end + 1, predicate=lambda hole: cleanup(hole.value), index=-1)
+            if not last_hole:
+                continue
+
+            previous_match = matches.previous(last_hole, lambda match: not match.private, index=0)
+            if previous_match and previous_match.name in self.scene_previous_names and \
+                    not matches.input_string[previous_match.end:last_hole.start].strip(seps) and \
+                    not int_coercable(last_hole.value.strip(seps)):
+
+                if release_group and release_group.start <= previous_match.start:
+                    continue
+
+                last_hole.name = 'release_group'
+                to_append.append(last_hole)
+                to_remove.extend(matches.named('release_group'))
+
+        return to_remove, to_append
+
+
+class ReleaseGroupPostProcessor(Rule):
+    """
+    Release Group post processor
+    Removes invalid parts from the release group property
+
+    e.g.: Some.Show.S02E14.1080p.HDTV.X264-GROUP[TRASH]
+
+    guessit -t episode "Some.Show.S02E14.1080p.HDTV.X264-GROUP[TRASH]"
+
+    without this post processor:
+        For: Some.Show.S02E14.1080p.HDTV.X264-GROUP[TRASH]
+        GuessIt found: {
+            "title": "Some Show",
+            "season": 2,
+            "episode": 14,
+            "screen_size": "1080p",
+            "format": "HDTV",
+            "video_codec": "h264",
+            "release_group": "GROUP[TRASH]",
+            "type": "episode"
+        }
+
+
+    with this post processor:
+        For: Some.Show.S02E14.1080p.HDTV.X264-GROUP[TRASH]
+        GuessIt found: {
+            "title": "Some Show",
+            "season": 2,
+            "episode": 14,
+            "screen_size": "1080p",
+            "format": "HDTV",
+            "video_codec": "h264",
+            "release_group": "GROUP",
+            "type": "episode"
+        }
+
+    """
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    regexes = [
+        # italian release: drop everything after [CURA]
+        re.compile(r'\[CURA\].*$', flags=re.IGNORECASE),
+
+        # NLSubs-word
+        re.compile(r'\W*\b([a-z]{1,3}[\.\-]?)?(subs?)\b\W*', flags=re.IGNORECASE),
+
+        # https://github.com/guessit-io/guessit/issues/302
+        re.compile(r'\W*\b(obfuscated|dual|audio)\b\W*', flags=re.IGNORECASE),
+        re.compile(r'\W*\b(vtv|sd|avc|rp|norar|re\-?up(loads?)?)\b\W*', flags=re.IGNORECASE),
+        re.compile(r'\W*\b(legenda(do)?|dublado|hebits)\b\W*', flags=re.IGNORECASE),
+
+        # [word], (word), {word}
+        re.compile(r'(?<=.)\W*[\[\(\{].+[\}\)\]]?\W*$', flags=re.IGNORECASE),
+
+        # https://github.com/guessit-io/guessit/issues/301
+        # vol255+101
+        re.compile(r'\.vol\d+\+\d+', flags=re.IGNORECASE),
+
+        # word.rar, word.gz
+        re.compile(r'\.((rar)|(gz)|(\d+))$', flags=re.IGNORECASE),
+
+        # word.rartv, word.ettv
+        re.compile(r'(?<=[a-z0-9]{3})\.([a-z]+)$', flags=re.IGNORECASE),
+
+        # word.a00, word.b12
+        re.compile(r'(?<=[a-z0-9]{3})\.([a-z]\d{2,3})$', flags=re.IGNORECASE),
+
+        # word-1234, word-456
+        re.compile(r'(?<=[a-z0-9]{3})\-(\d{3,4})$', flags=re.IGNORECASE),
+
+        # word-fansub
+        re.compile(r'(?<=[a-z0-9]{3})\-((fan)?sub(s)?)$', flags=re.IGNORECASE),
+
+        # ...word
+        re.compile(r'^\W+', flags=re.IGNORECASE),
+
+        # word[.
+        re.compile(r'\W+$', flags=re.IGNORECASE),
+
+        re.compile(r'\s+', flags=re.IGNORECASE),
+    ]
+
+    def when(self, matches, context):
+        """
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        release_groups = matches.named('release_group')
+        to_remove = []
+        to_append = []
+        for release_group in release_groups:
+            value = release_group.value
+            for regex in self.regexes:
+                value = regex.sub(' ', value).strip()
+                if not value:
+                    break
+
+            if release_group.value != value:
+                to_remove.append(release_group)
+                if value:
+                    new_release_group = copy.copy(release_group)
+                    new_release_group.value = clean_groupname(value)
+                    to_append.append(new_release_group)
+
+        return to_remove, to_append
+
+
+def rules():
+    """
+    Returns all custom rules to be applied to guessit default api.
+
+    IMPORTANT! The order is important.
+    Certain rules needs to be executed first, and others should be executed at the end
+    DO NOT define priority or dependency in each rule, it can become a mess. Better to just define the correct order
+    in this method
+
+    Builder for rebulk object.
+    :return: Created Rebulk object
+    :rtype: Rebulk
+    """
+    return Rebulk().rules(
+        FixTvChaosUkWorkaround,
+        FixAnimeReleaseGroup,
+        SpanishNewpctReleaseName,
+        FixInvalidTitleOrAlternativeTitle,
+        FixSeasonAndEpisodeConflicts,
+        FixWrongTitleDueToFilmTitle,
+        FixSeasonNotDetected,
+        FixWrongSeasonRangeDetectionDueToEpisode,
+        FixWrongSeasonAndReleaseGroup,
+        FixSeasonEpisodeDetection,
+        FixSeasonRangeDetection,
+        FixEpisodeRangeDetection,
+        FixEpisodeRangeWithSeasonDetection,
+        FixWrongEpisodeDetectionInSeasonRange,
+        FixTitlesContainsNumber,
+        FixWrongTitlesWithCompleteKeyword,
+        AnimeWithSeasonAbsoluteEpisodeNumbers,
+        AnimeAbsoluteEpisodeNumbers,
+        AbsoluteEpisodeNumbers,
+        PartsAsEpisodeNumbers,
+        ExpectedTitlePostProcessor,
+        CreateExtendedTitleWithAlternativeTitles,
+        CreateExtendedTitleWithCountryOrYear,
+        EnhanceReleaseGroupDetection,
+        ReleaseGroupPostProcessor,
+        FixMultipleTitles
+    )

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -537,7 +537,7 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
 
         # remember whether it's a proper
         if parse_result.extra_info:
-            self.is_proper = re.search(r'(^|[\. _-])(proper|repack)([\. _-]|$)', parse_result.extra_info, re.I) is not None
+            self.is_proper = parse_result.is_proper
 
         # if the result is complete then remember that for later
         # if the result is complete then set release name

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -1,0 +1,2464 @@
+# standard_repeat
+? Show.Name.S01E02.S01E03.HDTV.720p.x264-Group
+: title: Show Name
+  season: 1
+  episode: [2, 3]
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# standard_repeat
+? Show Name - S01E02 - S01E03 - S01E04 Episode Name
+: title: Show Name
+  season: 1
+  episode: [2, 3, 4]
+  episode_title: Episode Name
+  type: episode
+
+# fov_repeat
+? Show.Name.1x02.1x03.Bluray.1080p.x265-SuperGroup
+: title: Show Name
+  season: 1
+  episode: [2, 3]
+  format: BluRay
+  screen_size: 1080p
+  video_codec: h265
+  release_group: SuperGroup
+  type: episode
+
+# fov_repeat
+? Show Name 1x02 1x03 1x04 Episode Name
+: title: Show Name
+  season: 1
+  episode: [2, 3, 4]
+  episode_title: Episode Name
+  type: episode
+
+# standard
+? Show.Name.S01E02.HDTV.720p.x264-Group
+: title: Show Name
+  season: 1
+  episode: 2
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# standard
+? Show Name - S01E04 Episode Name
+: title: Show Name
+  season: 1
+  episode: 4
+  episode_title: Episode Name
+  type: episode
+
+# standard
+? Show.Name.S01.E02.My.Episode.Name
+: title: Show Name
+  season: 1
+  episode: 2
+  episode_title: My Episode Name
+  type: episode
+
+# standard
+? Show.Name.S01E02E03.HDTV.720p.x264-Group
+: title: Show Name
+  season: 1
+  episode: [2, 3]
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# standard
+? Show Name - S01E02-03 - Episode Name
+: title: Show Name
+  season: 1
+  episode: [2, 3]
+  episode_title: Episode Name
+  type: episode
+
+# standard
+? Show.Name.S01.E02.E03
+: title: Show Name
+  season: 1
+  episode: [2, 3]
+  type: episode
+
+# fov
+? Show_Name.1x02.HDTV_720p_x264-Group
+: title: Show Name
+  season: 1
+  episode: 2
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# fov
+? Show Name - 1x04 Episode Name
+: title: Show Name
+  season: 1
+  episode: 4
+  episode_title: Episode Name
+  type: episode
+
+# fov
+? Show_Name.1x02x03x04.DVD.480p_xvid-SomeGroup
+: title: Show Name
+  season: 1
+  episode: [2, 3, 4]
+  format: DVD
+  screen_size: 480p
+  video_codec: XviD
+  release_group: SomeGroup
+  type: episode
+
+# fov
+? Show Name - 1x02-03-04 - My Episode
+: title: Show Name
+  season: 1
+  episode: [2, 3, 4]
+  episode_title: My Episode
+  type: episode
+
+# newpct (SpanishNewpctReleaseName)
+? Show Name - Temporada 4 HDTV x264[Cap.408_409]SPANISH-AUDIO-NEWPCT
+: title: Show Name
+  season: 4
+  episode: [8, 9]
+  format: HDTV
+  video_codec: h264
+  language: es
+  release_group: NEWPCT
+  type: episode
+
+# newpct (SpanishNewpctReleaseName)
+? - Show Name - Temporada 4 [HDTV][Cap.408][Espanol Castellano]
+  - Show Name - Temporada 4 [HDTV][Cap.408][Español Castellano]
+: title: Show Name
+  season: 4
+  episode: 8
+  format: HDTV
+  language: es
+  type: episode
+
+# newpct (SpanishNewpctReleaseName)
+? Show Name - Temporada 4 HDTV x264[Cap.409]SPANISH AUDIO-NEWPCT)
+: title: Show Name
+  season: 4
+  episode: 9
+  format: HDTV
+  video_codec: h264
+  language: es
+  release_group: NEWPCT
+  type: episode
+
+# scene_date_format
+? Show.Name.2010.11.23.HDTV.720p.x264-Group
+: title: Show Name
+  date: 2010-11-23
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# scene_date_format
+? Show Name - 2010.11.23 - Episode Name
+: title: Show Name
+  date: 2010-11-23
+  episode_title: Episode Name
+  type: episode
+
+# scene_sports_format
+# TO FIX: current parser and guessit parser cannot parse this correctly
+? Show.Name.100.Event.2010.11.23.HDTV.720p.x264-Group
+: title: Show Name
+  season: 1 # ?
+  episode: 0 # ?
+  episode_title: Event
+  date: 2010-11-23
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# scene_sports_format
+? Show.Name.2011.12.24.HDTV.720p.x264-Group
+: title: Show Name
+  date: 2011-12-24
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# scene_sports_format
+? Show Name - 2010.11.23 - Episode Name
+: title: Show Name
+  date: 2010-11-23
+  episode_title: Episode Name
+  type: episode
+
+# stupid
+# TO FIX: current parser doesn't return series_name
+#         guessit parser cannot parse this correctly, only using a parent folder
+? /shows/Show.Name.Abbreviated.S01E02.1080p.BluRay.x264-TPZ/tzp-shownameabr102.mkv
+: title: Show Name Abbreviated
+  season: 1
+  episode: 2
+  video_codec: h264
+  format: BluRay
+  screen_size: 1080p
+  release_group: TPZ
+  container: mkv
+  mimetype: video/x-matroska
+  type: episode
+
+# verbose
+? Show Name Season 1 Episode 2 Ep Name
+: title: Show Name
+  season: 1
+  episode: 2
+  episode_title: Ep Name
+  type: episode
+
+# season_only
+? Show.Name.S01.HDTV.720p.x264-Group
+: title: Show Name
+  season: 1
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# no_season_multi_ep
+? Show.Name.E02-03.HDTV.720p.X264-Group
+: title: Show Name
+  episode: [2, 3]
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# no_season_multi_ep
+? Show.Name.E02.2010
+: title: Show Name
+  episode: 2
+  year: 2010
+  type: episode
+
+# no_season_general
+? Show.Name.E23.Test
+: title: Show Name
+  episode: 23
+  episode_title: Test
+  type: episode
+
+# no_season_general
+? Show.Name.Part.3.HDTV.720p.x264-Group
+: title: Show Name
+  episode: 3
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# no_season_general
+? Show.Name.Part.1.and.Part.2.HDTV.720p.x264-Group
+: title: Show Name
+  episode: [1, 2]
+  episode_title: and # guessit issue, but it's not a big problem
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# bare
+? Show.Name.102.HDTV.720p.x264-Group
+: title: Show Name
+  season: 1
+  episode: 2
+  format: HDTV
+  screen_size: 720p
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# no_season (on filename... only works with a parent folder)
+? /show/Show Name/Season 03/Show Name - 01 - Ep Name
+: title: Show Name
+  season: 3
+  episode: 1
+  episode_title: Ep Name
+  type: episode
+
+# no_season
+# TODO: current parser splits folders and files, but guessit does it altogether.
+? 01 - Ep Name
+: episode: 1
+  episode_title: Ep Name
+  type: episode
+  disabled: true # Disabling this test until a real scenario appears
+
+# anime_horriblesubs
+? "[HorribleSubs] Show Name - 01 [720p]"
+: title: Show Name
+  absolute_episode: 1
+  screen_size: 720p
+  release_group: HorribleSubs
+  type: episode
+
+# anime_ultimate
+
+# anime_french_fansub
+? "[SomeGroup-Fansub]_Show_Name_727_[VOSTFR][HD_1280x720]"
+: title: Show Name
+  absolute_episode: 727
+  release_group: SomeGroup
+  screen_size: 720p
+  subtitle_language: fr
+  other: HD
+  type: episode
+
+# anime_french_fansub
+? "[SomeGroup-Fansub]_Show_Name_269_[VOSTFR]_[720p]_[1921E00C]"
+: title: Show Name
+  absolute_episode: 269
+  screen_size: 720p
+  subtitle_language: fr
+  crc32: 1921E00C
+  release_group: SomeGroup
+  type: episode
+
+# anime_french_fansub
+? "[GROUP]Show_Name_726_[VOSTFR]_[V1]_[8bit]_[720p]_[2F7B3FA2]"
+: title: Show Name
+  absolute_episode: 726
+  screen_size: 720p
+  subtitle_language: fr
+  crc32: 2F7B3FA2
+  release_group: GROUP
+  version: 1
+  video_profile: 8bit
+  type: episode
+
+# anime_french_fansub
+# guessit parser only works with show_type=anime
+? Show Name 445 VOSTFR par Fansub-Resistance (1280*720) - version MQ
+: options: {show_type: anime}
+  title: Show Name
+  absolute_episode: 445
+  screen_size: 720p
+  subtitle_language: fr
+# TODO: Fix
+#  release_group: Resistance
+  release_group: version MQ
+  type: episode
+
+
+# anime_french_fansub
+# guessit parser only works with show_type=anime
+? Show Name Super 015 VOSTFR par Fansub-Resistance (1280x720) - HQ version
+: options: {show_type: anime}
+  title: Show Name Super
+  absolute_episode: 15
+  subtitle_language: fr
+  screen_size: 720p
+# TODO: Fix
+#  release_group: Resistance
+  release_group: version
+  other: HQ
+  type: episode
+
+# anime_french_fansub
+? "[Z-Team][DBSuper.pw] Show Name Super - 028 (VOSTFR)(720p AAC)(MP4)"
+: title: Show Name Super
+  absolute_episode: 28
+  subtitle_language: fr
+  screen_size: 720p
+  release_group: Z-Team
+  audio_codec: AAC
+  container: MP4
+  type: episode
+
+# anime_french_fansub
+? "[SnF] Show Name - 24 VOSTFR [720p][41761A60]"
+: title: Show Name
+  absolute_episode: 24
+  subtitle_language: fr
+  screen_size: 720p
+  release_group: SnF
+  crc32: 41761A60
+  type: episode
+
+# anime_french_fansub
+? "[Y-F] Very long Show Name Here - 03 Vostfr HD 8bits"
+: title: Very long Show Name Here
+  absolute_episode: 3
+  subtitle_language: fr
+  release_group: Y-F
+  other: HD
+  type: episode
+
+# anime_french_fansub (FixTitlesContainsNumber)
+? Show Name Online 2 - The Show 04 vostfr FHD
+: title: Show Name Online 2 The Show
+  absolute_episode: 4
+  subtitle_language: fr
+  release_group: FHD
+  type: episode
+
+# anime_french_fansub
+# guessit parser only works with show_type=anime
+? Show Name 804 vostfr HD
+: options: {show_type: anime}
+  title: Show Name
+  absolute_episode: 804
+  subtitle_language: fr
+  other: HD
+  type: episode
+
+# anime_french_fansub
+? Show Name 04 vostfr [1080p]
+: title: Show Name
+  absolute_episode: 4
+  subtitle_language: fr
+  screen_size: 1080p
+  type: episode
+
+# anime_french_fansub
+? Show Name 04 vostfr [720p]
+: title: Show Name
+  absolute_episode: 4
+  subtitle_language: fr
+  screen_size: 720p
+  type: episode
+
+# anime_standard
+? "[Group Name] Show Name.13-16"
+: title: Show Name
+  absolute_episode: [13, 14, 15, 16]
+  release_group: Group Name
+  type: episode
+
+# anime_standard
+? "[Group Name] Show Name - 13-16"
+: title: Show Name
+  absolute_episode: [13, 14, 15, 16]
+  release_group: Group Name
+  type: episode
+
+# anime_standard
+? Show Name 13-16
+: title: Show Name
+  absolute_episode: [13, 14, 15, 16]
+  type: episode
+
+# anime_standard
+? Show Name.13
+: title: Show Name
+  absolute_episode: 13
+  type: episode
+
+# anime_standard
+? Show Name - 13
+: title: Show Name
+  absolute_episode: 13
+  type: episode
+
+# anime_standard
+? Show Name 13
+: title: Show Name
+  absolute_episode: 13
+  type: episode
+
+# anime_standard_round
+? "[Group-Subs]_Show_Name_-_12_(1280x720_H.264_AAC)_[379759DB]"
+: title: Show Name
+  absolute_episode: 12
+  screen_size: 720p
+  video_codec: h264
+  audio_codec: AAC
+  crc32: 379759DB
+  release_group: Group
+  type: episode
+
+# anime_standard_round
+? "[SomeGroup-Subs] Show Name - 02-03 (CX 1280x720 x264 AAC)"
+: title: Show Name
+  absolute_episode: [2, 3]
+  screen_size: 720p
+  video_codec: h264
+  audio_codec: AAC
+  release_group: SomeGroup
+  type: episode
+
+# anime_slash
+? "[AAA] Show Name 312v1 [720p/MKV]"
+: title: Show Name
+  absolute_episode: 312
+  version: 1
+  screen_size: 720p
+  container: MKV
+  release_group: AAA
+  type: episode
+
+# anime_standard_codec
+? "[SomeOne]_Show_Name_-_IS_-_07_[H264][720p][EB7838FC]"
+: title: Show Name
+  episode_title: IS # Probably this is not correct, but it doesn't hurt
+  absolute_episode: 7
+  screen_size: 720p
+  video_codec: h264
+  crc32: EB7838FC
+  release_group: SomeOne
+  type: episode
+
+# anime_standard_codec
+? "[SomeOne]_Show_Name_-_IS_-_07v2_[H264][720p][EB7838FC]"
+: title: Show Name
+  episode_title: IS # Probably this is not correct, but it doesn't hurt
+  absolute_episode: 7
+  screen_size: 720p
+  video_codec: h264
+  crc32: EB7838FC
+  version: 2
+  release_group: SomeOne
+  type: episode
+
+# anime_standard_codec
+? "[SomeOne]_Show_Name_-_IS_-_07v2_[H264][720p][EB7838FC]"
+: title: Show Name
+  episode_title: IS # Probably this is not correct, but it doesn't hurt
+  absolute_episode: 7
+  screen_size: 720p
+  video_codec: h264
+  crc32: EB7838FC
+  version: 2
+  release_group: SomeOne
+  type: episode
+
+# anime_standard_codec
+? "[Group-Shikkaku] A Very Long Show Name Here - 10 [LQ][h264][720p] [8853B21C]"
+: title: A Very Long Show Name Here
+  absolute_episode: 10
+  video_codec: h264
+  screen_size: 720p
+  crc32: 8853B21C
+  release_group: Group-Shikkaku
+  type: episode
+
+# anime_codec_crc
+
+# anime_SxxExx (all examples are like the standard)
+# Show.Name.S01E02.Source.Quality.Etc-Group
+# Show Name - S01E02 - My Ep Name
+# Show.Name.S01.E03.My.Ep.Name
+# Show.Name.S01E02E03.Source.Quality.Etc-Group
+# Show Name - S01E02-03 - My Ep Name
+# Show.Name.S01.E02.E03
+
+# anime_and_normal (FixInvalidTitleOrAlternativeTitle - alternative_title case)
+? Show Name - s16e03-05 - 313-315
+: title: Show Name
+  absolute_episode: [313, 314, 315]
+  season: 16
+  episode: [3, 4, 5]
+  type: episode
+
+# anime_and_normal (FixInvalidTitleOrAlternativeTitle - alternative_title case)
+? Show.Name.s16e03-05.313-315
+: title: Show Name
+  absolute_episode: [313, 314, 315]
+  season: 16
+  episode: [3, 4, 5]
+  type: episode
+
+# anime_and_normal (FixInvalidTitleOrAlternativeTitle - alternative_title case)
+? Show Name s16e03-05 313-315
+: title: Show Name
+  absolute_episode: [313, 314, 315]
+  season: 16
+  episode: [3, 4, 5]
+  type: episode
+
+# anime_and_normal_x (FixInvalidTitleOrAlternativeTitle - alternative_title case)
+? Show Name - 16x03-05 - 313-315
+: title: Show Name
+  absolute_episode: [313, 314, 315]
+  season: 16
+  episode: [3, 4, 5]
+  type: episode
+
+# anime_and_normal_x (FixInvalidTitleOrAlternativeTitle - alternative_title case)
+? Show.Name.16x03-05.313-315
+: title: Show Name
+  absolute_episode: [313, 314, 315]
+  season: 16
+  episode: [3, 4, 5]
+  type: episode
+
+# anime_and_normal_x (FixInvalidTitleOrAlternativeTitle - alternative_title case)
+? Show Name 16x03-05 313-315
+: title: Show Name
+  absolute_episode: [313, 314, 315]
+  season: 16
+  episode: [3, 4, 5]
+  type: episode
+
+# FixInvalidTitleOrAlternativeTitle - alternative_title case (negative scenario)
+? Show Name 16x03-04 100-10
+: title: Show Name
+  episode_title: 100-10
+  season: 16
+  episode: [3, 4]
+  type: episode
+
+# anime_and_normal_reverse (FixInvalidAlternativeTitle - title case)
+? Show Name - 313-315 - s16e03-05
+: title: Show Name
+  absolute_episode: [313, 314, 315]
+  season: 16
+  episode: [3, 4, 5]
+  type: episode
+
+# anime_and_normal_reverse (FixInvalidAlternativeTitle - title case)
+? Show.Name.313-315.s16e03-05
+: title: Show Name
+  absolute_episode: [313, 314, 315]
+  season: 16
+  episode: [3, 4, 5]
+  type: episode
+
+# anime_and_normal_reverse (FixInvalidAlternativeTitle - title case)
+? Show Name 313-315 s16e03-05
+: title: Show Name
+  absolute_episode: [313, 314, 315]
+  season: 16
+  episode: [3, 4, 5]
+  type: episode
+
+# FixInvalidAlternativeTitle - title case (negative scenario)
+? Show Name 315-313 s16e03-05
+: title: Show Name
+  season: 16
+  episode: [3, 4, 5]
+  type: episode
+
+# anime_and_normal_front
+# This one doesn't work with both parsers (current nor guessit)
+#? 165.Show Name.s08e014
+#: title: Show Name
+#  absolute_episode: 165
+#  season: 8
+#  episode: 14
+#  type: episode
+
+# anime_ep_name
+
+# anime_WarB3asT
+# Both parsers work only with show_type = 'anime' 
+? 003. Show Name - Ep Name.mkv
+: options: {show_type: anime}
+  title: Show Name
+  absolute_episode: 3
+  episode_title: Ep Name
+  container: mkv
+  mimetype: video/x-matroska
+  type: episode
+
+# anime_WarB3asT
+? 003-005. Show Name - Ep Name.mkv
+: title: Show Name
+  absolute_episode: [3, 4, 5]
+  episode_title: Ep Name
+  container: mkv
+  mimetype: video/x-matroska
+  type: episode
+
+# anime_bare
+# Both parsers work only with show_type = 'anime' 
+? One Piece - 102
+: options: {show_type: anime}
+  title: One Piece
+  absolute_episode: 102
+  type: episode
+
+# anime_bare
+? "[ABC]_Show_Name_001.mkv"
+: title: Show Name
+  absolute_episode: 1
+  container: mkv
+  mimetype: video/x-matroska
+  release_group: ABC
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/308 (conflict with screen size)
+? "[SuperGroup].Show.Name.-.06.[720.Hi10p][1F5578AC]"
+: title: Show Name
+  absolute_episode: 6
+  screen_size: 720p
+  video_profile: 10bit
+  crc32: 1F5578AC
+  release_group: SuperGroup
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/308 (conflict with screen size)
+? "[SuperGroup].Show.Name.-.06.[1080.Hi10p][1F5578AC]"
+: title: Show Name
+  absolute_episode: 6
+  screen_size: 1080p
+  video_profile: 10bit
+  crc32: 1F5578AC
+  release_group: SuperGroup
+  type: episode
+
+# FixSeasonAndEpisodeConflicts (conflict with expected release_group)
+? Show.Name.S02.REPACK.720p.BluRay.DD5.1.x264-4EVERHD
+: title: Show Name
+  season: 2
+  other: Proper
+  proper_count: 1
+  screen_size: 720p
+  format: BluRay
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  video_codec: h264
+  release_group: 4EVERHD
+  type: episode
+
+# expected_title
+? - Show.Net.S01E06.720p
+  - /Show.Net/Season 1/Show.Net.S01E06.720p
+  - /Show Net/Season 1/Show.Net.S01E06.720p
+: title: Show Net
+  season: 1
+  episode: 6
+  screen_size: 720p
+  type: episode
+
+# expected_title
+? - 11.22.63.S01E06.720p
+  - /11.22.63/Season 1/11.22.63.S01E06.720p
+: title: 11.22.63
+  season: 1
+  episode: 6
+  screen_size: 720p
+  type: episode
+
+# expected_title
+? - 11.22.63.106.hdtv-abc
+  - /11.22.63/Season 1/11.22.63.106.hdtv-abc
+: title: 11.22.63
+  season: 1
+  episode: 6
+  format: HDTV
+  release_group: abc
+  type: episode
+
+# expected_title
+? - 12.monkeys.Season.1.Complete
+  - /somefolder/12.monkeys.Season.1.Complete
+  - /12 Monkeys/12.monkeys.Season.1.Complete
+: title: 12 monkeys
+  season: 1
+  other: Complete
+  type: episode
+
+# expected_title
+? - The.100.Season.1.Complete
+  - /somefolder/The.100.Season.1.Complete
+  - /The 100/The.100.Season.1.Complete
+  - /The.100.Season.1.Complete/The.100.Season.1.Complete
+: title: The 100
+  season: 1
+  other: Complete
+  type: episode
+
+# expected_title
+? - Storm.Chasers.Season.1
+  - /somefolder/Storm.Chasers.Season.1
+: title: Storm Chasers
+  season: 1
+  type: episode
+
+# expected_title
+? - 60.Minutes.-.2008.01.06
+  - /somefolder/60.Minutes.-.2008.01.06
+: title: 60 Minutes
+  date: 2008-01-06
+  type: episode
+
+# expected_title
+? - Star.Trek.DS9.S01E03
+  - /Star.Trek/Season 01/Star.Trek.DS9.S01E03
+: title: Star Trek DS9
+  season: 1
+  episode: 3
+  type: episode
+
+# expected_title
+? "[Group].Pan.de.Peace!.-.08.[1080p]"
+: title: Pan de Peace!
+  absolute_episode: 8
+  screen_size: 1080p
+  release_group: Group
+  type: episode
+
+# expected_group
+? Show.Name.x264-byEMP
+: title: Show Name
+  video_codec: h264
+  release_group: byEMP
+  type: episode
+
+# expected_group
+? Show.Name.x264-ELITETORRENT
+: title: Show Name
+  video_codec: h264
+  release_group: ELITETORRENT
+  type: episode
+
+# expected_group
+? Show.Name.x264-F4ST3R
+: title: Show Name
+  video_codec: h264
+  release_group: F4ST3R
+  type: episode
+
+# expected_group
+? Show.Name.x264-F4ST
+: title: Show Name
+  video_codec: h264
+  release_group: F4ST
+  type: episode
+
+# expected_group
+? Show.Name.x264-TGNF4ST
+: title: Show Name
+  video_codec: h264
+  release_group: TGNF4ST
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/316
+? Show.Name.x264-CDD
+: title: Show Name
+#  video_codec: h264
+  cd_count: 264 # TODO fix when guessit bug is fixed
+  release_group: CDD
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/316
+? Show.Name.x264-CDP
+: title: Show Name
+#  video_codec: h264
+  cd_count: 264 # TODO fix when guessit bug is fixed
+  release_group: CDP
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/317
+? Show.Name.x264-HDD
+: title: Show Name
+  video_codec: h264
+  release_group: HDD
+  audio_codec: DolbyDigital # TODO remove when guessit bug is fixed
+  type: episode
+
+# expected_group
+? Show.Name.x264-NovaRip
+: title: Show Name
+  video_codec: h264
+  release_group: NovaRip
+  type: episode
+
+# expected_group
+? Show.Name.x264-PARTiCLE
+: title: Show Name
+  video_codec: h264
+  release_group: PARTiCLE
+  type: episode
+
+# expected_group
+? Show.Name.x264-POURMOi
+: title: Show Name
+  video_codec: h264
+  release_group: POURMOi
+  type: episode
+
+# expected_group
+? Show.Name.x264-RipPourBox
+: title: Show Name
+  video_codec: h264
+  release_group: RipPourBox
+  type: episode
+
+# expected_group
+? Show.Name.x264-RiPRG
+: title: Show Name
+  video_codec: h264
+  release_group: RiPRG
+  type: episode
+
+# expected_group
+? Show.Name.x264-TV2LAX9
+: title: Show Name
+  video_codec: h264
+  release_group: TV2LAX9
+  bonus: 9 # not a big issue
+  type: episode
+
+# expected_group
+? Show.Name.x264-AF
+: title: Show Name
+  video_codec: h264
+  release_group: AF
+  type: episode
+
+# expected_group
+? Show.Name.x264-AR
+: title: Show Name
+  video_codec: h264
+  release_group: AR
+  type: episode
+
+# expected_group
+? Show.Name.x264-CS
+: title: Show Name
+  video_codec: h264
+  release_group: CS
+  type: episode
+
+# expected_group
+? Show.Name.x264-DR
+: title: Show Name
+  video_codec: h264
+  release_group: DR
+  type: episode
+
+# expected_group
+? Show.Name.x264-MC
+: title: Show Name
+  video_codec: h264
+  release_group: MC
+  type: episode
+
+# expected_group
+? Show.Name.x264-NA
+: title: Show Name
+  video_codec: h264
+  release_group: NA
+  type: episode
+
+# expected_group
+? Show.Name.x264-TL
+: title: Show Name
+  video_codec: h264
+  release_group: TL
+  type: episode
+
+# expected_group
+? Show.Name.x264-YT
+: title: Show Name
+  video_codec: h264
+  release_group: YT
+  type: episode
+
+# expected_group
+? Show.Name.x264-ZT
+: title: Show Name
+  video_codec: h264
+  release_group: ZT
+  type: episode
+
+# CreateExtendedTitleWithCountryOrYear (Country)
+? - Show.Name.US.S03.720p.BluRay.x264-SuperGroup
+  - /Show.Name/Show.Name.US.S03.720p.BluRay.x264-SuperGroup
+  - /Show Name - US/Season 3/Show.Name.US.S03.720p.BluRay.x264-SuperGroup
+  - /Show Name/Season 3/Show.Name.US.S03.720p.BluRay.x264-SuperGroup
+: title: Show Name
+  extended_title: Show Name US
+  country: US
+  season: 3
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithCountryOrYear (Country inside brackets)
+? Show.Name.(US).S03.720p.BluRay.x264-SuperGroup
+: title: Show Name
+  extended_title: Show Name US
+  country: US
+  season: 3
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithCountryOrYear (Country followed by episode)
+? Show.Name.US.E03.720p.BluRay.x264-SuperGroup
+: title: Show Name
+  extended_title: Show Name US
+  country: US
+  episode: 3
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithCountryOrYear (Country followed by date)
+? Show.Name.US.2012.12.12.720p.BluRay.x264-SuperGroup
+: title: Show Name
+  extended_title: Show Name US
+  country: US
+  date: 2012-12-12
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithCountryOrYear (Year)
+? Show.Name.2002.S03.720p.BluRay.x264-SuperGroup
+: title: Show Name
+  extended_title: Show Name 2002
+  year: 2002
+  season: 3
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithCountryOrYear (Year inside brackets)
+? Show.Name.(2002).S03.720p.BluRay.x264-SuperGroup
+: title: Show Name
+  extended_title: Show Name 2002
+  year: 2002
+  season: 3
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithCountryOrYear (negative country scenario)
+? Show.Name.S03.US.720p.BluRay.x264-SuperGroup
+: title: Show Name
+  country: US
+  season: 3
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithCountryOrYear (negative country scenario)
+? Show.Name.S03.(US).720p.BluRay.x264-SuperGroup
+: title: Show Name
+  country: US
+  season: 3
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithCountryOrYear (negative year scenario)
+? Show.Name.S03.2005.720p.BluRay.x264-SuperGroup
+: title: Show Name
+  year: 2005
+  season: 3
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithCountryOrYear (negative year scenario)
+? Show.Name.S03.(2005).720p.BluRay.x264-SuperGroup
+: title: Show Name
+  year: 2005
+  season: 3
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: SuperGroup
+  type: episode
+
+# AnimeWithSeasonAbsoluteEpisodeNumbers
+? - "[Group].Show.Name.S2.-.19.[1080p]"
+  - /Show.Name.S2/[Group].Show.Name.S2.-.19.[1080p]
+  - /Show Name S2/[Group].Show.Name.S2.-.19.[1080p]
+: title: Show Name S2
+  absolute_episode: 19
+  screen_size: 1080p
+  release_group: Group
+  type: episode
+
+# AnimeWithSeasonAbsoluteEpisodeNumbers (negative scenario)
+? "[Group].Show.Name.G2.-.19.[1080p]"
+: title: Show Name G2
+  absolute_episode: 19
+  screen_size: 1080p
+  release_group: Group
+  type: episode
+
+# AnimeWithSeasonAbsoluteEpisodeNumbers (options show_type='regular', it disables this rule since it's only for animes)
+? "[Group].Show.Name.S2.-.19.[1080p]"
+: options: {show_type: regular}
+  title: Show Name
+  season: 2
+  episode_title: '19'
+  screen_size: 1080p
+  release_group: Group
+  type: episode
+
+# AnimeAbsoluteEpisodeNumbers
+? "[Group].Show.Name.-.102.[720p]"
+: title: Show Name
+  absolute_episode: 102
+  screen_size: 720p
+  release_group: Group
+  type: episode
+
+# AnimeAbsoluteEpisodeNumbers (options show_type='regular', it disables this rule since it's only for animes)
+? "[Group].Show.Name.-.102.[720p]"
+: options: {show_type: regular}
+  title: Show Name
+  season: 1
+  episode: 2
+  screen_size: 720p
+  release_group: Group
+  type: episode
+
+# AbsoluteEpisodeNumbers
+? Show.Name.10.720p
+: title: Show Name
+  absolute_episode: 10
+  screen_size: 720p
+  type: episode
+
+# AbsoluteEpisodeNumbers (options show_type='regular', it disables this rule since it's only for animes)
+? Show.Name.10.720p
+: options: {show_type: regular}
+  title: Show Name
+  episode: 10
+  screen_size: 720p
+  type: episode
+
+# AbsoluteEpisodeNumbers (negative scenario - not absolute number)
+? Some.Show.1of8..Title.x264.AAC.Group
+: title: Some Show
+  episode: 1
+  episode_count: 8
+  episode_title: Title
+  video_codec: h264
+  audio_codec: AAC
+  release_group: Group
+  type: episode
+
+# AbsoluteEpisodeNumbers (negative scenario - not absolute number)
+? Some.Show.E07.1080p.HDTV.x265-GROUP
+: title: Some Show
+  episode: 7
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h265
+  release_group: GROUP
+  type: episode
+
+# AbsoluteEpisodeNumbers (negative scenario - not absolute number)
+? Some.Show.Episode.10.Some.Title.720p
+: title: Some Show
+  episode: 10
+  episode_title: Some Title
+  screen_size: 720p
+  type: episode
+
+# PartsAsEpisodeNumbers
+? Show.Name.Part.3.720p.HDTV.x264-Group
+: title: Show Name
+  episode: 3
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# PartsAsEpisodeNumbers (negative scenario - there's season)
+? Show.Name.S02.Some.Name.Part.2.720p.BluRay.x264-Group
+: title: Show Name
+  season: 2
+  episode_title: Some Name
+  part: 2
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# PartsAsEpisodeNumbers (negative scenario - there's episode)
+? Show.Name.E01.Some.Name.Part.2.720p.BluRay.x264-Group
+: title: Show Name
+  episode: 1
+  episode_title: Some Name
+  part: 2
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# PartsAsEpisodeNumbers (negative scenario - there's date)
+? Show.Name.2016.05.24.Some.Name.Part.2.720p.BluRay.x264-Group
+: title: Show Name
+  date: 2016-05-24
+  episode_title: Some Name
+  part: 2
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# PartsAsEpisodeNumbers (negative scenario - there are season and episode)
+? Show.Name.S02E01.Some.Name.Part.2.720p.BluRay.x264-Group
+: title: Show Name
+  season: 2
+  episode: 1
+  episode_title: Some Name
+  part: 2
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/295
+? - Some.Show.S02E14.X264.1080p.HDTV
+  - /Some.Show.S02E14.X264.1080p.HDTV/Some.Show.S02E14.X264.1080p.HDTV
+  - /Some Show/Season 2/Some.Show.S02E14.X264.1080p.HDTV
+: title: Some Show
+  season: 2
+  episode: 14
+  video_codec: h264
+  screen_size: 1080p
+  format: HDTV
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/295 (h265)
+? Some.Show.S02E14.X265.1080p.HDTV
+: title: Some Show
+  season: 2
+  episode: 14
+  video_codec: h265
+  screen_size: 1080p
+  format: HDTV
+  type: episode 
+
+# https://github.com/guessit-io/guessit/issues/295 (negative scenario: xvid)
+? Some.Show.S02E14.XviD.HDTV
+: title: Some Show
+  season: 2
+  episode: 14
+  video_codec: XviD
+  format: HDTV
+  type: episode 
+
+# https://github.com/guessit-io/guessit/issues/306
+? - Show.Name.-.Season.3.-.720p.BluRay.-.x264.-.Group
+  - Show.Name.-.Series.3.-.720p.BluRay.-.x264.-.Group
+: title: Show Name
+  season: 3
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+
+# https://github.com/guessit-io/guessit/issues/306 (more specific)
+? /Show.Name.-.Season.3.-.720p.BluRay.-.x264.-.Group/Show.Name.-.Season.3.-E02-.720p.BluRay.-.x264.-.Group
+: title: Show Name
+  season: 3
+  episode: 2
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/306
+? Show.Name.Season.1.-.720p.HDTV.x265.-.{Group}
+: title: Show Name
+  season: 1
+  screen_size: 720p
+  format: HDTV
+  video_codec: h265
+  release_group: Group
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/303
+? - Show.Name.S06E04.1080i.HDTV.DD5.1.H264.BS666
+  - /Show.Name.S06E04.1080i.HDTV.DD5.1.H264.BS666/Show.Name.S06E04.1080i.HDTV.DD5.1.H264.BS666
+  - /Show Name/Season 6/Show.Name.S06E04.1080i.HDTV.DD5.1.H264.BS666
+: title: Show Name
+  season: 6
+  episode: 4
+  screen_size: 1080i
+  format: HDTV
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  video_codec: h264
+  release_group: BS666
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/303 (ccs3)
+? Show.Name.S06E04.1080i.HDTV.DD5.1.H264.ccs3
+: title: Show Name
+  season: 6
+  episode: 4
+  screen_size: 1080i
+  format: HDTV
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  video_codec: h264
+  release_group: ccs3
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/303 (qqss44)
+? Show.Name.S06E04.1080i.HDTV.DD5.1.H264.qqss44
+: title: Show Name
+  season: 6
+  episode: 4
+  screen_size: 1080i
+  format: HDTV
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  video_codec: h264
+  release_group: qqss44
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/303 (qqss44) and WEBDLRip
+? Show.Name.s06e14.WEBDLRip.-qqss44.avi
+: title: Show Name
+  season: 6
+  episode: 14
+  format: WEBRip
+  release_group: qqss44
+  container: avi
+  mimetype: video/x-msvideo
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/287
+? show name s01-s04
+: title: show name
+  season: [1, 2, 3, 4]
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/287
+? show name s01-04
+: title: show name
+  season: [1, 2, 3, 4]
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/287
+? show name s01.to.s04
+: title: show name
+  season: [1, 2, 3, 4]
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/287 (negative scenario - not a season range)
+? - /show name/s01-s04/show name s01E03
+  - /show name s01-s04/show name s01E03
+: title: show name
+  season: 1
+  episode: 3
+  type: episode
+
+# TODO: FixSeasonRangeDetection and episode_count scenario
+
+# https://github.com/guessit-io/guessit/issues/287
+? - show name s02e01-e04
+  - show name S02E01-E04
+: title: show name
+  season: 2
+  episode: [1, 2, 3, 4]
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/287
+? show name s02e01-04
+: title: show name
+  season: 2
+  episode: [1, 2, 3, 4]
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/287
+? Show.Name.S01E01-S01E04
+: title: Show Name
+  season: 1
+  episode: [1, 2, 3, 4]
+  type: episode
+
+
+# https://github.com/guessit-io/guessit/issues/304
+? Show.season_1-10.(DVDrip)
+: title: Show
+  season: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  format: DVD
+  type: episode
+
+# ReleaseGroupPostProcessor
+? Some.Show.S02E14.1080p.HDTV.X264-GROUP[TRASH]
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  type: episode
+
+# ReleaseGroupPostProcessor
+? Some.Show.S02E14.1080p.HDTV.X264-GROUP(TRASH)
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  type: episode
+
+# ReleaseGroupPostProcessor
+? Some.Show.S02E14.1080p.HDTV.X264-GROUP=={{TRASH}}==
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  type: episode
+
+# ReleaseGroupPostProcessor
+? Some.Show.S02E14.1080p.HDTV.X264-123mb.GROUP
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  size: 123MB
+  release_group: GROUP
+  type: episode
+
+# ReleaseGroupPostProcessor
+? Some.Show.S02E14.1080p.HDTV.X264-4.2GB.GROUP
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  size: 4.2GB
+  release_group: GROUP
+  type: episode
+
+# Re-Encoded
+? - Some.Show.S02E14.1080p.HDTV.X264-reenc.GROUP
+  - Some.Show.S02E14.1080p.HDTV.X264-re-enc.GROUP
+  - Some.Show.S02E14.1080p.HDTV.X264-re-encoded.GROUP
+  - Some.Show.S02E14.1080p.HDTV.X264-reencoded.GROUP
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  other: Re-Encoded
+  release_group: GROUP
+  type: episode
+
+# Size (MB)
+? Show.Name.S03E15.480p.177mb.Proper.HDTV.x264
+: title: Show Name
+  season: 3
+  episode: 15
+  screen_size: 480p
+  size: 177MB
+  other: Proper
+  proper_count: 1
+  format: HDTV
+  video_codec: h264
+  type: episode
+
+# Size (GB)
+? Show.Name.S03E15.480p.4.8GB.Proper.HDTV.x264
+: title: Show Name
+  season: 3
+  episode: 15
+  screen_size: 480p
+  size: 4.8GB
+  other: Proper
+  proper_count: 1
+  format: HDTV
+  video_codec: h264
+  type: episode
+
+# Size (TB)
+? Show.Name.S03.1.1TB.Proper.HDTV.x264
+: title: Show Name
+  season: 3
+  size: 1.1TB
+  other: Proper
+  proper_count: 1
+  format: HDTV
+  video_codec: h264
+  type: episode
+
+# ReleaseGroupPostProcessor
+? Some.Show.S02E14.1080p.HDTV.X264-GROUP.rar
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  mimetype: application/rar
+  type: episode
+
+# ReleaseGroupPostProcessor
+? Some.Show.S02E14.1080p.HDTV.X264-GROUP.trash
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  type: episode
+
+# subtitle language
+? Some.Show.S02E14.1080p.HDTV.X264.NLSubs.Group
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  subtitle_language: nl
+  release_group: Group
+  type: episode
+
+# ReleaseGroupPostProcessor
+? Some.Show.S02E14.1080p.HDTV.X264...Group
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# ReleaseGroupPostProcessor
+? Some.Show.S02E14.1080p.HDTV.X264.Group.[
+: title: Some Show
+  season: 2
+  episode: 14
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/294
+? Show.Name.S03E16.1080p.WEB-DL.DD5.1.H.264-GOLF68
+: title: Show Name
+  season: 3
+  episode: 16
+  screen_size: 1080p
+  format: WEB-DL
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  video_codec: h264
+  release_group: GOLF68
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/294
+? Show.Name.S02E04.WEBRip.x264-NF69-={TRASH}=-
+: title: Show Name
+  season: 2 
+  episode: 4
+  format: WEBRip
+  video_codec: h264
+  release_group: NF69 
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/294  (and episode_title has the word: special)
+? Show.Name.S02E05.F1.Special.720p.HDTV.x264-C4TV
+: title: Show Name
+  season: 2 
+  episode: 5
+  episode_details: Special
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  release_group: C4TV 
+  type: episode
+
+# Corner case with absolute numbering
+? "[SuperGroup].Show.Name.-.462.[1080p]"
+: title: Show Name
+  absolute_episode: 462
+  screen_size: 1080p
+  release_group: SuperGroup
+  type: episode
+
+# Corner case when episode conflicts with 720p
+? Show.Name.S11E11.DKsubs720p.HDTV.X264-GROUP
+: title: Show Name
+  season: 11
+  episode: 11
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  type: episode
+  disabled: true # to be fixed
+
+# Corner case with 2 seasons
+? Show.Name.Season.1.2.HDTV.XviD-GoodGroup[SomeTrash]
+: title: Show Name
+  season: [1, 2]
+  format: HDTV
+  video_codec: XviD
+  release_group: GoodGroup
+  type: episode
+
+# Corner case with only date and 720p
+? The.Show.Name.2016.05.18.720.HDTV.x264-GROUP.VTV
+: title: The Show Name
+  date: 2016-05-18
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  type: episode
+
+# Corner case with season range using range separator
+? - Show.Name.-.Season.1.to.3.-.Mp4.1080p
+  - Show.Name.Season.1~3.Mp4.1080p
+  - Show.Name.Season.1-3.Mp4.1080p
+: title: Show Name
+  season: [1, 2, 3]
+  container: MP4
+  screen_size: 1080p
+  type: episode
+
+# Corner case with season range not using range separator
+? - Show.Name.-.Season.1.3.4-.Mp4.1080p
+  - Show.Name.-.Season.1.3.and.4-.Mp4.1080p
+: title: Show Name
+  season: [1, 3, 4]
+  container: MP4
+  screen_size: 1080p
+  type: episode
+
+# CreateExtendedTitleWithAlternativeTitles (separated by +)
+? - "[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]"
+  - /Shows/Show Name - Still+Name/[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
+  - /Shows/Show Name/[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
+: title: Show Name
+  alternative_title: [Still, Name]
+  extended_title: "Show Name - Still+Name"
+  absolute_episode: 11
+  screen_size: 1080p
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithAlternativeTitles (separated by -)
+? "[SuperGroup].Show.Name.-.Still.-.Name.-.11.[1080p]"
+: title: Show Name
+  alternative_title: [Still, Name]
+  extended_title: "Show Name - Still - Name"
+  absolute_episode: 11
+  screen_size: 1080p
+  release_group: SuperGroup
+  type: episode
+
+# CreateExtendedTitleWithAlternativeTitles (separated by space)
+? "[SuperGroup].Show.Name.-.Still.Name.-.11.[1080p]"
+: title: Show Name
+  alternative_title: Still Name
+  extended_title: "Show Name - Still Name"
+  absolute_episode: 11
+  screen_size: 1080p
+  release_group: SuperGroup
+  type: episode
+
+# FixAnimeTitlesContainsNumber
+? "[Group].Show.Name.2.The.Big.Show.-.11.[1080p]"
+: title: Show Name 2 The Big Show
+  absolute_episode: 11
+  screen_size: 1080p
+  release_group: Group
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/294
+? Show.Name.S03E19.FASTSUB.VOSTFR.HDTV.XviD-F4ST
+: title: Show Name
+  season: 3
+  episode: 19
+  subtitle_language: fr
+  other: Fastsub
+  format: HDTV
+  video_codec: XviD
+  release_group: F4ST
+  type: episode
+
+# Corner case: episode range
+? Show.Name.Season.4.Episodes.1-12
+: title: Show Name
+  season: 4
+  episode: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  type: episode
+
+# Just to make sure season 0 is not ignored
+? Show.Name.S00E25.Episode.Name.720p.HDTV.x264-BCDE
+: title: Show Name
+  season: 0
+  episode: 25
+  episode_title: Episode Name
+  screen_size: 720p
+  video_codec: h264
+  format: HDTV
+  release_group: BCDE
+  type: episode
+
+# Just to make sure episode 0 is not ignored
+? Show.Name.S01E00.Episode.Name.720p.HDTV.x264-BCDE
+: title: Show Name
+  season: 1
+  episode: 0
+  episode_title: Episode Name
+  screen_size: 720p
+  video_codec: h264
+  format: HDTV
+  release_group: BCDE
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/303 (NLtoppers4ALL)
+? Show.Name.s01-E12.(2014).XViD.DD5.1.NLSubs.NLtoppers4ALL
+: title: Show Name
+  season: 1
+  episode: 12
+  year: 2014
+  video_codec: XviD
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  subtitle_language: nl
+  release_group: NLtoppers4ALL
+  type: episode
+  disabled: true
+
+# Corner Case: Episode range
+? Show.Name.Season.4.Episodes.1-12
+: title: Show Name
+  season: 4
+  episode: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  type: episode
+
+# Corner Case: Implicit episode range
+? Show.Name.1-3.-.LostFilm.TV
+: title: Show Name
+  episode: [1, 2, 3]
+  release_group: LostFilm.TV
+  type: episode
+  disabled: true # work in progress
+
+# Corner Case: Episode 2 with a number after it
+? "[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]"
+: title: Show Name
+  absolute_episode: 2
+  episode_details: Special
+  screen_size: 1080p
+  format: BluRay
+  release_group: GroupName
+  type: episode
+
+# FixAnimeReleaseGroup
+# Corner Case: Anime with absolute numbering and two possible release groups
+? "[AnimeRG].Show.Name.-.462.[720p].[10bit].[JRR].[Shippuden]"
+: title: Show Name
+  absolute_episode: 462
+  screen_size: 720p
+  video_profile: 10bit
+  release_group: AnimeRG
+  type: episode
+
+# FixAnimeReleaseGroup
+# Corner Case: Anime with absolute numbering and two possible release groups
+? "/somefoldername/[AnimeRG].Show.Name.-.462.[720p].[10bit].[JRR].[Shippuden]"
+: title: Show Name
+  absolute_episode: 462
+  screen_size: 720p
+  video_profile: 10bit
+  release_group: AnimeRG
+  type: episode
+
+# FixAnimeReleaseGroup
+# Corner Case: Anime with absolute numbering and two possible release groups
+? "/Show.Name/[AnimeRG].Show.Name.-.462.[720p].[10bit].[JRR].[Shippuden]"
+: title: Show Name
+  absolute_episode: 462
+  screen_size: 720p
+  video_profile: 10bit
+  release_group: AnimeRG
+  type: episode
+
+# FixAnimeReleaseGroup (negative scenario)
+# It's not an anime
+? "[PRiVATE].Fear.The.Show.Name.S02E02.HDTV.XviD-FUM[ettv]"
+: title: Fear The Show Name
+  season: 2
+  episode: 2
+  format: HDTV
+  video_codec: XviD
+  release_group: FUM
+  type: episode
+
+# FixAnimeReleaseGroup (negative scenario)
+# It's not an anime
+? "[REQ].The.Show.Name.S02E02.HDTV.h265-ABC[rartv]"
+: title: The Show Name
+  season: 2
+  episode: 2
+  format: HDTV
+  video_codec: h265
+  release_group: ABC
+  type: episode
+
+# FixAnimeReleaseGroup (negative scenario)
+# It's not an anime
+? "[NO.RAR].The.Show.Name.S05E01.HDTV.h264-GOOD[trash]"
+: title: The Show Name
+  season: 5
+  episode: 1
+  format: HDTV
+  video_codec: h264
+  release_group: GOOD
+  type: episode
+
+# FixAnimeReleaseGroup (options = show_type: regular
+? "[FakeGroup].Show.Name.[720p].[RealGroup]"
+: options: {show_type: regular}
+  title: Show Name
+  screen_size: 720p
+  release_group: RealGroup
+  type: episode
+
+# Corner Case: Additional implicit episode
+# https://github.com/guessit-io/guessit/issues/311
+? Show.Name.S03E21.22.FASTSUB.VOSTFR.HDTV.XviD.GROUP
+: title: Show Name
+  season: 3
+  episode: [21, 22]
+  subtitle_language: fr
+  format: HDTV
+  video_codec: XviD
+  other: Fastsub
+  release_group: GROUP
+  type: episode
+
+# Formula 1 tv show
+? Show.Name.S02E05.F1.Special.720p.HDTV.x264-C4TV.English
+: title: Show Name
+  season: 2
+  episode: 5
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  release_group: C4TV
+  language: en
+  episode_details: Special
+  type: episode
+
+# Title dots should be kept
+? 11.22.63.105.hdtv-abc
+: title: 11.22.63
+  season: 1
+  episode: 5
+  format: HDTV
+  release_group: abc
+  type: episode
+
+# SpanishNewpctReleaseName - season and episode:
+? - Show.Name.-.Temporada.1.720p.HDTV.x264[Cap.102]SPANISH.AUDIO-NEWPCT
+  - /Show Name/Season 01/Show.Name.-.Temporada.1.720p.HDTV.x264[Cap.102]SPANISH.AUDIO-NEWPCT
+  - /Show Name/Temporada 01/Show.Name.-.Temporada.1.720p.HDTV.x264[Cap.102]SPANISH.AUDIO-NEWPCT
+: title: Show Name
+  season: 1
+  episode: 2
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  language: es
+  release_group: NEWPCT
+  type: episode
+
+# SpanishNewpctReleaseName
+? Show.Name.-.Temporada1.[HDTV][Cap.105][Español.Castellano]
+: title: Show Name
+  format: HDTV
+  season: 1
+  episode: 5
+  language: es
+  type: episode
+
+# SpanishNewpctReleaseName
+? Show.Name.-.Temporada1.[HDTV][Cap.105][Español]
+: title: Show Name
+  format: HDTV
+  season: 1
+  episode: 5
+  language: es
+  type: episode
+
+# SpanishNewpctReleaseName - season and episode with range:
+? Show.Name.-.Temporada.1.720p.HDTV.x264[Cap.102_104]SPANISH.AUDIO-NEWPCT
+: title: Show Name
+  season: 1
+  episode: [2, 3, 4]
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  language: es
+  release_group: NEWPCT
+  type: episode
+
+# SpanishNewpctReleaseName - season and episode (2 digit season)
+? Show.Name.-.Temporada.15.720p.HDTV.x264[Cap.1503]SPANISH.AUDIO-NEWPCT
+: title: Show Name
+  season: 15
+  episode: 3
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  language: es
+  release_group: NEWPCT
+  type: episode
+
+# SpanishNewpctReleaseName - season and episode (2 digit season with range)
+? Show.Name.-.Temporada.15.720p.HDTV.x264[Cap.1503_1506]SPANISH.AUDIO-NEWPCT
+: title: Show Name
+  season: 15
+  episode: [3, 4, 5, 6]
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  language: es
+  release_group: NEWPCT
+  type: episode
+
+# SpanishNewpctReleaseName - season and episode:
+? Show.Name.-.Temp.1.720p.HDTV.x264[Cap.102]SPANISH.AUDIO-NEWPCT
+: title: Show Name
+  season: 1
+  episode: 2
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  language: es
+  release_group: NEWPCT
+  type: episode
+
+# SpanishNewpctReleaseName - season and episode:
+? Show.Name.-.Tem.1.720p.HDTV.x264[Cap.102]SPANISH.AUDIO-NEWPCT
+: title: Show Name
+  season: 1
+  episode: 2
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  language: es
+  release_group: NEWPCT
+  type: episode
+
+# SpanishNewpctReleaseName - season and episode:
+? Show.Name.-.Tem.1.720p.HDTV.x264[Cap.112_114.Final]SPANISH.AUDIO-NEWPCT
+: title: Show Name
+  season: 1
+  episode: [12, 13, 14]
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  language: es
+  release_group: NEWPCT
+  other: FINAL
+  type: episode
+
+# corner case
+# https://github.com/guessit-io/guessit/issues/295
+? Show.Name.S6.Ep5.X265.Dolby.2.0.KTM3
+: title: Show Name
+  season: 6
+  episode: 5
+  video_codec: h265
+  audio_codec: DolbyDigital
+  audio_channels: '2.0'
+  release_group: KTM3
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/309
+? - Show.Name.S01E05.WEBRip.x264-GROUP
+  - /folder/Show.Name.S01E05.WEBRip.x264-GROUP__gYDfLA/Show.Name.S01E05.WEBRip.x264-GROUP"
+: title: Show Name
+  season: 1
+  episode: 5
+  format: WEBRip
+  video_codec: h264
+  release_group: GROUP
+  type: episode
+
+# normal release with date
+? Show.Name.2016.06.14.Some.Title.720p.HDTV.x264-GROUP
+: title: Show Name
+  date: 2016-06-14
+  episode_title: Some Title
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  type: episode
+
+# Italian releases
+? Show Name S02e19 [Mux - H264 - Ita Aac] DLMux by UBi
+: title: Show Name
+  season: 2
+  episode: 19
+  video_codec: h264
+  language: it
+  audio_codec: AAC
+  format: WEB-DL
+  release_group: UBi
+  type: episode
+
+# Italian releases
+? Show Name S01e04 [SATrip - H264 - Ita Ac3] HDTV - DEUS TEAM
+: title: Show Name
+  season: 1
+  episode: 4
+  video_codec: h264
+  language: it
+  audio_codec: AC3
+  format: [DSRip, HDTV]
+  release_group: DEUS TEAM
+  type: episode
+
+# Italian releases
+? Show Name S01e10[Mux - 1080p - H264 - Ita Eng Ac3 - Sub Ita Eng]DLMux By GiuseppeTnT Littlelinx
+: title: Show Name
+  season: 1
+  episode: 10
+  screen_size: 1080p
+  video_codec: h264
+  language: [it, en]
+  format: WEB-DL
+  audio_codec: AC3
+  subtitle_language: [it, en]
+  release_group: GiuseppeTnT Littlelinx
+  type: episode
+
+# Italian releases
+? Show Name S04e07-08 [H264 - Ita Aac] HDTVMux by NovaRip
+: title: Show Name
+  season: 4
+  episode: [7, 8]
+  video_codec: h264
+  language: it
+  audio_codec: AAC
+  format: HDTV
+  release_group: NovaRip
+  type: episode
+
+# Italian releases
+? Show Name 3x18 Un Tuffo Nel Passato ITA HDTVMux x264 NovaRip
+: title: Show Name
+  season: 3
+  episode: 18
+  episode_title: Un Tuffo Nel Passato
+  language: it
+  format: HDTV
+  video_codec: h264
+  release_group: NovaRip
+  type: episode
+
+# Italian releases
+? Show Name (2014) S02e23 [Mux - XviD - Ita Eng Mp3 - Sub Ita Eng] DLMux By Pir8 [CURA] Supereroi SEASON FINALE
+: title: Show Name
+  extended_title: Show Name 2014
+  year: 2014
+  season: 2
+  episode: 23
+  video_codec: XviD
+  language: [it, en]
+  audio_codec: MP3
+  subtitle_language: [it, en]
+  format: WEB-DL
+  release_group: Pir8
+  type: episode
+
+# Italian releases
+? Il Trono Di Spade - Game Of Thrones S06e07 [Mux - H264 - Ita Eng Aac - Sub Ita Eng] DLMux by sp_54321
+: title: Il Trono Di Spade
+  alternative_title: Game Of Thrones
+  season: 6
+  episode: 7
+  video_codec: h264
+  language: [it, en]
+  audio_codec: AAC
+  subtitle_language: [it, en]
+  format: WEB-DL
+  release_group: sp_54321
+  type: episode
+
+# Storm correctly detected (regression bug when it was detected as subtitle_language: ST = subtitle Orm = Oromo)
+? Mellan.Bleke.Och.Storm.SWEDiSH.720p.HDTV.x264-GROUP
+: title: Mellan Bleke Och Storm
+  language: sv
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  type: episode
+
+? Show.Name.1999.1080p.HDTV.x264_HDv_0day_Team.mkv
+: title: Show Name
+  year: 1999
+  screen_size: 1080p
+  format: HDTV
+  video_codec: h264
+  release_group: HDv_0day_Team
+  container: mkv
+  mimetype: video/x-matroska
+  type: episode
+
+# Important: the suffix .hdtv.x264 is an existing workaround in the application for a certain provider. It should be removed when there's a video_codec conflict
+? 500.Bus.Stops.Series.1.XviD.hdtv.x264
+: title: 500 Bus Stops
+  season: 1
+  video_codec: XviD
+  format: HDTV
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/310
+? Show.Name.COMPLETE.SERIES.DVDRip.XviD-AR
+: title: Show Name
+  other: Complete
+  format: DVD
+  video_codec: XviD
+  release_group: AR
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/310
+? Show Name The Complete Seasons 1 to 5 720p BluRay x265 HEVC-SUJAIDR[UTR]
+: title: Show Name
+  other: Complete
+  season: [1, 2, 3, 4, 5]
+  screen_size: 720p
+  format: BluRay
+  video_codec: h265
+  release_group: SUJAIDR
+  type: episode
+
+? Show.Name.-.Alternative.-.02.(1280x720.HEVC.AAC)
+: title: Show Name
+  alternative_title: Alternative
+  extended_title: Show Name - Alternative
+  absolute_episode: 2
+  screen_size: 720p
+  video_codec: h265
+  audio_codec: AAC
+  type: episode
+
+? Show.Name.S02E01.MULTi.FRENCH.VOSTFR-EN.1080p.WEB-DL.HEVC.x265-GOLF68
+: title: Show Name
+  season: 2
+  episode: 1
+  language: [fr, en]
+  subtitle_language: fr
+  screen_size: 1080p
+  format: WEB-DL
+  video_codec: h265
+  release_group: GOLF68
+  type: episode
+
+? Show.Name.S03E21.22.FASTSUB.VOSTFR.HDTV.XviD.F4ST.avi
+: title: Show Name
+  season: 3
+  episode: [21, 22]
+  other: Fastsub
+  subtitle_language: fr
+  format: HDTV
+  video_codec: XviD
+  release_group: F4ST
+  container: avi
+  mimetype: video/x-msvideo
+  type: episode
+
+? Show.Name.Season.1.(x265.10bit.Joy)
+: title: Show Name
+  season: 1
+  video_codec: h265
+  video_profile: 10bit
+  release_group: Joy
+  type: episode
+
+? - Show.Name.S01E01.DVDRip.XviD-W4F
+  - Show.Name.S01E01.DVDRip.XviD-W4F[something]
+: title: Show Name
+  season: 1
+  episode: 1
+  format: DVD
+  video_codec: XviD
+  release_group: W4F
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313
+? Show.Name.S01E01.DVDRip.XviD.REPACK-OMiCRON
+: title: Show Name
+  season: 1
+  episode: 1
+  format: DVD
+  video_codec: XviD
+  other: Proper
+  proper_count: 1
+  release_group: OMiCRON
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313
+? Show.Name.S01E01.2008.BluRay.VC1.1080P.5.1.WMV-NOVO
+: title: Show Name
+  season: 1
+  episode: 1
+  year: 2008
+  format: BluRay
+  screen_size: 1080p
+  audio_channels: '5.1'
+  container: WMV
+  release_group: NOVO
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313
+? Show.Name.S01E02.HDTV.x264.PROPER-LOL
+: title: Show Name
+  season: 1
+  episode: 2
+  format: HDTV
+  video_codec: h264
+  other: Proper
+  proper_count: 1
+  release_group: LOL
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313
+? - Show.Name.S01E01.Pilot.DVDSCR.x264.PREAiR-NoGRP
+  - Show.Name.S01E01.Pilot.DVDSCR.x264.PREAiR-NoGRP[rartv]
+  - Show.Name.S01E01.Pilot.DVDSCR.x264.PREAiR-NoGRP[ettv]
+  - Show.Name.S01E01.Pilot.DVDSCR.x264.PREAiR-NoGRP[something]
+: title: Show Name
+  season: 1
+  episode: 1
+  episode_title: Pilot
+  episode_details: Pilot
+  format: DVD
+  video_codec: h264
+  other: [Screener, Preair]
+  release_group: NoGRP
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313
+? Show.Name.S02E01.HDTV.x264.AAC.MP4-k3n.mp4
+: title: Show Name
+  season: 2
+  episode: 1
+  format: HDTV
+  video_codec: h264
+  audio_codec: AAC
+  container: [MP4, mp4] # not a big issue
+  release_group: k3n
+  mimetype: video/mp4
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313
+? Show.Name.S03.1080p.BluRay.DTS-HD.MA.5.1.AVC.REMUX-FraMeSToR
+: title: Show Name
+  season: 3
+  format: BluRay
+  audio_codec: DTS
+  audio_profile: HDMA
+  audio_channels: '5.1'
+  other: Remux
+  screen_size: 1080p
+  release_group: FraMeSToR
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313 and PtM (that confuses guessit with Pt=Part and M = 1000)
+? Show.Name.S01-S03.COMPLETE.720p.BluRay.x264-PtM
+: title: Show Name
+  season: [1, 2, 3]
+  other: Complete
+  screen_size: 720p
+  format: BluRay
+  video_codec: h264
+  part: 1000 # not a big issue
+  release_group: PtM
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313 (regression test for multiple release_groups issue)
+? Show.Name.S04E23.Parley.720p.HDTV.x264.DIMENSION.P00\SNLA0423.720p.HDTV.X264-DIMENSION
+: title: Show Name
+  season: 4
+  episode: 23
+  episode_title: Parley
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  release_group: DIMENSION
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313 (due to language)
+? Show.Name.S01E03.WEB-DL.x264.HUN-nIk
+: title: Show Name
+  season: 1
+  episode: 3
+  format: WEB-DL
+  video_codec: h264
+  language: hu
+  release_group: nIk
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313 (due to subtitle_language)
+? Show.Name.S01.720p.HDTV.x264.2xRus.Eng.Subs-Hype
+: title: Show Name
+  season: 1
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  subtitle_language: en
+  release_group: Hype
+  type: episode
+
+# https://github.com/guessit-io/guessit/issues/313 (due to subtitle_language)
+? Show.Name.S01.DVD2.NLsubs-QoQ
+: title: Show Name
+  season: 1
+  format: DVD
+  subtitle_language: nl 
+  release_group: QoQ
+  type: episode
+
+# Regression test for wrong series
+? Show.Name.TV.Series.2016.S01.complete.480p.mp4
+: title: Show Name
+  year: 2016
+  season: 1
+  other: Complete
+  screen_size: 480p
+  container: mp4
+  mimetype: video/mp4
+  type: episode
+  disabled: true
+
+# DSR:
+? Show.Name.S05E09.Some.Episode.Title.WS.DSR.x264-[NY2]
+: title: Show Name
+  season: 5
+  episode: 9
+  episode_title: Some Episode Title
+  other: WideScreen
+  format: DSRip
+  video_codec: h264
+  release_group: NY2
+  type: episode
+
+# Romanian subtitles
+? Show.Name.S02E11.720p.HDTV.X264.RoSubbed-Grp
+: title: Show Name
+  season: 2
+  episode: 11
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  subtitle_language: ro
+  release_group: Grp
+  type: episode
+
+# Hardcoded subtitles
+? Show.Name.S06E16.HC.SWESUB.HDTV.x264
+: title: Show Name
+  season: 6
+  episode: 16
+  other: Hardcoded subtitles
+  format: HDTV
+  video_codec: h264
+  subtitle_language: sv
+  type: episode
+
+# 720pHD
+? Show.Name.(s01e10).(720pHD)
+: title: Show Name
+  season: 1
+  episode: 10
+  screen_size: 720p
+  type: episode
+
+# 1080pHD
+? Show.Name.(s01e10).(1080pHD)
+: title: Show Name
+  season: 1
+  episode: 10
+  screen_size: 1080p
+  type: episode
+
+# DIRFIX
+? Show.Name.S12E17.DIRFIX.HDTV.x264-Group
+: title: Show Name
+  season: 12
+  episode: 17
+  other: DirFix
+  format: HDTV
+  video_codec: h264
+  release_group: Group
+  type: episode
+
+# INTERNAL
+? Show.Name.S06E04.INTERNAL.HDTV.x264-GROUP
+: title: Show Name
+  season: 6
+  episode: 4
+  other: Internal
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  type: episode
+

--- a/tests/guessit_tests.py
+++ b/tests/guessit_tests.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+"""
+Guessit name parser tests
+"""
+import os
+import unittest
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode, SequenceNode
+
+from nose_parameterized import parameterized
+from sickbeard.name_parser.guessit_parser import parser
+
+
+__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+
+
+def construct_mapping(self, node, deep=False):
+    """
+    Custom yaml map constructor to allow lists to be key of a map
+    :param self:
+    :param node:
+    :param deep:
+    :return:
+    """
+    if not isinstance(node, MappingNode):
+        raise ConstructorError(None, None,
+                               "expected a mapping node, but found %s" % node.id,
+                               node.start_mark)
+    mapping = {}
+    for key_node, value_node in node.value:
+        is_sequence = isinstance(key_node, SequenceNode)
+        key = self.construct_object(key_node, deep=deep or is_sequence)
+        try:
+            if is_sequence:
+                key = tuple(key)
+            hash(key)
+        except TypeError, exc:
+            raise ConstructorError("while constructing a mapping", node.start_mark,
+                                   "found unacceptable key (%s)" % exc, key_node.start_mark)
+        value = self.construct_object(value_node, deep=deep)
+        mapping[key] = value
+    return mapping
+
+
+yaml.SafeLoader.add_constructor(u'tag:yaml.org,2002:map', construct_mapping)
+
+
+class GuessitTests(unittest.TestCase):
+    """
+    Guessit Tests :-)
+    """
+    files = {
+        'tvshows': 'tvshows.yml',
+    }
+
+    parameters = []
+
+    for scenario_name, file_name in files.iteritems():
+        with open(os.path.join(__location__, 'datasets', file_name), 'r') as stream:
+            data = yaml.safe_load(stream)
+
+        for release_names, expected in data.iteritems():
+            expected = {k: v for k, v in expected.iteritems()}
+
+            if not isinstance(release_names, tuple):
+                release_names = (release_names, )
+
+            for release_name in release_names:
+                parameters.append([scenario_name, release_name, expected])
+
+    @parameterized.expand(parameters)
+    def test_guess(self, scenario_name, release_name, expected):
+        """
+        :param scenario_name:
+        :type scenario_name: str
+        :param release_name: the input release name
+        :type release_name: str
+        :param expected: the expected guessed dict
+        :type expected: dict
+        """
+        self.maxDiff = None
+        options = expected.pop('options', {})
+        actual = parser.guess(release_name, show_type=options.get('show_type'))
+        actual = {k: v for k, v in actual.iteritems()}
+
+        def format_param(param):
+            if isinstance(param, list):
+                result = []
+                for p in param:
+                    result.append(str(p))
+                return result
+
+            return str(param)
+
+        if 'country' in actual:
+            actual['country'] = format_param(actual['country'])
+        if 'language' in actual:
+            actual['language'] = format_param(actual['language'])
+        if 'subtitle_language' in actual:
+            actual['subtitle_language'] = format_param(actual['subtitle_language'])
+
+        expected['release_name'] = release_name
+        actual['release_name'] = release_name
+
+        if expected.get('disabled'):
+            print(u'Skipping {scenario}: {release_name}'.format(scenario=scenario_name, release_name=release_name))
+        else:
+            print(u'Testing {scenario}: {release_name}'.format(scenario=scenario_name, release_name=release_name))
+            self.assertEqual(expected, actual)
+
+    # for debugging purposes
+    #def dump(self, scenario_name, release_name, values):
+    #    print('')
+    #    print('# {scenario_name}'.format(scenario_name=scenario_name))
+    #    print('? {release_name}'.format(release_name=release_name))
+    #    start = ':'
+    #    for k, v in values.iteritems():
+    #        print('{start} {k}: {v}'.format(start=start, k=k, v=v))
+    #        start = ' '

--- a/tests/name_parser_tests.py
+++ b/tests/name_parser_tests.py
@@ -184,7 +184,7 @@ class UnicodeTests(test.SickbeardTestDBCase):
         :param result:
         :return:
         """
-        name_parser = parser.NameParser(True, showObj=self.show)
+        name_parser = parser.NameParser(True, showObj=self.show, use_guessit=False)
         parse_result = name_parser.parse(name)
 
         # this shouldn't raise an exception
@@ -211,7 +211,7 @@ class FailureCaseTests(test.SickbeardTestDBCase):
         :param name:
         :return:
         """
-        name_parser = parser.NameParser(True)
+        name_parser = parser.NameParser(True, use_guessit=False)
         try:
             parse_result = name_parser.parse(name)
         except (parser.InvalidNameException, parser.InvalidShowException):
@@ -248,7 +248,7 @@ class ComboTests(test.SickbeardTestDBCase):
             print
             print 'Testing', name
 
-        name_parser = parser.NameParser(True)
+        name_parser = parser.NameParser(True, use_guessit=False)
 
         try:
             test_result = name_parser.parse(name)
@@ -329,112 +329,112 @@ class BasicTests(test.SickbeardTestDBCase):
         """
         Test standard names
         """
-        name_parser = parser.NameParser(True)
+        name_parser = parser.NameParser(True, use_guessit=False)
         self._test_names(name_parser, 'standard')
 
     def test_standard_file_names(self):
         """
         Test standard file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'standard', lambda x: x + '.avi')
 
     def test_standard_repeat_names(self):
         """
         Test standard repeat names
         """
-        name_parser = parser.NameParser(False)
+        name_parser = parser.NameParser(False, use_guessit=False)
         self._test_names(name_parser, 'standard_repeat')
 
     def test_standard_repeat_file_names(self):
         """
         Test standard repeat file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'standard_repeat', lambda x: x + '.avi')
 
     def test_fov_names(self):
         """
         Test fov names
         """
-        name_parser = parser.NameParser(False)
+        name_parser = parser.NameParser(False, use_guessit=False)
         self._test_names(name_parser, 'fov')
 
     def test_fov_file_names(self):
         """
         Test fov file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'fov', lambda x: x + '.avi')
 
     def test_fov_repeat_names(self):
         """
         Test fov repeat names
         """
-        name_parser = parser.NameParser(False)
+        name_parser = parser.NameParser(False, use_guessit=False)
         self._test_names(name_parser, 'fov_repeat')
 
     def test_fov_repeat_file_names(self):
         """
         Test fov repeat file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'fov_repeat', lambda x: x + '.avi')
 
     def test_stupid_names(self):
         """
         Test stupid names
         """
-        name_parser = parser.NameParser(False)
+        name_parser = parser.NameParser(False, use_guessit=False)
         self._test_names(name_parser, 'stupid')
 
     def test_stupid_file_names(self):
         """
         Test stupid file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'stupid', lambda x: x + '.avi')
 
     def test_no_s_general_names(self):
         """
         Test no season general names
         """
-        name_parser = parser.NameParser(False)
+        name_parser = parser.NameParser(False, use_guessit=False)
         self._test_names(name_parser, 'no_season_general')
 
     def test_no_s_general_file_names(self):
         """
         Test no season general file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'no_season_general', lambda x: x + '.avi')
 
     def test_no_s_multi_ep_names(self):
         """
         Test no season multi episode names
         """
-        name_parser = parser.NameParser(False)
+        name_parser = parser.NameParser(False, use_guessit=False)
         self._test_names(name_parser, 'no_season_multi_ep')
 
     def test_no_s_multi_ep_file_names(self):
         """
         Test no season multi episode file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'no_season_multi_ep', lambda x: x + '.avi')
 
     def test_s_only_names(self):
         """
         Test season only names
         """
-        name_parser = parser.NameParser(False)
+        name_parser = parser.NameParser(False, use_guessit=False)
         self._test_names(name_parser, 'season_only')
 
     def test_s_only_file_names(self):
         """
         Test season only file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'season_only', lambda x: x + '.avi')
 
 
@@ -480,6 +480,7 @@ class BasicFailedTests(test.SickbeardTestDBCase):
             else:
                 result.which_regex = [section]
                 test_result = name_parser.parse(cur_test)
+                test_result.which_regex = [section]
 
             if DEBUG or verbose:
                 print 'air_by_date:', test_result.is_air_by_date, 'air_date:', test_result.air_date
@@ -493,14 +494,14 @@ class BasicFailedTests(test.SickbeardTestDBCase):
         """
         Test no season names
         """
-        name_parser = parser.NameParser(False)
+        name_parser = parser.NameParser(False, use_guessit=False)
         self._test_names(name_parser, 'no_season')
 
     def test_no_s_file_names(self):
         """
         Test no season file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'no_season', lambda x: x + '.avi')
 
     @unittest.expectedFailure
@@ -508,7 +509,7 @@ class BasicFailedTests(test.SickbeardTestDBCase):
         """
         Test bare names
         """
-        name_parser = parser.NameParser(False)
+        name_parser = parser.NameParser(False, use_guessit=False)
         self._test_names(name_parser, 'bare')
 
     @unittest.expectedFailure
@@ -516,7 +517,7 @@ class BasicFailedTests(test.SickbeardTestDBCase):
         """
         Test bare file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'bare', lambda x: x + '.avi')
 
     @unittest.skip('Not yet implemented')
@@ -531,7 +532,7 @@ class BasicFailedTests(test.SickbeardTestDBCase):
         """
         Test scene date format names
         """
-        name_parser = parser.NameParser(False)
+        name_parser = parser.NameParser(False, use_guessit=False)
         self._test_names(name_parser, 'scene_date_format')
 
     @unittest.skip('Not trying indexer')
@@ -539,7 +540,7 @@ class BasicFailedTests(test.SickbeardTestDBCase):
         """
         Test scene date format file names
         """
-        name_parser = parser.NameParser()
+        name_parser = parser.NameParser(use_guessit=False)
         self._test_names(name_parser, 'scene_date_format', lambda x: x + '.avi')
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,9 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 envdir = {toxworkdir}/tox
 deps =
     coveralls
+    PyYAML
     nose
+    nose-parameterized
     rednose
     mock
 


### PR DESCRIPTION
- **NameParser**: added a new flag `use_guessit` that enables guessit name parser (default `true` on this branch). Setting it to false will keep the current parser without any change.
- **GuessitNameParser**: This should be the new API and it should be really small and straightforward. Right now, it plugs in our own `rules` and it calls `guessit.guess(..)` with the correct parameters and adapt the response property names to the same ones `NameParseResult` has. I'm planning to move the `expected_titles` and `expected_groups` out of this file to a yaml file. But this list should always be short and simple.
- **Rebulk Rules**: This is where our magic happens. The main idea is to manipulate `matches` after guessit executed its work and before returning the guessed `matches`. With rebulk API, everything that we do is to apply our rules. I wrote some instructions and guidelines to always have each rule simple and maintainable. Some rules are fixes/workarounds for guessit bugs. I have flagged them with each issue url, so we can remove then when guessit is fixed.
- **Tests**: I have created a simple unit test that executes against an yaml file. For each regex in regexes.py and each rule in our rules.py, I added an entry in this yaml file, so they will work will regression tests. There are positive and negative test cases.

And the current status (as of 21.06.2016 20:40 GMT+2):
- Total = 47125
- Success = 45692 (96.96%)
- Discarded = 666 (1.41%)
- Mismatch: episode_numbers = 70 (0.15%)
- Mismatch: air_date = 40 (0.08%)
- Mismatch: series_name = 42 (0.09%)
- Mismatch: proper = 140 (0.29%)
- Mismatch: episode_numbers_range = 2 (0.005%)
- Mismatch: season_number_range = 0 (0%)
- Mismatch ab_episode_numbers = 13 (0.03%)
- Mismatch season_number = 28 (0.06%)
- Mismatch release_group = 432 (0.92%)

