### PR TITLE
Fix for Usenet-crawler not doing the caps check

### DIFF
--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -276,12 +276,11 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
         if not self._check_auth():
             return results
 
-        # gingadaddy has no caps.
-        if not self.caps and 'gingadaddy' not in self.url:
+        # gingadaddy and usenet-crawler have no caps.
+        if not self.caps and all(provider not in self.url for provider in ['gingadaddy', 'usenet-crawler']):
             self.get_newznab_categories(just_caps=True)
-
-        if not self.caps and 'gingadaddy' not in self.url:
-            return results
+            if not self.caps:
+                return results
 
         for mode in search_strings:
             torznab = False


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

UC is currently giving back a 500 on t=caps.
By checking for this during search, it's not giving back results.