### PR TITLE
Fixed failedDownoads page, when using limit = all

### DIFF
--- a/sickbeard/server/web/manage/handler.py
+++ b/sickbeard/server/web/manage/handler.py
@@ -696,7 +696,7 @@ class Manage(Home, WebRoot):
     def failedDownloads(self, limit=100, toRemove=None):
         failed_db_con = db.DBConnection('failed.db')
 
-        if limit:
+        if int(limit):
             sql_results = failed_db_con.select(
                 b'SELECT * '
                 b'FROM failed '


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

Limit was passed as string