### PR TITLE
First POC for loading torrentday through medusa. Should fix the reCaptcha

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -1789,6 +1789,10 @@ select .selected {
     background-position: -488px 0px;
 }
 
+div.g-recaptcha {
+    visibility: visible!important;
+}
+
 /* =======================================================================
 config_postProcessing.mako
 ========================================================================== */

--- a/gui/slick/js/configProviders.js
+++ b/gui/slick/js/configProviders.js
@@ -567,4 +567,32 @@ $(document).ready(function(){
     if ($('#editANewznabProvider').length) {
         $(this).populateNewznabSection();
     }
+    
+    $(".get-recaptcha").on( "click", function(e) {
+        var providerId = $(this).attr('data-provider');
+        $("#captcha-modal").load(srRoot + '/config/providers/loadReCaptcha?provider_id='+ providerId + '&url=https://www.torrentday.com');
+        $('#myModal').modal({show:true})
+        return false;
+    });
+    
+    $( "#captcha-modal" ).on( "click", function(event) {
+        if (event.target.value === 'Sign In') {
+            var gCaptchaResponse = $('textarea#g-recaptcha-response').val();
+            if (gCaptchaResponse){
+                var params = {'provider_id': 'torrentday', captcha: gCaptchaResponse};
+                $.getJSON(srRoot + '/config/providers/getProviderCaptchaCookie', params, function(data){
+                    if (data.error !== undefined) {
+                        alert(data.error);
+                        return false;
+                    }
+                    
+                });
+            }
+            
+        } else {
+            return false;
+        }
+        return false;
+    })
+    
 });

--- a/gui/slick/js/configProviders.js
+++ b/gui/slick/js/configProviders.js
@@ -575,14 +575,17 @@ $(document).ready(function(){
         return false;
     });
     
-    $( "#captcha-modal" ).on( "click", function(event) {
-        if (event.target.value === 'Sign In') {
-            var gCaptchaResponse = $('textarea#g-recaptcha-response').val();
+    $("#captcha-modal, #captcha-ok-button").on("click", function(event) {
+        debugger;
+        var params = {'provider_id': 'torrentday', captcha: gCaptchaResponse};
+        var gCaptchaResponse = $('textarea#g-recaptcha-response').val();
+        if (event.target.value === 'Sign In' || event.target.id === 'captcha-ok-button') {
             if (gCaptchaResponse){
                 var params = {'provider_id': 'torrentday', captcha: gCaptchaResponse};
                 $.getJSON(srRoot + '/config/providers/getProviderCaptchaCookie', params, function(data){
                     if (data.error !== undefined) {
                         alert(data.error);
+                        $('#myModal').modal("hide");
                         return false;
                     }
                     
@@ -590,8 +593,10 @@ $(document).ready(function(){
             }
             
         } else {
+            //Not the sign in button
             return false;
         }
+        $('#myModal').modal("hide");
         return false;
     })
     

--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -418,6 +418,17 @@ $('#config-components').tabs();
                             </label>
                         </div>
                         % endif
+                        
+                        % if hasattr(curTorrentProvider, 'recaptcha'):
+                        <div class="field-pair">
+                            <label for="${curTorrentProvider.get_id()}_freeleech">
+                                <span class="component-title">Reauth Captcha</span>
+                                <span class="component-desc">
+                                    <button class="get-recaptcha" data-provider=${curTorrentProvider.get_id()}>Get Providers reCaptcha login page</button>
+                                </span>
+                            </label>
+                        </div>
+                        % endif
 
                         % if hasattr(curTorrentProvider, 'pin'):
                         <div class="field-pair">
@@ -800,5 +811,21 @@ $('#config-components').tabs();
 
         </form>
     </div>
+
+	<div id="myModal" class="modal fade" tabindex="-1" role="dialog" style="width: 750px; margin-left: auto; margin-right:auto; background-color: white;">
+	    <div class="modal-header">
+	        <button type="button" class="close" data-dismiss="modal">x</button>
+	            <h3>This is CSS-less representation of your providers login page. <br/>
+	            You might need to authenticate with captcha. If that's the case, you can do it here.<br/>
+	            Make sure you click on the Sign-In button after performing the captcha test. 
+	            You don't need to enter your credentials, Medusa already has those!</h3>
+	    </div>
+	    <div id="captcha-modal" class="modal-body">
+	    </div>
+	    <div class="modal-footer">
+	        <button class="btn" data-dismiss="modal">OK</button>
+	    </div>
+    </div>
 </div>
+
 </%block>

--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -812,7 +812,7 @@ $('#config-components').tabs();
         </form>
     </div>
 
-	<div id="myModal" class="modal fade" tabindex="-1" role="dialog" style="width: 750px; margin-left: auto; margin-right:auto; background-color: white;">
+	<div id="myModal" class="modal fade" tabindex="-1" role="dialog" style="width: 750px; margin-left: auto; margin-right:auto; background-color: white; display: none;">
 	    <div class="modal-header">
 	        <button type="button" class="close" data-dismiss="modal">x</button>
 	            <h3>This is CSS-less representation of your providers login page. <br/>
@@ -820,10 +820,10 @@ $('#config-components').tabs();
 	            Make sure you click on the Sign-In button after performing the captcha test. 
 	            You don't need to enter your credentials, Medusa already has those!</h3>
 	    </div>
-	    <div id="captcha-modal" class="modal-body">
+	    <div id="captcha-modal" class="modal-body" style="visibility: hidden">
 	    </div>
 	    <div class="modal-footer">
-	        <button class="btn" data-dismiss="modal">OK</button>
+	        <button id="captcha-ok-button" class="btn" data-dismiss="modal">OK</button>
 	    </div>
     </div>
 </div>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1921,6 +1921,10 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
         if hasattr(curTorrentProvider, 'subtitle'):
             new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_subtitle'] = int(
                 curTorrentProvider.subtitle)
+        if hasattr(curTorrentProvider, '_uid'):
+            new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_uid'] = curTorrentProvider._uid
+        if hasattr(curTorrentProvider, '_hash'):
+            new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_hash'] = curTorrentProvider._hash
 
     for curNzbProvider in [curProvider for curProvider in providers.sortedProviderList() if
                            curProvider.provider_type == GenericProvider.NZB]:

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -50,20 +50,32 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         # URLs
         self.url = 'https://classic.torrentday.com'
         self.urls = {
-            'login': urljoin(self.url, '/torrents/'),
+            'recaptcha': 'https://www.torrentday.com/tak3login.php',
+            'login': 'https://www.torrentday.com',
             'search': urljoin(self.url, '/V3/API/API.php'),
             'download': urljoin(self.url, '/download.php/')
         }
+
+        self.recaptcha = {'uid': self._uid, 'pass': self._hash}
 
         self.cookies = None
         self.categories = {'Season': {'c14': 1}, 'Episode': {'c2': 1, 'c26': 1, 'c7': 1, 'c24': 1},
                            'RSS': {'c2': 1, 'c26': 1, 'c7': 1, 'c24': 1, 'c14': 1}}
 
+        self.login_data = {
+            'username': self.username,
+            'password': self.password,
+            'submit.x': 0,
+            'submit.y': 0
+        }
+
         # Cache
         self.cache = tvcache.TVCache(self, min_time=10)  # Only poll IPTorrents every 10 minutes max
 
     def login(self):
-        if any(dict_from_cookiejar(self.session.cookies).values()):
+        if (any(dict_from_cookiejar(self.session.cookies).values()) and
+            all(['uid' in dict_from_cookiejar(self.session.cookies),
+                 'pass' in dict_from_cookiejar(self.session.cookies)])):
             return True
 
         if self._uid and self._hash:
@@ -87,7 +99,7 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                 return False
 
             try:
-                if dict_from_cookiejar(self.session.cookies)['uid'] and dict_from_cookiejar(self.session.cookies)['pass']:
+                if dict_from_cookiejar(self.session.cookies).get('uid') and dict_from_cookiejar(self.session.cookies).get('pass'):
                     self._uid = dict_from_cookiejar(self.session.cookies)['uid']
                     self._hash = dict_from_cookiejar(self.session.cookies)['pass']
                     self.cookies = {'uid': self._uid,

--- a/sickbeard/server/web/config/providers.py
+++ b/sickbeard/server/web/config/providers.py
@@ -15,10 +15,12 @@ from sickbeard import (
 )
 from sickbeard.providers import newznab, rsstorrent
 from sickrage.helper.common import try_int
+from sickbeard.helpers import getURL, make_session
 from sickrage.helper.encoding import ek
 from sickrage.providers.GenericProvider import GenericProvider
 from sickbeard.server.web.core import PageTemplate
 from sickbeard.server.web.config.handler import Config
+from requests.utils import dict_from_cookiejar
 
 
 @route('/config/providers(/?.*)')
@@ -87,6 +89,57 @@ class ConfigProviders(Config):
             new_provider = newznab.NewznabProvider(name, url, key=key)
             sickbeard.newznabProviderList.append(new_provider)
             return '|'.join([new_provider.get_id(), new_provider.configStr()])
+
+    @staticmethod
+    def testProviderLogin(provider_id):
+        """
+        Tests if it is possible to authenticate whit your current provider settings.
+        """
+        temp_provider = sickbeard.providers.getProviderClass(provider_id)
+        return json.dumps({"login": len(temp_provider.search({'RSS': ['']})) > 0})
+
+    @staticmethod
+    def loadReCaptcha(provider_id, url=None, params=None, post_data=None, headers=None):
+        provider = sickbeard.providers.getProviderClass(provider_id)
+        if not provider.urls.get('login'):
+            return "<h1>Provider does not need recaptcha authentication</h1>"
+        if not url:
+            url = provider.urls.get('login')
+        mysession = make_session()
+        # captcha_page = provider.get_url(url, post_data=post_data, params=params, verify=False, returns='response')
+        captcha_page = getURL(url, post_data=post_data, session=mysession, params=params, verify=False, returns='text')
+        return captcha_page
+
+    @staticmethod
+    def getProviderCaptchaCookie(provider_id, captcha=None):
+        provider = sickbeard.providers.getProviderClass(provider_id)
+        post_data = provider.login_data
+        post_data['g-recaptcha-response'] = captcha
+        post_data['username'] = provider.username
+        post_data['password'] = provider.password
+        html = provider.get_url(provider.urls.get('recaptcha'), post_data=post_data, returns='response', verify=False)
+
+        all_cookies = {}
+        all_cookies.update(dict_from_cookiejar(html.cookies))
+        all_cookies.update(dict_from_cookiejar(html.request._cookies))
+
+        # Let's get the required cookies
+        if hasattr(provider, 'recaptcha'):
+            for key in provider.recaptcha:
+                # Combine request and response cookie
+                if key in all_cookies:
+                    provider.recaptcha[key] = all_cookies.get(key)
+                    # This is legacy crap. Should be removed later
+                    if hasattr(provider, '_uid') and key == 'uid':
+                        provider._uid = all_cookies.get(key)
+                    if hasattr(provider, '_hash') and key == 'pass':
+                        provider._hash = all_cookies.get(key)
+
+        sickbeard.save_config()
+        if provider.login():
+            return json.dumps({'result': 'true'})
+
+        return json.dumps({'result': 'false'})
 
     @staticmethod
     def getNewznabCategories(name, url, key):

--- a/sickbeard/server/web/config/providers.py
+++ b/sickbeard/server/web/config/providers.py
@@ -107,7 +107,7 @@ class ConfigProviders(Config):
             url = provider.urls.get('login')
         mysession = make_session()
         # captcha_page = provider.get_url(url, post_data=post_data, params=params, verify=False, returns='response')
-        captcha_page = getURL(url, post_data=post_data, session=mysession, params=params, verify=False, returns='text')
+        captcha_page = getURL(url, post_data=post_data, session=mysession, params=params, returns='text')
         return captcha_page
 
     @staticmethod

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -326,14 +326,16 @@ def episode_num(season=None, episode=None, **kwargs):
         if not (season and episode) and (season or episode):
             return '{0:0>3}'.format(season or episode)
 
+
 def enabled_providers(search_type):
-    """ 
+    """
     Return providers based on search type: daily, backlog and manualsearch
     """
     return [x for x in sickbeard.providers.sortedProviderList(sickbeard.RANDOMIZE_PROVIDERS)
-        if x.is_active() and
-        hasattr(x, 'enable_{}'.format(search_type)) and
-        getattr(x, 'enable_{}'.format(search_type))]
+            if x.is_active() and
+            hasattr(x, 'enable_{}'.format(search_type)) and
+            getattr(x, 'enable_{}'.format(search_type))]
+
 
 def remove_strings(old_string, unwanted_strings):
     """

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -69,6 +69,7 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
         self.show = None
         self.supports_absolute_numbering = False
         self.supports_backlog = True
+        self.recaptcha = False
         self.url = ''
         self.urls = {}
 


### PR DESCRIPTION
This is just a POC! So don't merge it!!!

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

This is showcase a way of doing captcha authentication within medusa. Pls try it out. But no guarentees it will work for you.

How it works:
You can go to your provider configuration (options tab). If you select your provider, you will see the options. If it's torrentday, it will have a button "get providers reCaptcha login page"
![image](https://cloud.githubusercontent.com/assets/1331394/16058859/b19ba4c8-3280-11e6-9aca-06965f4a8180.png)

When clicking the button, a modal will be loaded, with the login page of the provider. This has been routed through medusa! Meaning, it asked medusa to get the login page, and medusa did so, and forwarded it back to the modal. But this also means, any other secondary content normally loaded from  torrentday, can't (or I havent' implemented it). Meaning, you won't have css parsed.

In the modal, the google reCaptcha is loaded, and you can solve the puzzel if required.

Last step! Click on the Sign In button.

![image](https://cloud.githubusercontent.com/assets/1331394/16058958/3956afd4-3281-11e6-9832-00d4c65d805b.png)

Now, you can start using the provider. Manual searches / Rss / backlog, should all work.

Removed some of the not needed html:
http://imgur.com/f0HThIN