### PR TITLE
Unicode mass edit

### DIFF
--- a/sickbeard/server/web/home/add_shows.py
+++ b/sickbeard/server/web/home/add_shows.py
@@ -149,7 +149,7 @@ class HomeAddShows(Home):
                 dir_results = main_db_con.select(
                     b'SELECT indexer_id '
                     b'FROM tv_shows '
-                    b'WHERE location = ? LIMIT 1', 
+                    b'WHERE location = ? LIMIT 1',
                     [cur_path]
                 )
 
@@ -534,7 +534,7 @@ class HomeAddShows(Home):
         series_pieces = whichSeries.split('|')
         if (whichSeries and rootDir) or (whichSeries and fullShowPath and len(series_pieces) > 1):
             if len(series_pieces) < 6:
-                logger.log(u'Unable to add show due to show selection. Not anough arguments: %s' % (repr(series_pieces)),
+                logger.log(u'Unable to add show due to show selection. Not enough arguments: %s' % (repr(series_pieces)),
                            logger.ERROR)
                 ui.notifications.error('Unknown error. Unable to add show due to problem with show selection.')
                 return self.redirect('/addShows/existingShows/')

--- a/sickbeard/server/web/home/handler.py
+++ b/sickbeard/server/web/home/handler.py
@@ -1369,7 +1369,6 @@ class Home(WebRoot):
                 show_obj.rls_ignore_words = rls_ignore_words.strip()
                 show_obj.rls_require_words = rls_require_words.strip()
 
-            location = location.decode('UTF-8')
             # if we change location clear the db of episodes, change it, write to db, and rescan
             old_location = ek(os.path.normpath, show_obj._location)
             new_location = ek(os.path.normpath, location)


### PR DESCRIPTION
OS: Windows 10
Python: 2.7.11
Medusa: Current dev

When using mass edit to change directories containing non-ascii can cause UnicodeError.  This fixes the issue by removing an unnecessary `.decode()`.

Also fixes minor typo.