### PR TITLE
Added cookies_ingest attribute to torrent providers. Should fix the TD captcha.

### DIFF
--- a/gui/slick/js/configProviders.js
+++ b/gui/slick/js/configProviders.js
@@ -283,7 +283,7 @@ $(document).ready(function(){
         } else {
             $('#torrentrss_name').attr("disabled", "disabled");
             $('#torrentrss_url').removeAttr("disabled");
-            $('#torrentrss_cookies').removeAttr("disabled");
+            $('#torrentrss_cookies').attr("disabled", "disabled");
             $('#torrentrss_titleTAG').removeAttr("disabled");
             $('#torrentrss_delete').removeAttr("disabled");
         }

--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -408,12 +408,12 @@ $('#config-components').tabs();
                         </div>
                         % endif
 
-                        % if hasattr(curTorrentProvider, 'cookies_ingest'):
+                        % if curTorrentProvider.enable_cookies:
                         <div class="field-pair">
-                            <label for="${curTorrentProvider.get_id()}_torrent_ingest">
+                            <label for="${curTorrentProvider.get_id()}_cookies">
                                 <span class="component-title">Cookies:</span>
                                 <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.get_id()}_cookies_ingest" id="${curTorrentProvider.get_id()}_cookies_ingest" value="${curTorrentProvider.cookies_ingest}" class="form-control input-sm input350" autocapitalize="off" autocomplete="no" />
+                                    <input type="text" name="${curTorrentProvider.get_id()}_cookies" id="${curTorrentProvider.get_id()}_cookies" value="${curTorrentProvider.cookies}" class="form-control input-sm input350" autocapitalize="off" autocomplete="no" />
                                 </span>
                             </label>
                             <label>
@@ -783,11 +783,11 @@ $('#config-components').tabs();
                         <div class="field-pair">
                             <label for="torrentrss_cookies">
                                 <span class="component-title">Cookies:</span>
-                                <input type="text" id="torrentrss_cookies" class="form-control input-sm input350" autocapitalize="off" />
+                                <input type="text" id="torrentrss_cookies" class="form-control input-sm input350" autocapitalize="off" disabled="disabled"/>
                             </label>
                             <label>
                                 <span class="component-title">&nbsp;</span>
-                                <span class="component-desc">eg. uid=xx;pass=yy</span>
+                                <span class="component-desc">eg. uid=xx;pass=yy, please use "Provider options" to reconfigure!</span>
                             </label>
                         </div>
                         <div class="field-pair">

--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -408,6 +408,23 @@ $('#config-components').tabs();
                         </div>
                         % endif
 
+                        % if hasattr(curTorrentProvider, 'cookies_ingest'):
+                        <div class="field-pair">
+                            <label for="${curTorrentProvider.get_id()}_torrent_ingest">
+                                <span class="component-title">Cookies:</span>
+                                <span class="component-desc">
+                                    <input type="text" name="${curTorrentProvider.get_id()}_cookies_ingest" id="${curTorrentProvider.get_id()}_cookies_ingest" value="${curTorrentProvider.cookies_ingest}" class="form-control input-sm input350" autocapitalize="off" autocomplete="no" />
+                                </span>
+                            </label>
+                            <label>
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">
+                                    <p>eg. uid=xx;pass=yy</p>
+                                </span>
+                            </label>
+                        </div>
+                        % endif
+
                         % if hasattr(curTorrentProvider, 'passkey'):
                         <div class="field-pair">
                             <label for="${curTorrentProvider.get_id()}_passkey">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1395,6 +1395,9 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             if hasattr(curTorrentProvider, 'subtitle'):
                 curTorrentProvider.subtitle = bool(check_setting_int(CFG, curTorrentProvider.get_id().upper(),
                                                                      curTorrentProvider.get_id() + '_subtitle', 0))
+            if hasattr(curTorrentProvider, 'cookies_ingest'):
+                curTorrentProvider.cookies_ingest = check_setting_str(CFG, curTorrentProvider.get_id().upper(),
+                                                                      curTorrentProvider.get_id() + '_cookies_ingest', '', censor_log='low')
 
         for curNzbProvider in [curProvider for curProvider in providers.sortedProviderList() if
                                curProvider.provider_type == GenericProvider.NZB]:
@@ -1921,6 +1924,9 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
         if hasattr(curTorrentProvider, 'subtitle'):
             new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_subtitle'] = int(
                 curTorrentProvider.subtitle)
+        if hasattr(curTorrentProvider, 'cookies_ingest'):
+            new_config[curTorrentProvider.get_id().upper()][
+                curTorrentProvider.get_id() + '_cookies_ingest'] = curTorrentProvider.cookies_ingest
 
     for curNzbProvider in [curProvider for curProvider in providers.sortedProviderList() if
                            curProvider.provider_type == GenericProvider.NZB]:

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1395,9 +1395,9 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             if hasattr(curTorrentProvider, 'subtitle'):
                 curTorrentProvider.subtitle = bool(check_setting_int(CFG, curTorrentProvider.get_id().upper(),
                                                                      curTorrentProvider.get_id() + '_subtitle', 0))
-            if hasattr(curTorrentProvider, 'cookies_ingest'):
-                curTorrentProvider.cookies_ingest = check_setting_str(CFG, curTorrentProvider.get_id().upper(),
-                                                                      curTorrentProvider.get_id() + '_cookies_ingest', '', censor_log='low')
+            if curTorrentProvider.enable_cookies:
+                curTorrentProvider.cookies = check_setting_str(CFG, curTorrentProvider.get_id().upper(),
+                                                               curTorrentProvider.get_id() + '_cookies', '', censor_log='low')
 
         for curNzbProvider in [curProvider for curProvider in providers.sortedProviderList() if
                                curProvider.provider_type == GenericProvider.NZB]:
@@ -1924,9 +1924,9 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
         if hasattr(curTorrentProvider, 'subtitle'):
             new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_subtitle'] = int(
                 curTorrentProvider.subtitle)
-        if hasattr(curTorrentProvider, 'cookies_ingest'):
+        if hasattr(curTorrentProvider, 'cookies'):
             new_config[curTorrentProvider.get_id().upper()][
-                curTorrentProvider.get_id() + '_cookies_ingest'] = curTorrentProvider.cookies_ingest
+                curTorrentProvider.get_id() + '_cookies'] = curTorrentProvider.cookies
 
     for curNzbProvider in [curProvider for curProvider in providers.sortedProviderList() if
                            curProvider.provider_type == GenericProvider.NZB]:

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -154,40 +154,40 @@ class TorrentRssProvider(TorrentProvider):  # pylint: disable=too-many-instance-
             add_cookie = self.add_cookies_from_ui()
             if not add_cookie:
                 return add_cookie
-#             if self.cookies:
-#                 cookie_validator = re.compile(r'^(\w+=\w+)(;\w+=\w+)*$')
-#                 if not cookie_validator.match(self.cookies):
-#                     return False, 'Cookie is not correctly formatted: {0}'.format(self.cookies)
-#                 add_dict_to_cookiejar(self.session.cookies, dict(x.rsplit('=', 1) for x in self.cookies.split(';')))
 
             # pylint: disable=protected-access
             # Access to a protected member of a client class
             data = self.cache._getRSSData()['entries']
             if not data:
-                return False, 'No items found in the RSS feed {0}'.format(self.url)
+                return {'result': False,
+                        'message': 'No items found in the RSS feed {0}'.format(self.url)}
 
             title, url = self._get_title_and_url(data[0])
 
             if not title:
-                return False, 'Unable to get title from first item'
+                return {'result': False,
+                        'message': 'Unable to get title from first item'}
 
             if not url:
-                return False, 'Unable to get torrent url from first item'
+                return {'result': False,
+                        'message': 'Unable to get torrent url from first item'}
 
             if url.startswith('magnet:') and re.search(r'urn:btih:([\w]{32,40})', url):
-                return True, 'RSS feed Parsed correctly'
+                return {'result': True,
+                        'message': 'RSS feed Parsed correctly'}
             else:
                 torrent_file = self.get_url(url, returns='content')
                 try:
                     bdecode(torrent_file)
                 except Exception as error:
                     self.dump_html(torrent_file)
-                    return False, 'Torrent link is not a valid torrent file: {0}'.format(ex(error))
+                    return {'result': False,
+                            'message': 'Torrent link is not a valid torrent file: {0}'.format(ex(error))}
 
-            return True, 'RSS feed Parsed correctly'
+            return {'result': True, 'message': 'RSS feed Parsed correctly'}
 
         except Exception as error:
-            return False, 'Error when trying to load RSS: {0}'.format(ex(error))
+            return {'result': False, 'message': 'Error when trying to load RSS: {0}'.format(ex(error))}
 
     @staticmethod
     def dump_html(data):

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -152,7 +152,7 @@ class TorrentRssProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         try:
             add_cookie = self.add_cookies_from_ui()
-            if not add_cookie:
+            if not add_cookie.get('result'):
                 return add_cookie
 
             # pylint: disable=protected-access

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -27,7 +27,7 @@ from requests.utils import add_dict_to_cookiejar, dict_from_cookiejar
 
 from sickbeard import logger, tvcache
 
-from sickrage.helper.common import convert_size, try_int
+from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
@@ -178,7 +178,9 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                 logger.log('Too many login access attempts', logger.WARNING)
                 return False
 
-            if dict_from_cookiejar(self.session.cookies).get('uid') not in response.text:
+            if dict_from_cookiejar(self.session.cookies).get('uid') in response.text:
+                return True
+            else:
                 logger.log('Failed to login, check your cookies', logger.WARNING)
                 return False
 

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -54,13 +54,11 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         # Miscellaneous Options
         self.freeleech = False
-        self.cookies = None
+        self.enable_cookies = True
+        self.cookies = ''
 
         self.categories = {'Season': {'c14': 1}, 'Episode': {'c2': 1, 'c26': 1, 'c7': 1, 'c24': 1},
                            'RSS': {'c2': 1, 'c26': 1, 'c7': 1, 'c24': 1, 'c14': 1}}
-
-        # Ingest cookies from config, if provided by user in UI
-        self.cookies_ingest = ''
 
         # Torrent Stats
         self.minseed = None
@@ -159,9 +157,9 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         if dict_from_cookiejar(self.session.cookies).get('uid') and dict_from_cookiejar(self.session.cookies).get('pass'):
             return True
 
-        if self.cookies_ingest:
-            if 'uid' in self.cookies_ingest and 'pass' in self.cookies_ingest:
-                add_dict_to_cookiejar(self.session.cookies, self.split_cookies(self.cookies_ingest))
+        if self.cookies:
+            if 'uid' in self.cookies and 'pass' in self.cookies:
+                self.add_cookies_from_ui()
 
             login_params = {
                 'username': self.username,

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -103,6 +103,7 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                     jdata = response.json()
                 except ValueError:  # also catches JSONDecodeError if simplejson is installed
                     logger.log('Data returned from provider is not json', logger.ERROR)
+                    self.session.cookies.clear()
                     continue
 
                 torrents = jdata.get('Fs', [dict()])[0].get('Cn', {}).get('torrents', [])

--- a/sickbeard/server/web/config/providers.py
+++ b/sickbeard/server/web/config/providers.py
@@ -494,11 +494,11 @@ class ConfigProviders(Config):
                 except (AttributeError, KeyError):
                     curTorrentProvider.subtitle = 0  # these exceptions are actually catching unselected checkboxes
 
-            if hasattr(curTorrentProvider, 'cookies_ingest'):
+            if curTorrentProvider.enable_cookies:
                 try:
-                    curTorrentProvider.cookies_ingest = str(kwargs['{id}_cookies_ingest'.format(id=curTorrentProvider.get_id())]).strip()
+                    curTorrentProvider.cookies = str(kwargs['{id}_cookies'.format(id=curTorrentProvider.get_id())]).strip()
                 except (AttributeError, KeyError):
-                    curTorrentProvider.cookies_ingest = None  # these exceptions are actually catching unselected checkboxes
+                    pass  # I don't want to configure a default value here, as it can also be configured intially as a custom rss torrent provider
 
         for curNzbProvider in [prov for prov in sickbeard.providers.sortedProviderList() if
                                prov.provider_type == GenericProvider.NZB]:

--- a/sickbeard/server/web/config/providers.py
+++ b/sickbeard/server/web/config/providers.py
@@ -152,11 +152,11 @@ class ConfigProviders(Config):
         if temp_provider.get_id() in provider_dict:
             return json.dumps({'error': 'Exists as {name}'.format(name=provider_dict[temp_provider.get_id()].name)})
         else:
-            (succ, err_msg) = temp_provider.validate_rss()
-            if succ:
+            validate = temp_provider.validate_rss()
+            if validate['result']:
                 return json.dumps({'success': temp_provider.get_id()})
             else:
-                return json.dumps({'error': err_msg})
+                return json.dumps({'error': validate['message']})
 
     @staticmethod
     def saveTorrentRssProvider(name, url, cookies, titleTAG):

--- a/sickbeard/server/web/config/providers.py
+++ b/sickbeard/server/web/config/providers.py
@@ -494,6 +494,12 @@ class ConfigProviders(Config):
                 except (AttributeError, KeyError):
                     curTorrentProvider.subtitle = 0  # these exceptions are actually catching unselected checkboxes
 
+            if hasattr(curTorrentProvider, 'cookies_ingest'):
+                try:
+                    curTorrentProvider.cookies_ingest = str(kwargs['{id}_cookies_ingest'.format(id=curTorrentProvider.get_id())]).strip()
+                except (AttributeError, KeyError):
+                    curTorrentProvider.cookies_ingest = None  # these exceptions are actually catching unselected checkboxes
+
         for curNzbProvider in [prov for prov in sickbeard.providers.sortedProviderList() if
                                prov.provider_type == GenericProvider.NZB]:
 

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -39,7 +39,7 @@ from sickbeard.tvcache import TVCache
 from sickrage.helper.common import replace_extension, sanitize_filename
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex
-
+from requests.utils import add_dict_to_cookiejar
 
 # Keep a list of per provider of recent provider search results
 recent_results = {}
@@ -77,6 +77,11 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
         self.supports_backlog = True
         self.url = ''
         self.urls = {}
+
+        # Use and configure the attribute enable_cookies to show or hide the cookies input field per provider
+        self.enable_cookies = False
+        self.cookies = ''
+        self.rss_cookies = ''
 
         # Paramaters for reducting the daily search results parsing
         self.max_recent_items = 5
@@ -546,3 +551,19 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
                     add_to_list += [item]
             results = add_to_list + recent_results[self.get_id()]
             recent_results[self.get_id()] = results[:self.max_recent_items]
+
+    def add_cookies_from_ui(self):
+        """
+        Adds the cookies configured from UI to the providers requests session
+        :return: A tuple with the the (success result, and a descriptive message in str)
+        """
+
+        # This is the generic attribute used to manually add cookies for provider authentication
+        if self.enable_cookies and self.cookies:
+            cookie_validator = re.compile(r'^(\w+=\w+)(;\w+=\w+)*$')
+            if not cookie_validator.match(self.cookies):
+                return False, 'Cookie is not correctly formatted: {0}'.format(self.cookies)
+            add_dict_to_cookiejar(self.session.cookies, dict(x.rsplit('=', 1) for x in self.cookies.split(';')))
+            return True, 'torrent cookie'
+
+        return False, 'No Cookies added from ui for provider: {0}'.format(self.name)

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -577,3 +577,6 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
                                          'No Cookies added from ui for provider: {0}'.format(self.name))
                 return {'result': False,
                         'message': 'No Cookies added from ui for provider: {0}'.format(self.name)}
+
+        return {'result': False,
+                'message': 'Adding cookies is not supported for provider: {0}'.format(self.name)}

--- a/sickrage/providers/torrent/TorrentProvider.py
+++ b/sickrage/providers/torrent/TorrentProvider.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import traceback
+
 from datetime import datetime
 from feedparser.util import FeedParserDict
 from hachoir_parser import createParser
@@ -193,4 +193,3 @@ class TorrentProvider(GenericProvider):
             hash = None
 
         return hash
-

--- a/sickrage/providers/torrent/TorrentProvider.py
+++ b/sickrage/providers/torrent/TorrentProvider.py
@@ -17,11 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import sickbeard
-
+import traceback
 from datetime import datetime
 from feedparser.util import FeedParserDict
 from hachoir_parser import createParser
+
+import sickbeard
 from sickbeard import logger
 from sickbeard.classes import Proper, TorrentSearchResult
 from sickbeard.common import Quality
@@ -192,3 +193,12 @@ class TorrentProvider(GenericProvider):
             hash = None
 
         return hash
+
+    @staticmethod
+    def split_cookies(cookie):
+        try:
+            return {k.strip(): v.strip() for k, v in [cookie.split('=') for cookie in cookie.split(';')]}
+        except Exception:
+            logger.log('Could not parse cookie! Check your input!'.format
+                       (traceback.format_exc()), logger.WARNING)
+            return {}

--- a/sickrage/providers/torrent/TorrentProvider.py
+++ b/sickrage/providers/torrent/TorrentProvider.py
@@ -194,11 +194,3 @@ class TorrentProvider(GenericProvider):
 
         return hash
 
-    @staticmethod
-    def split_cookies(cookie):
-        try:
-            return {k.strip(): v.strip() for k, v in (cookie.split('=') for cookie in cookie.split(';'))}
-        except Exception:
-            logger.log('Could not parse cookie! Check your input! Exception: {0}'.format
-                       (traceback.format_exc()), logger.WARNING)
-            return {}

--- a/sickrage/providers/torrent/TorrentProvider.py
+++ b/sickrage/providers/torrent/TorrentProvider.py
@@ -197,7 +197,7 @@ class TorrentProvider(GenericProvider):
     @staticmethod
     def split_cookies(cookie):
         try:
-            return {k.strip(): v.strip() for k, v in [cookie.split('=') for cookie in cookie.split(';')]}
+            return {k.strip(): v.strip() for k, v in (cookie.split('=') for cookie in cookie.split(';'))}
         except Exception:
             logger.log('Could not parse cookie! Check your input! Exception: {0}'.format
                        (traceback.format_exc()), logger.WARNING)

--- a/sickrage/providers/torrent/TorrentProvider.py
+++ b/sickrage/providers/torrent/TorrentProvider.py
@@ -199,6 +199,6 @@ class TorrentProvider(GenericProvider):
         try:
             return {k.strip(): v.strip() for k, v in [cookie.split('=') for cookie in cookie.split(';')]}
         except Exception:
-            logger.log('Could not parse cookie! Check your input!'.format
+            logger.log('Could not parse cookie! Check your input! Exception: {0}'.format
                        (traceback.format_exc()), logger.WARNING)
             return {}


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

Users will now be able to configure cookies for providers with the cookies_ingest attribute.
This is now only enabled for torrentday. To fix the captcha issue.