### PR TITLE
Fix encoding userid/password before logging in to SMTP server

### DIFF
--- a/sickbeard/notifiers/emailnotify.py
+++ b/sickbeard/notifiers/emailnotify.py
@@ -319,7 +319,7 @@ class Notifier(object):
                 srv.ehlo()
             if user and pwd:
                 logger.log('Sending LOGIN command!', logger.DEBUG)
-                srv.login(user, pwd)
+                srv.login(user.encode('utf-8'), pwd.encode('utf-8'))
 
             srv.sendmail(smtp_from, to, msg.as_string())
             srv.quit()


### PR DESCRIPTION
Fix from @avdleeuw thanks!

@medariox 