### PR TITLE
Remove associated files when episode gets deleted

### DIFF
--- a/sickbeard/databases/main_db.py
+++ b/sickbeard/databases/main_db.py
@@ -50,6 +50,20 @@ class MainSanityCheck(db.DBSanityCheck):
         self.fix_show_nfo_lang()
         self.convert_tvrage_to_tvdb()
         self.convert_archived_to_compound()
+        self.fix_subtitle_reference()
+
+    def fix_subtitle_reference(self):
+        logger.log(u'Checking for delete episodes with subtitle reference', logger.DEBUG)
+        query = "SELECT episode_id, showid, location, subtitles, subtitles_searchcount, subtitles_lastsearch " + \
+                "FROM tv_episodes WHERE location = '' AND subtitles is not ''"
+
+        sql_results = self.connection.select(query)
+        if sql_results:
+            for sql_result in sql_results:
+                logger.log(u"Found deleted episode id {0} from show ID {1} with subtitle data. Erasing reference...".format
+                    (sql_result['episode_id'], sql_result['showid']), logger.WARNING)
+                self.connection.action("UPDATE tv_episodes SET subtitles = '', subtitles_searchcount = 0, subtitles_lastsearch = '' " + \
+                                        "WHERE episode_id = %i" % (sql_result['episode_id']))
 
     def convert_archived_to_compound(self):
         logger.log(u'Checking for archived episodes not qualified', logger.DEBUG)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1287,15 +1287,28 @@ class TVShow(TVObject):
                                        (id=self.indexerid, ep=episode_num(season, episode),
                                         status=statusStrings[new_status]), logger.DEBUG)
                             cur_ep.status = new_status
-                            cur_ep.subtitles = list()
+                            cur_ep.subtitles = ''
                             cur_ep.subtitles_searchcount = 0
-                            cur_ep.subtitles_lastsearch = str(datetime.datetime.min)
+                            cur_ep.subtitles_lastsearch = ''
                         cur_ep.location = ''
                         cur_ep.hasnfo = False
                         cur_ep.hastbn = False
                         cur_ep.release_name = ''
 
                         sql_l.append(cur_ep.get_sql())
+
+                    logger.log("Looking for hanging associates files for: {}".format(cur_loc))
+                    related_files = postProcessor.PostProcessor(cur_loc).list_associated_files(
+                                    cur_loc, base_name_only=False, subfolders=True)
+
+                    if related_files:
+                        logger.log(u"{id}: Found hanging associated files for {ep}, deleting: {files}".format
+                                       (id=self.indexerid, ep=episode_num(season, episode), files=related_files), logger.WARNING)
+                        for related_file in related_files:
+                            try:
+                                os.remove(related_file)
+                            except Exception as e:
+                                logger.log(u"Could not delete associate file: {0}. Error: {1}".format(related_file, e), logger.WARNING)
 
         if sql_l:
             main_db_con = db.DBConnection()


### PR DESCRIPTION
@medariox @ratoaq2 thoughts?

WARNING for now so everybody can easily test without digging into log

I tested this for one week

```
2016-07-03 03:08:36 WARNING  SHOWQUEUE-REFRESH :: [42fd472] 75682: Found hanging associated files for S11E19, deleting: [u'/media/SAMSUNG/media/series/Bones/Season 11/Bones.S11E19.1080p.WEB-DL.DD5.1.H.264-NTb.pt-BR.srt']
2016-07-03 03:08:36 INFO     SHOWQUEUE-REFRESH :: [42fd472] Looking for hanging associates files for: /media/SAMSUNG/media/series/Bones/Season 11/Bones.S11E19.1080p.WEB-DL.DD5.1.H.264-NTb.mkv
2016-07-03 03:08:36 DEBUG    SHOWQUEUE-REFRESH :: [42fd472] 75682: Location for S11E19 doesn't exist, removing it and changing our status to Archived (1080p WEB-DL)
```