### PR TITLE
Fix routes and location called from logger

### DIFF
--- a/sickbeard/server/web/home/handler.py
+++ b/sickbeard/server/web/home/handler.py
@@ -762,7 +762,7 @@ class Home(WebRoot):
                 })
                 submenu.append({
                     'title': 'Remove',
-                    'path': 'home/delete_show?show={show}'.format(show=show_obj.indexerid),
+                    'path': 'home/deleteShow?show={show}'.format(show=show_obj.indexerid),
                     'class': 'removeshow',
                     'confirm': True,
                     'icon': 'ui-icon ui-icon-trash',
@@ -1085,7 +1085,7 @@ class Home(WebRoot):
                 })
                 submenu.append({
                     'title': 'Remove',
-                    'path': 'home/delete_show?show={show}'.format(show=show_obj.indexerid),
+                    'path': 'home/deleteShow?show={show}'.format(show=show_obj.indexerid),
                     'class': 'removeshow',
                     'confirm': True,
                     'icon': 'ui-icon ui-icon-trash',

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1205,10 +1205,10 @@ class TVShow(TVObject):
                 else:
                     ek(shutil.rmtree, self.location)
 
-                logger.log(u'%s show folder %s' % (('Deleted', 'Trashed')[sickbeard.TRASH_REMOVE_SHOW], self.location))
+                logger.log(u'%s show folder %s' % (('Deleted', 'Trashed')[sickbeard.TRASH_REMOVE_SHOW], self.raw_location))
 
             except ShowDirectoryNotFoundException:
-                logger.log(u'Show folder does not exist, no need to %s %s' % (action, self.location), logger.WARNING)
+                logger.log(u'Show folder does not exist, no need to %s %s' % (action, self.raw_location), logger.WARNING)
             except OSError as e:
                 logger.log(u'Unable to %s %s: %s / %s' % (action, self.location, repr(e), str(e)), logger.WARNING)
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1210,7 +1210,7 @@ class TVShow(TVObject):
             except ShowDirectoryNotFoundException:
                 logger.log(u'Show folder does not exist, no need to %s %s' % (action, self.raw_location), logger.WARNING)
             except OSError as e:
-                logger.log(u'Unable to %s %s: %s / %s' % (action, self.location, repr(e), str(e)), logger.WARNING)
+                logger.log(u'Unable to %s %s: %s / %s' % (action, self.raw_location, repr(e), str(e)), logger.WARNING)
 
         if sickbeard.USE_TRAKT and sickbeard.TRAKT_SYNC_WATCHLIST:
             logger.log(u'Removing show: indexerid ' + str(self.indexerid) +


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

* Fixed route, deleteShow was renamed to delete_show. That's okay for variables, but with routes we should be extra careful.
* Fixed bug where location is called as an attribute, but the attribute itself is verifying the location. Which does not work, if the file/location has been deleted from disk.

Fix for: https://github.com/pymedusa/SickRage/pull/746
And issue: https://github.com/pymedusa/SickRage/issues/765