### PR TITLE
Fixing guessit multiple formats

### DIFF
--- a/sickbeard/name_parser/rules/rules.py
+++ b/sickbeard/name_parser/rules/rules.py
@@ -1733,6 +1733,84 @@ class FixMultipleTitles(Rule):
         return to_remove
 
 
+class FixMultipleFormats(Rule):
+    """Fix multiple formats.
+
+    Related to guessit bug: https://github.com/guessit-io/guessit/issues/327
+
+    e.g.: Show.Name.S02E01.eps2.0.unm4sk-pt1.tc.1080p.WEB-DL.DD5.1.H264-GROUP
+
+    guessit -t episode "Show.Name.S02E01.eps2.0.unm4sk-pt1.tc.1080p.WEB-DL.DD5.1.H264-GROUP"
+
+    without this rule:
+        For: Show.Name.S02E01.eps2.0.unm4sk-pt1.tc.1080p.WEB-DL.DD5.1.H264-GROUP
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 2,
+            "episode": 1,
+            "episode_title": "eps2 0 unm4sk",
+            "part": 1,
+            "format": [
+                "Telecine",
+                "WEB-DL"
+            ],
+            "screen_size": "1080p",
+            "audio_codec": "DolbyDigital",
+            "audio_channels": "5.1",
+            "video_codec": "h264",
+            "release_group": "GROUP",
+            "type": "episode"
+        }
+
+
+    with this rule:
+        For: Show.Name.S02E01.eps2.0.unm4sk-pt1.tc.1080p.WEB-DL.DD5.1.H264-GROUP
+        GuessIt found: {
+            "title": "Show Name",
+            "season": 2,
+            "episode": 1,
+            "episode_title": "eps2 0 unm4sk",
+            "part": 1,
+            "format": "WEB-DL",
+            "screen_size": "1080p",
+            "audio_codec": "DolbyDigital",
+            "audio_channels": "5.1",
+            "video_codec": "h264",
+            "release_group": "GROUP",
+            "type": "episode"
+        }
+    """
+
+    priority = POST_PROCESS
+    consequence = RemoveMatch
+
+    def when(self, matches, context):
+        """Evaluate the rule.
+
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        to_remove = []
+        fileparts = matches.markers.named('path')
+        for filepart in marker_sorted(fileparts, matches):
+            formats = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'format')
+            if len(formats) < 2:
+                continue
+
+            last_format = formats[-1]
+            previous = matches.previous(last_format, predicate=lambda match: match.name == 'screen_size')
+            next_range = matches.range(last_format.end, filepart.end,
+                                       lambda match: match.name in ('video_codec', 'release_group'))
+            # If we have at least 3 matches near by, then discard the other formats
+            if len(previous) + len(next_range) > 2:
+                to_remove.extend(formats[0:-1])
+
+        return to_remove
+
+
 class EnhanceReleaseGroupDetection(Rule):
     """Enhance release group detection.
 
@@ -1960,5 +2038,6 @@ def rules():
         CreateAliasWithCountryOrYear,
         EnhanceReleaseGroupDetection,
         ReleaseGroupPostProcessor,
-        FixMultipleTitles
+        FixMultipleTitles,
+        FixMultipleFormats
     )

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -2705,3 +2705,18 @@
   release_group: POOLSTAR
   type: episode
 
+# FixMultipleFormats
+? Show.Name.S02E01.eps2.0.unm4sk-pt1.tc.1080p.WEB-DL.DD5.1.H264-GROUP
+: title: Show Name
+  season: 2
+  episode: 1
+  # episode title and part are not fixed. Not a big issue for us.
+  episode_title: eps2 0 unm4sk
+  part: 1
+  screen_size: 1080p
+  format: WEB-DL
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  video_codec: h264
+  release_group: GROUP
+  type: episode


### PR DESCRIPTION
This is a guessit rule until https://github.com/guessit-io/guessit/issues/327 is fixed.

This rule will detect multiple formats and will keep the last format if the last format is surrounded by screen_size, video_codec and release_group

The episode_title is not handled/fixed since it doesn't cause issues for us.

Fixes https://github.com/pymedusa/SickRage/issues/772

