### PR TITLE
Additional fix for guessit multiple formats

### DIFF
--- a/sickbeard/name_parser/rules/rules.py
+++ b/sickbeard/name_parser/rules/rules.py
@@ -1793,7 +1793,6 @@ class FixMultipleFormats(Rule):
         :type context: dict
         :return:
         """
-        to_remove = []
         fileparts = matches.markers.named('path')
         for filepart in marker_sorted(fileparts, matches):
             formats = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'format')
@@ -1806,9 +1805,9 @@ class FixMultipleFormats(Rule):
                                        lambda match: match.name in ('video_codec', 'release_group'))
             # If we have at least 3 matches near by, then discard the other formats
             if len(previous) + len(next_range) > 2:
-                to_remove.extend(formats[0:-1])
-
-        return to_remove
+                invalid_formats = {f.value for f in formats[0:-1]}
+                to_remove = matches.named('format', predicate=lambda m: m.value in invalid_formats)
+                return to_remove
 
 
 class EnhanceReleaseGroupDetection(Rule):

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -2706,7 +2706,8 @@
   type: episode
 
 # FixMultipleFormats
-? Show.Name.S02E01.eps2.0.unm4sk-pt1.tc.1080p.WEB-DL.DD5.1.H264-GROUP
+? - Show.Name.S02E01.eps2.0.unm4sk-pt1.tc.1080p.WEB-DL.DD5.1.H264-GROUP.mkv
+  - /folder/Show.Name.S02E01.eps2.0.unm4sk-pt1.tc.1080p.WEB-DL.DD5.1.H264-GROUP[something]/Show.Name.S02E01.eps2.0.unm4sk-pt1.tc.1080p.WEB-DL.DD5.1.H264-GROUP.mkv
 : title: Show Name
   season: 2
   episode: 1
@@ -2719,6 +2720,8 @@
   audio_channels: '5.1'
   video_codec: h264
   release_group: GROUP
+  container: mkv
+  mimetype: video/x-matroska
   type: episode
 
 # Size detection separated with .


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

This should fix #772 

The problem happened again because the file path has 2 portions with the same information, but the first part has a release group with additional words between brackets; so the second part would have all info except the release_group, which was affecting the logic of our fix.