### PR TITLE
tvepisode refiner

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -611,6 +611,17 @@ class Quality(object):
         }
     }
 
+    to_guessit_format_list = [
+        ANYHDTV, ANYWEBDL, ANYBLURAY
+    ]
+
+    to_guessit_screen_size_map = {
+        HDTV | HDWEBDL | HDBLURAY: '720p',
+        RAWHDTV: '1080i',
+        FULLHDTV | FULLHDWEBDL | FULLHDBLURAY: '1080p',
+        UHD_4K_TV | UHD_4K_WEBDL | UHD_4K_BLURAY: '4K',
+    }
+
     @staticmethod
     def from_guessit(guess):
         """
@@ -638,6 +649,48 @@ class Quality(object):
 
         quality = format_map.get(fmt)
         return quality if quality is not None else Quality.UNKNOWN
+
+    @staticmethod
+    def to_guessit(status):
+        """Return a guessit dict containing 'screen_size and format' from a Quality (composite status)
+
+        :param status: a quality composite status
+        :type status int
+        :return: dict {'screen_size': <screen_size>, 'format': <format>}
+        :rtype: dict (str, str)
+        """
+        _, quality = Quality.splitCompositeStatus(status)
+        result = {
+            'screen_size': Quality.to_guessit_screen_size(quality),
+            'format': Quality.to_guessit_format(quality)
+        }
+        return result
+
+    @staticmethod
+    def to_guessit_format(quality):
+        """Return a guessit format from a Quality
+
+        :param quality: the quality
+        :type quality: int
+        :return: guessit format
+        :rtype: str
+        """
+        for q in Quality.to_guessit_format_list:
+            if quality & q:
+                return Quality.combinedQualityStrings.get(q)
+
+    @staticmethod
+    def to_guessit_screen_size(quality):
+        """Return a guessit screen_size from a Quality
+
+        :param quality: the quality
+        :type quality: int
+        :return: guessit screen_size
+        :rtype: str
+        """
+        for key, value in Quality.to_guessit_screen_size_map.items():
+            if quality & key:
+                return value
 
     DOWNLOADED = None
     SNATCHED = None

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -655,7 +655,7 @@ class Quality(object):
         """Return a guessit dict containing 'screen_size and format' from a Quality (composite status)
 
         :param status: a quality composite status
-        :type status int
+        :type status: int
         :return: dict {'screen_size': <screen_size>, 'format': <format>}
         :rtype: dict (str, str)
         """

--- a/sickbeard/refiners/release.py
+++ b/sickbeard/refiners/release.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+"""Release refiner."""
+from __future__ import unicode_literals
+
 import logging
 import os
 
 from guessit import guessit
-from sickbeard.helpers import remove_non_release_groups
 
 logger = logging.getLogger(__name__)
 
@@ -16,9 +18,10 @@ EPISODE_ATTRIBUTES = {'series': 'title', 'season': 'season', 'episode': 'episode
 
 def refine(video, release_name=None, release_file=None, extension='release', **kwargs):
     """Refine a video by using the original release name.
+
     The refiner will first try:
     - Read the file video_name.<extension> seeking for a release name
-    - If no release name, it will read the file release file seeking for a release name
+    - If no release name, it will read the release_file seeking for a release name
     - If no release name, it will use the release_name passed as an argument
     - If no release name, then no change in the video object is made
 
@@ -38,25 +41,25 @@ def refine(video, release_name=None, release_file=None, extension='release', **k
       * :attr:`~subliminal.video.Video.audio_codec`
 
     :param video: the video to refine.
+    :type video: subliminal.video.Video
     :param str release_name: the release name to be used.
     :param str release_file: the release file to be used
     :param str extension: the release file extension.
-
     """
-    logger.debug(u'Starting release refiner [extension=%s, release_name=%s, release_file=%s]',
-                 extension, release_name, release_file)
+    logger.debug('Starting release refiner [extension={extension}, release_name={name}, release_file={file}]',
+                 extension=extension, name=release_name, file=release_file)
     dirpath, filename = os.path.split(video.name)
     dirpath = dirpath or '.'
     fileroot, fileext = os.path.splitext(filename)
     release_file = get_release_file(dirpath, fileroot, extension) or release_file
-    release_name = remove_non_release_groups(get_release_name(release_file) or release_name)
+    release_name = get_release_name(release_file) or release_name
 
     if not release_name:
-        logger.debug(u'No release name for %s', video.name)
+        logger.debug('No release name for {video}', video=video.name)
         return
 
     release_path = os.path.join(dirpath, release_name + fileext)
-    logger.debug(u'Guessing using %s', release_path)
+    logger.debug('Guessing using {path}', path=release_path)
 
     guess = guessit(release_path)
     attributes = MOVIE_ATTRIBUTES if guess.get('type') == 'movie' else EPISODE_ATTRIBUTES
@@ -66,37 +69,36 @@ def refine(video, release_name=None, release_file=None, extension='release', **k
 
         if new_value and old_value != new_value:
             setattr(video, key, new_value)
-            logger.debug(u'Attribute %s changed from %s to %s', key, old_value, new_value)
+            logger.debug('Attribute {key} changed from {old} to {new}', key=key, old=old_value, new=new_value)
 
 
 def get_release_file(dirpath, filename, extension):
-    """
-    Given a `dirpath`, `filename` and `extension`, it returns the release file that should contain the original
-    release name.
+    """Return the release file that should contain the release name for a given a `dirpath`, `filename` and `extension`.
 
-    Args:
-        dirpath: the file base folder
-        filename: the file name without extension
-        extension: the file extension
-
-    Returns: the release file if the file exists
+    :param dirpath: the file base folder
+    :type dirpath: str
+    :param filename: the file name without extension
+    :type filename: str
+    :param extension:
+    :type extension: the file extension
+    :return: the release file if the file exists
+    :rtype: str
     """
     release_file = os.path.join(dirpath, filename + '.' + extension)
 
     # skip if info file doesn't exist
     if os.path.isfile(release_file):
-        logger.debug(u'Found release file %s', release_file)
+        logger.debug('Found release file {file}', file=release_file)
         return release_file
 
 
 def get_release_name(release_file):
-    """
-    Given a `release_file` it will return the release name
+    """Given a `release_file` it will return the release name.
 
-    Args:
-        release_file: the text file that contains the release name
-
-    Returns: the release name
+    :param release_file: the text file that contains the release name
+    :type release_file: str
+    :return: the release name
+    :rtype: str
     """
     if not release_file:
         return
@@ -106,6 +108,6 @@ def get_release_name(release_file):
 
     # skip if no release name was found
     if not release_name:
-        logger.warning(u'Release file %s does not contain a release name', release_file)
+        logger.warning('Release file {file} does not contain a release name', file=release_file)
 
     return release_name

--- a/sickbeard/refiners/tvepisode.py
+++ b/sickbeard/refiners/tvepisode.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""TVEpisode refiner."""
+from __future__ import unicode_literals
+
+import logging
+import re
+
+from sickbeard.common import Quality
+from subliminal.video import Episode
+
+logger = logging.getLogger(__name__)
+
+SHOW_MAPPING = {
+    'series_tvdb_id': 'tvdb_id',
+    'series_imdb_id': 'imdbid',
+    'year': 'startyear'
+}
+
+EPISODE_MAPPING = {
+    'tvdb_id': 'tvdb_id',
+    'episode': 'episode',
+    'season': 'season',
+    'size': 'file_size',
+    'title': 'name',
+}
+
+series_re = re.compile(r'^(?P<series>.*?)(?: \((?:(?P<year>\d{4})|(?P<country>[A-Z]{2}))\))?$')
+
+
+def refine(video, tv_episode=None, **kwargs):
+    """Refine a video by using TVEpisode information.
+
+    :param video: the video to refine.
+    :type video: Episode
+    :param tv_episode: the TVEpisode to be used.
+    :type tv_episode: sickbeard.tv.TVEpisode
+    :param kwargs:
+    """
+    if video.series_tvdb_id and video.tvdb_id:
+        logger.debug('No need to refine with TVEpisode')
+        return
+
+    if not tv_episode:
+        logger.debug('No TVEpisode to be used to refine')
+        return
+
+    if not isinstance(video, Episode):
+        logger.debug('Video {name} is not an episode. Skipping refiner...', name=video.name)
+        return
+
+    if tv_episode.show:
+        logger.debug('Refining using TVShow information.')
+        series, year, country = series_re.match(tv_episode.show.name).groups()
+        enrich({'series': series, 'year': int(year) if year else None}, video)
+        enrich(SHOW_MAPPING, video, tv_episode.show)
+
+    logger.debug('Refining using TVEpisode information.')
+    enrich(EPISODE_MAPPING, video, tv_episode)
+    enrich({'release_group': tv_episode.release_group}, video, overwrite=False)
+    enrich(Quality.to_guessit(tv_episode.status), video, overwrite=False)
+
+
+def enrich(attributes, target, source=None, overwrite=True):
+    """Copy attributes from source to target.
+
+    :param attributes: the attributes mapping
+    :type attributes: dict(str -> str)
+    :param target: the target object
+    :param source: the source object. If None, the value in attributes dict will be used as new_value
+    :param overwrite: if source field should be overwritten if not already set
+    :type overwrite: bool
+    """
+    for key, value in attributes.items():
+        old_value = getattr(target, key)
+        if old_value and not overwrite:
+            continue
+
+        new_value = getattr(source, value) if source else value
+
+        if new_value and old_value != new_value:
+            setattr(target, key, new_value)
+            logger.debug('Attribute {key} changed from {old} to {new}', key=key, old=old_value, new=new_value)

--- a/sickbeard/refiners/tvepisode.py
+++ b/sickbeard/refiners/tvepisode.py
@@ -57,7 +57,8 @@ def refine(video, tv_episode=None, **kwargs):
     logger.debug('Refining using TVEpisode information.')
     enrich(EPISODE_MAPPING, video, tv_episode)
     enrich({'release_group': tv_episode.release_group}, video, overwrite=False)
-    enrich(Quality.to_guessit(tv_episode.status), video, overwrite=False)
+    guess = Quality.to_guessit(tv_episode.status)
+    enrich({'resolution': guess['screen_size'], 'format': guess['format']}, video, overwrite=False)
 
 
 def enrich(attributes, target, source=None, overwrite=True):

--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -741,6 +741,8 @@ class SubtitlesFinder(object):
                     run_post_process = True
                     continue
 
+                # 'postpone' should not consider existing subtitles from db.
+                tv_episode.subtitles = []
                 downloaded_languages = download_subtitles(tv_episode, video_path=video_path,
                                                           subtitles=False, embedded_subtitles=False)
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -404,15 +404,15 @@ class TVShow(TVObject):
         if season not in self.episodes:
             self.episodes[season] = {}
 
-        ep = None
-        if episode not in self.episodes[season] or self.episodes[season][episode] is None:
-            if no_create:
-                return None
+        if episode in self.episodes[season] and self.episodes[season][episode] is not None:
+            return self.episodes[season][episode]
+        elif no_create:
+            return None
 
-            if filepath:
-                ep = TVEpisode(self, season, episode, filepath)
-            else:
-                ep = TVEpisode(self, season, episode)
+        if filepath:
+            ep = TVEpisode(self, season, episode, filepath)
+        else:
+            ep = TVEpisode(self, season, episode)
 
         if ep is not None and should_cache:
             self.episodes[season][episode] = ep

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -412,6 +412,8 @@ class TVShow(TVObject):
 
             if ep is not None:
                 self.episodes[season][episode] = ep
+        elif filepath:
+            self.episodes[season][episode].location = filepath
 
         return self.episodes[season][episode]
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

Adding a subliminal refiner that will enrich the video information with tvdbid, imdb_id and other information present in our database. That way, some refiners in subliminal will be skipped since the information is already present (it can improve performance in a show refresh). I'm not disabling those refiners since they can act as a fallback if no TVEpisode is present (for any reason).