### PR TITLE
Fixes pymedusa/SickRage/issues/728 and warn about no cookies set

### DIFF
--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -167,6 +167,9 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         if self.cookies:
             self.add_cookies_from_ui()
+        else:
+            logger.log('Failed to login, you must add your cookies in the provider settings', logger.WARNING)
+            return False
 
             login_params = {
                 'username': self.username,

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -104,7 +104,15 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                     self.session.cookies.clear()
                     continue
 
-                torrents = jdata.get('Fs', [dict()])[0].get('Cn', {}).get('torrents', [])
+                try:
+                    cn = jdata.get('Fs', [dict()])[0].get('Cn', {})
+                    torrents = cn.get('torrents', []) if cn else []
+                except (AttributeError, TypeError, KeyError, ValueError, IndexError) as e:
+                    # If TorrentDay changes their website issue will be opened so we can fix fast
+                    # and not wait user notice it's not downloading torrents from there
+                    logger.log('TorrentDay response: {0}. Error: {1!r}'.format(jdata, e), logger.ERROR)
+                    continue
+
                 if not torrents:
                     logger.log('Data returned from provider does not contain any torrents', logger.DEBUG)
                     continue


### PR DESCRIPTION
@p0psicles 
Fixes https://github.com/pymedusa/SickRage/issues/728

From my PR I got:
Torrentday response to send to devs: {u'Fs': [{u'Cn': 0, u'Fn': u'Oarrive'}], u'er': 0}

```python
>>> jdata = {u'Fs': [{u'Cn': 0, u'Fn': u'Oarrive'}], u'er': 0}
>>> torrents = jdata.get('Fs', [dict()])[0].get('Cn', {}).get('torrents', [])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'int' object has no attribute 'get'

```