### PR TITLE
Fix delete file when non-ascii

### DIFF
--- a/sickbeard/databases/main_db.py
+++ b/sickbeard/databases/main_db.py
@@ -61,9 +61,9 @@ class MainSanityCheck(db.DBSanityCheck):
         if sql_results:
             for sql_result in sql_results:
                 logger.log(u"Found deleted episode id {0} from show ID {1} with subtitle data. Erasing reference...".format
-                    (sql_result['episode_id'], sql_result['showid']), logger.WARNING)
+                           (sql_result['episode_id'], sql_result['showid']), logger.WARNING)
                 self.connection.action("UPDATE tv_episodes SET subtitles = '', subtitles_searchcount = 0, subtitles_lastsearch = '' " + \
-                                        "WHERE episode_id = %i" % (sql_result['episode_id']))
+                                       "WHERE episode_id = %i" % (sql_result['episode_id']))
 
     def convert_archived_to_compound(self):
         logger.log(u'Checking for archived episodes not qualified', logger.DEBUG)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1308,7 +1308,7 @@ class TVShow(TVObject):
                             id=self.indexerid, ep=episode_num(season, episode), files=related_files), logger.WARNING)
                         for related_file in related_files:
                             try:
-                                os.remove(related_file)
+                                ek(os.remove, related_file)
                             except Exception as e:
                                 logger.log(u"Could not delete associate file: {0}. Error: {1}".format(related_file, e),
                                            logger.WARNING)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1299,19 +1299,20 @@ class TVShow(TVObject):
 
                         sql_l.append(cur_ep.get_sql())
 
-                    logger.log("Looking for hanging associates files for: {}".format(cur_loc))
+                    logger.log('Looking for hanging associated files for: {0}'.format(cur_loc))
                     related_files = postProcessor.PostProcessor(cur_loc).list_associated_files(
-                                    cur_loc, base_name_only=False, subfolders=True)
+                        cur_loc, base_name_only=False, subfolders=True)
 
                     if related_files:
-                        logger.log(u"{id}: Found hanging associated files for {ep}, deleting: {files}".format(
-                            id=self.indexerid, ep=episode_num(season, episode), files=related_files), logger.WARNING)
+                        logger.log(u'{id}: Found hanging associated files for {ep}, deleting: {files}'.format
+                                   (id=self.indexerid, ep=episode_num(season, episode), files=related_files),
+                                   logger.WARNING)
                         for related_file in related_files:
                             try:
                                 ek(os.remove, related_file)
                             except Exception as e:
-                                logger.log(u"Could not delete associate file: {0}. Error: {1}".format(related_file, e),
-                                           logger.WARNING)
+                                logger.log(u'Could not delete associated file: {0}. Error: {1}'.format
+                                           (related_file, e), logger.WARNING)
 
         if sql_l:
             main_db_con = db.DBConnection()


### PR DESCRIPTION
as pointed by @medariox 

Dont change anything else otherwise will conflict with rato's rewrite in tvrefiner

Could not delete associate file: /media/Data/Media/TV Shows/Lucifer/S01/Subsè/Lucifer.S01E08.HDTV.XviD-FUM.it.srt. Error: 'ascii' codec can't encode character u'\xe8' in position 43: ordinal not in range(128)