### PR TITLE
guessit: use user's show list as expected titles

### DIFF
--- a/sickbeard/name_parser/guessit_parser.py
+++ b/sickbeard/name_parser/guessit_parser.py
@@ -10,6 +10,7 @@ import six
 from guessit.api import default_api
 from guessit.rules.common.date import valid_year
 
+
 # hardcoded expected titles
 fixed_expected_titles = {
     # guessit doesn't add dots for this show
@@ -134,7 +135,33 @@ def get_expected_titles():
 
         # (?<![^/\\]) means -> it matches nothing but path separators (negative lookbehind)
         fmt = r're:\b{name}\b' if show.is_anime else r're:(?<![^/\\]){name}\b'
-        escaped_name = re.escape(series).replace(r'\ ', ' ')  # space should not be escaped
-        expected_titles.append(fmt.format(name=escaped_name))
+        expected_titles.append(fmt.format(name=prepare(series)))
 
     return expected_titles
+
+
+def prepare(string):
+    """Prepare a string to be used as a regex in guessit expected_title
+
+    :param string:
+    :type string: str
+    :return:
+    :rtype: str
+    """
+    # replace some special characters with space
+    characters = {'-', ':', '.', ',', '*'}
+    string = re.sub(r'[%s]' % re.escape(''.join(characters)), ' ', string)
+
+    # escape other characters that might be problematic
+    string = re.escape(string)
+
+    # ' should be optional
+    string = string.replace(r"\'", r"'?")
+
+    # spaces shouldn't be escaped
+    string = string.replace('\ ', ' ')
+
+    # replace multiple spaces with one
+    string = re.sub(r'\s+', ' +', string.strip())
+
+    return string

--- a/sickbeard/name_parser/guessit_parser.py
+++ b/sickbeard/name_parser/guessit_parser.py
@@ -134,6 +134,7 @@ def get_expected_titles():
 
         # (?<![^/\\]) means -> it matches nothing but path separators (negative lookbehind)
         fmt = r're:\b{name}\b' if show.is_anime else r're:(?<![^/\\]){name}\b'
-        expected_titles.append(fmt.format(name=series))
+        escaped_name = re.escape(series).replace(r'\ ', ' ')  # space should not be escaped
+        expected_titles.append(fmt.format(name=escaped_name))
 
     return expected_titles

--- a/sickbeard/name_parser/guessit_parser.py
+++ b/sickbeard/name_parser/guessit_parser.py
@@ -13,9 +13,6 @@ from guessit.rules.common.date import valid_year
 
 # hardcoded expected titles
 fixed_expected_titles = {
-    # guessit doesn't add dots for this show
-    '11.22.63',
-
     # guessit: conflicts with italian language
     r're:(?<![^/\\])\w+ it\b',
 }
@@ -132,6 +129,10 @@ def get_expected_titles():
 
         if not any([char.isdigit() for char in series]):
             continue
+
+        if not any([char.isalpha() for char in series]):
+            # if no alpha chars then add series name 'as-is'
+            expected_titles.append(series)
 
         # (?<![^/\\]) means -> it matches nothing but path separators (negative lookbehind)
         fmt = r're:\b{name}\b' if show.is_anime else r're:(?<![^/\\]){name}\b'

--- a/sickbeard/name_parser/rules/rules.py
+++ b/sickbeard/name_parser/rules/rules.py
@@ -1728,9 +1728,11 @@ class FixMultipleTitles(Rule):
         # In case of duplicated titles, keep only the first one
         titles = matches.named('title')
 
-        to_remove = titles[1:]
-
-        return to_remove
+        if titles and len(titles) > 1:
+            # Safety: https://github.com/pymedusa/SickRage/pull/812#issuecomment-235824102
+            # Only remove matches that are different from the first match
+            to_remove = matches.named('title', predicate=lambda match: match.span != titles[0].span)
+            return to_remove
 
 
 class FixMultipleFormats(Rule):

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -182,6 +182,7 @@ class TVShow(TVObject):
         self.episodes = {}
         self.nextaired = ''
         self.release_groups = None
+        self.exceptions = []
 
         other_show = Show.find(sickbeard.showList, self.indexerid)
         if other_show is not None:

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -2777,3 +2777,10 @@
   container: mkv
   mimetype: video/x-matroska
   type: episode
+
+# Show name with number
+? R-15.S03E04
+: title: R-15
+  season: 3
+  episode: 4
+  type: episode

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -2767,7 +2767,7 @@
   release_group: GROUP
   type: episode
 
-# Anime show containing number in its title
+# Anime show containing number in its title and show with :
 ? "[GROUP].Mobile.Suit.Gundam.Unicorn.RE.0096.-.14.[720p].mkv"
 : title: Mobile Suit Gundam Unicorn RE 0096
   absolute_episode: 14
@@ -2776,6 +2776,14 @@
   release_group: GROUP
   container: mkv
   mimetype: video/x-matroska
+  type: episode
+
+# Anime show containing number in its title and show with :
+? /Anime/Mobile Suit Gundam UC RE0096/Season 01/Mobile Suit Gundam UC RE0096 - s01e15 - Title
+: title: Mobile Suit Gundam UC RE0096
+  season: 1
+  episode: 15
+  episode_title: Title
   type: episode
 
 # Show name with number
@@ -2790,4 +2798,21 @@
 : title: The Someone's Show 2
   season: 5
   episode: 7
+  type: episode
+
+# Show name with numbers and a single quote but filename without it:
+? The.Someones.Show.**.2.**.S05E07
+: title: The Someones Show 2
+  season: 5
+  episode: 7
+  type: episode
+
+# Regression test for https://github.com/pymedusa/SickRage/pull/812#issuecomment-235824102
+# Case: Expected title + 2 file parts and the second one starts with a word separator (dot)
+? 11.22.63./.11.22.63.[S01].(2016).HDTVRip.|.Group
+: title: 11.22.63
+  season: 1
+  year: 2016
+  format: HDTV
+  release_group: Group
   type: episode

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -2754,7 +2754,6 @@
   release_group: Group
   type: episode
 
-
 # CreateProperTags
 ? Show.Name.S03E08.REPACK.PROPER.HDTV.x264-GROUP
 : title: Show Name
@@ -2766,4 +2765,15 @@
   format: HDTV
   video_codec: h264
   release_group: GROUP
+  type: episode
+
+# Anime show containing number in its title
+? "[GROUP].Mobile.Suit.Gundam.Unicorn.RE.0096.-.14.[720p].mkv"
+: title: Mobile Suit Gundam Unicorn RE 0096
+  absolute_episode: 14
+  episode: 14
+  screen_size: 720p
+  release_group: GROUP
+  container: mkv
+  mimetype: video/x-matroska
   type: episode

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -2784,3 +2784,10 @@
   season: 3
   episode: 4
   type: episode
+
+# Show name with special characters and numbers:
+? The.Someone's.Show.**.2.**.S05E07
+: title: The Someone's Show 2
+  season: 5
+  episode: 7
+  type: episode

--- a/tests/guessit_tests.py
+++ b/tests/guessit_tests.py
@@ -98,6 +98,7 @@ class GuessitTests(unittest.TestCase):
         regular_format = r're:(?<![^/\\]){name}\b'
         anime_format = r're:\b{name}\b'
         sickbeard.showList = [
+            _mock_tv_show('1.2.3'),
             _mock_tv_show('Super Show (1999)'),
             _mock_tv_show('Incredible Show 2007'),
             _mock_tv_show('The Show (UK)'),
@@ -113,6 +114,8 @@ class GuessitTests(unittest.TestCase):
 
         # Then
         expected = set(sut.fixed_expected_titles) | {
+            '1.2.3',
+            regular_format.format(name='1 +2 +3'),
             regular_format.format(name='The +123 +Show'),
             regular_format.format(name='222 +Show'),
             regular_format.format(name="The +Someone'?s +Show +2"),

--- a/tests/guessit_tests.py
+++ b/tests/guessit_tests.py
@@ -67,10 +67,13 @@ class GuessitTests(unittest.TestCase):
 
     # show names with numbers that are used in our test suite
     show_list = [
+            _mock_tv_show('11.22.63'),
             _mock_tv_show('12 Monkeys'),
             _mock_tv_show('500 Bus Stops'),
             _mock_tv_show('60 Minutes'),
             _mock_tv_show('Mobile Suit Gundam Unicorn RE 0096', is_anime=True),
+            _mock_tv_show('R-15'),
+            _mock_tv_show('The Show ** 2 **'),
             _mock_tv_show('The 100'),
         ]
 

--- a/tests/guessit_tests.py
+++ b/tests/guessit_tests.py
@@ -71,9 +71,9 @@ class GuessitTests(unittest.TestCase):
             _mock_tv_show('12 Monkeys'),
             _mock_tv_show('500 Bus Stops'),
             _mock_tv_show('60 Minutes'),
-            _mock_tv_show('Mobile Suit Gundam Unicorn RE 0096', is_anime=True),
+            _mock_tv_show('Mobile Suit Gundam Unicorn RE:0096', is_anime=True),
             _mock_tv_show('R-15'),
-            _mock_tv_show('The Show ** 2 **'),
+            _mock_tv_show(r"The.Someone's.Show.**.2.**"),
             _mock_tv_show('The 100'),
         ]
 
@@ -103,20 +103,23 @@ class GuessitTests(unittest.TestCase):
             _mock_tv_show('The Show (UK)'),
             _mock_tv_show('The 123 Show'),
             _mock_tv_show('222 Show (2010)'),
+            _mock_tv_show('Something RE:0096', is_anime=True),
             _mock_tv_show('The 10 Anime Show', is_anime=True),
+            _mock_tv_show(r"The.Someone's.Show.**.2.**"),
         ]
 
         # When
         actual = sut.get_expected_titles()
 
         # Then
-        expected = list(sut.fixed_expected_titles)
-        expected.extend([
-            regular_format.format(name='The 123 Show'),
-            regular_format.format(name='222 Show'),
-            anime_format.format(name='The 10 Anime Show'),
-        ])
-        self.assertEqual(expected, actual)
+        expected = set(sut.fixed_expected_titles) | {
+            regular_format.format(name='The +123 +Show'),
+            regular_format.format(name='222 +Show'),
+            regular_format.format(name="The +Someone'?s +Show +2"),
+            anime_format.format(name='Something +RE +0096'),
+            anime_format.format(name='The +10 +Anime +Show'),
+        }
+        self.assertEqual(expected, set(actual))
 
     def test_pre_configured_guessit(self):
         """Assert that guessit.guessit() uses the pre-configured hook."""


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

- Remove hardcoded list of show names that contains numbers and make use of user's show list to build the expected titles list
- Added unit test and updated dataset with a real scenario