### PR TITLE
Update pull approve to include Thraxis

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -15,3 +15,4 @@ reviewers:
       - p0psicles
       - OmgImAlexis
       - adaur
+      - Thraxis


### PR DESCRIPTION
will only have effect when merged into master

@Thraxis 

No idea why it failed:
Parsing errors
  "{'required': 1, 'name': 'devs', 'members': ['duramato', 'fernandog', 'labrys', 'medariox', 'ratoaq2', 'p0psicles', 'OmgImAlexis', 'adaur', 'Thraxis']}" is an invalid value for reviewers: 'Thraxis' is not a collaborator of this repo

