### PR TITLE
Changed foreground displayShowTable and summary opacity to 0.9, 0.8 i…

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -1170,7 +1170,11 @@ span.snatched b {
 
 .displayShowTableFanArt.display_show {
     clear:both;
-    opacity: 0.8;
+    opacity: 0.9;
+}
+
+.summaryFanArt {
+   opacity: 0.9; 
 }
 
 .displayShowTableFanArt th.row-seasonheader {
@@ -1187,10 +1191,6 @@ span.snatched b {
 
 .snatchTitle {
     color: rgb(255, 255, 255) !important;
-}
-
-.summaryFanArt {
-   opacity: 0.8 !important; 
 }
 
 .tablesorterFanArt {


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

The less transparant the background, the more it will trouble the foreground/content. In the examples below the background opacity is 0.4.

opacity 0.8:
![image](https://cloud.githubusercontent.com/assets/1331394/17341262/056f9ee4-58f4-11e6-9a91-c142d1433fd9.png)

opacity 0.9:
![image](https://cloud.githubusercontent.com/assets/1331394/17341269/112ea234-58f4-11e6-8343-5fab26f40cee.png)
