### PR TITLE
Fix guessit parser when show titles contains numbers and unicode chars

### DIFF
--- a/sickbeard/name_parser/guessit_parser.py
+++ b/sickbeard/name_parser/guessit_parser.py
@@ -151,11 +151,17 @@ def prepare(string):
     :rtype: str
     """
     # replace some special characters with space
-    characters = {'-', '.', ',', '*'}
+    characters = {'-', '.', ',', '*', '(', ')'}
     string = re.sub(r'[%s]' % re.escape(''.join(characters)), ' ', string)
+
+    # replace unicode characters with period
+    string = re.sub(r'[^\x00-\x7F]+', '.', string)
 
     # escape other characters that might be problematic
     string = re.escape(string)
+
+    # dots (the replacement of unicode characters) shouldn't be escaped and should match 1 or more characters
+    string = string.replace('\.', '.+')
 
     # ' should be optional
     string = string.replace(r"\'", r"'?")

--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -84,6 +84,7 @@ class NameParser(object):
         # if we have an air-by-date show and the result is air-by-date,
         # then get the real season/episode numbers
         if result.show.air_by_date and result.is_air_by_date:
+            logger.debug('Show {name} is air by date', name=show.name)
             airdate = result.air_date.toordinal()
             main_db_con = db.DBConnection()
             sql_result = main_db_con.select(
@@ -96,8 +97,11 @@ class NameParser(object):
             if sql_result:
                 season_number = int(sql_result[0][0])
                 episode_numbers = [int(sql_result[0][1])]
+                logger.debug('Database info for show {name}: S{season} E{episodes}',
+                             name=show.name, season=season_number, episodes=episode_numbers)
 
             if season_number is None or not episode_numbers:
+                logger.debug('Show {name} has no season or episodes, using indexer...', name=show.name)
                 indexer_api = sickbeard.indexerApi(result.show.indexer)
                 try:
                     indexer_api_params = indexer_api.api_params.copy()
@@ -110,9 +114,11 @@ class NameParser(object):
 
                     season_number = int(tv_episode['seasonnumber'])
                     episode_numbers = [int(tv_episode['episodenumber'])]
+                    logger.debug('Indexer info for show {name}: S{season}E{episodes}',
+                                 name=show.name, season=season_number, episodes=episode_numbers)
                 except sickbeard.indexer_episodenotfound:
-                    logger.warn('Unable to find episode with date {date} for show {show.name} skipping',
-                                date=result.air_date, show=show.name)
+                    logger.warn('Unable to find episode with date {date} for show {name} skipping',
+                                date=result.air_date, name=show.name)
                     episode_numbers = []
                 except sickbeard.indexer_error as e:
                     logger.warn('Unable to contact {indexer_api.name}: {ex!r}', indexer_api=indexer_api, ex=e)
@@ -127,10 +133,13 @@ class NameParser(object):
                                                                    result.show.indexer,
                                                                    season_number,
                                                                    episode_number)
+                    logger.debug('Scene show {name}, using indexer numbering: S{season}E{episodes}',
+                                 name=show.name, season=s, episodes=e)
                 new_episode_numbers.append(e)
                 new_season_numbers.append(s)
 
         elif result.show.is_anime and result.is_anime:
+            logger.debug('Scene show {name} is anime', name=show.name)
             scene_season = scene_exceptions.get_scene_exception_by_name(result.series_name)[1]
             for absolute_episode in result.ab_episode_numbers:
                 a = absolute_episode
@@ -141,6 +150,8 @@ class NameParser(object):
                                                                        True, scene_season)
 
                 (s, e) = helpers.get_all_episodes_from_absolute_number(result.show, [a])
+                logger.debug('Scene show {name} using indexer for absolute {absolute}: S{season}E{episodes}',
+                             name=show.name, absolute=a, season=s, episodes=e)
 
                 new_absolute_numbers.append(a)
                 new_episode_numbers.extend(e)
@@ -156,10 +167,15 @@ class NameParser(object):
                                                                    result.show.indexer,
                                                                    result.season_number,
                                                                    episode_number)
+                    logger.debug('Scene show {name} using indexer numbering: S{season}E{episodes}',
+                                 name=show.name, season=s, episodes=e)
+
                 if result.show.is_anime:
                     a = helpers.get_absolute_number_from_season_and_episode(result.show, s, e)
                     if a:
                         new_absolute_numbers.append(a)
+                        logger.debug('Scene anime show {name} using indexer with absolute {absolute}: S{season}E{episodes}',
+                                     name=show.name, absolute=a, season=s, episodes=e)
 
                 new_episode_numbers.append(e)
                 new_season_numbers.append(s)

--- a/sickbeard/name_parser/rules/rules.py
+++ b/sickbeard/name_parser/rules/rules.py
@@ -1676,6 +1676,9 @@ class ExpectedTitlePostProcessor(Rule):
             # Remove all dots from the title
             new_title = copy.copy(title)  # IMPORTANT - never change the value. Better to remove and add it
             new_title.value = cleanup(title.value)
+            # important to remove tags from title: equivalent-ignore. Otherwise guessit exception might occur
+            # when more than 2 equivalent titles are found and episode title has number that conflicts with year
+            title.tags = []
             to_remove.append(title)
             to_append.append(new_title)
 

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -3004,3 +3004,15 @@
   season: 1
   episode: 1
   type: episode
+
+# Show containing numbers in the title; 2 parts (folder and filename) that matches expected title; + episode title with number!
+# regression test: guessit exception was happening
+? Show '70s Name/Season 07/Show '70s Name - S07E22 - 2000 Episode Title.mkv
+: title: Show '70s Name
+  season: 7
+  episode: 22
+  episode_title: Episode Title
+  year: 2000 # not a big issue for us
+  container: mkv
+  mimetype: video/x-matroska
+  type: episode

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -2997,3 +2997,10 @@
   container: mkv
   mimetype: video/x-matroska
   type: episode
+
+# Title with number and unicode character
+? 3 Show.på.(abc2).s01e01
+: title: 3 Show på abc2
+  season: 1
+  episode: 1
+  type: episode

--- a/tests/test_guessit.py
+++ b/tests/test_guessit.py
@@ -35,6 +35,7 @@ def show_list(create_tvshow):
         create_tvshow(indexerid=14, name=r"The.Someone's.Show.**.2.**"),
         create_tvshow(indexerid=15, name='The Show (UK)'),
         create_tvshow(indexerid=16, name='3 Show på (abc2)'),  # unicode characters, numbers and parenthesis
+        create_tvshow(indexerid=16, name="Show '70s Name"),
     ]
 
 

--- a/tests/test_guessit.py
+++ b/tests/test_guessit.py
@@ -8,6 +8,7 @@ import os
 import guessit
 import pytest
 import sickbeard.name_parser.guessit_parser as sut
+from six import text_type
 import yaml
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -33,6 +34,7 @@ def show_list(create_tvshow):
         create_tvshow(indexerid=13, name='The 123 Show'),
         create_tvshow(indexerid=14, name=r"The.Someone's.Show.**.2.**"),
         create_tvshow(indexerid=15, name='The Show (UK)'),
+        create_tvshow(indexerid=16, name='3 Show på (abc2)'),  # unicode characters, numbers and parenthesis
     ]
 
 
@@ -44,7 +46,7 @@ def _format_param(param):
     if isinstance(param, int):
         return param
 
-    return str(param)
+    return text_type(param)
 
 
 def _parameters(files, single_test=None):


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

- When user has a show with numbers and unicode characters a guessit exception happens when trying to parse any release name:

```
  File "C:\sickbeard\name_parser\guessit_parser.py", line 91, in guessit
    return default_api.guessit(name, options=final_options)
  File "C:\lib\guessit\api.py", line 113, in guessit
    raise GuessitException(string, options)
GuessitException: An internal error has occured in guessit.
===================== Guessit Exception Report =====================
version=2.1.0.dev0
string=someshow
options={'allowed_languages': ['ru', 'hu', 'en', 'nl', 'pt', 'de', 'jp', 'sv', 'it', 'fr', 'es', 'uk', 'ro', 'pl', 'he'], 'expected_group': ['re:\\bCDD\\b', 're:\\bF4ST3R\\b', 're:\\bTGNF4ST\\b', 're:\\bNovaRip
\\b', 're:\\bRiPRG\\b', 're:\\bPtM\\b', 're:\\bbyEMP\\b', 're:\\b4EVERHD\\b', 're:\\bPOURMOi\\b', 're:\\bPARTiCLE\\b', 're:\\bTV2LAX9\\b', 're:\\bCDP\\b', 're:\\bELITETORRENT\\b', 're:\\bRipPourBox\\b', 're:\\b
F4ST\\b', 're:\\bHDD\\b'], 'expected_title': ['re:(?<![^/\\\\])\\w+ it\\b', 're:(?<![^/\\\\\\.])Gutta +P\\\xc3\xa5 +Tur +\\(Tv2\\)\\b'], 'allowed_countries': ['gb', 'us'], 'episode_prefe
r_number': False, 'show_type': u'regular', 'type': u'episode', 'implicit': True}
```