### PR TITLE
Fix AttributeError: type object 'GithubException' has no attribute 'B…

### DIFF
--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -38,7 +38,8 @@ import subliminal
 
 from requests.compat import quote
 from six import itervalues, text_type
-from github import Github, InputFileContent, GithubException  # pylint: disable=import-error
+from github import Github, InputFileContent  # pylint: disable=import-error
+from github.GithubException import BadCredentialsException, RateLimitExceededException
 
 import sickbeard
 from sickbeard import classes
@@ -521,7 +522,7 @@ class Logger(object):  # pylint: disable=too-many-instance-attributes
                 if issue_id and cur_error in classes.ErrorViewer.errors:
                     # clear error from error list
                     classes.ErrorViewer.errors.remove(cur_error)
-        except (GithubException.BadCredentialsException, GithubException.RateLimitExceededException) as e:
+        except (BadCredentialsException, RateLimitExceededException) as e:
             self.log('Error while accessing github: {0}'.format(e), WARNING)
         except Exception:  # pylint: disable=broad-except
             self.log(traceback.format_exc(), ERROR)

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -522,15 +522,14 @@ class Logger(object):  # pylint: disable=too-many-instance-attributes
                 if issue_id and cur_error in classes.ErrorViewer.errors:
                     # clear error from error list
                     classes.ErrorViewer.errors.remove(cur_error)
-        except BadCredentialsException as e:
+        except BadCredentialsException:
             submitter_result = 'Please check your Github credentials in Medusa settings. Bad Credentials error'
             issue_id = None
-        except RateLimitExceededException as e:
-            submitter_result = 'Please wait before submit new issues . Github Rate Limit Exceeded error'
+        except RateLimitExceededException:
+            submitter_result = 'Please wait before submit new issues. Github Rate Limit Exceeded error'
             issue_id = None
-        except Exception:  # pylint: disable=broad-except
-            self.log(traceback.format_exc(), ERROR)
-            submitter_result = 'Exception generated in issue submitter, please check the log'
+        except Exception as e:  # pylint: disable=broad-except
+            submitter_result = 'Exception generated in issue submitter. Error: {0}'.format(ex(e))
             issue_id = None
         finally:
             self.submitter_running = False

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -522,8 +522,12 @@ class Logger(object):  # pylint: disable=too-many-instance-attributes
                 if issue_id and cur_error in classes.ErrorViewer.errors:
                     # clear error from error list
                     classes.ErrorViewer.errors.remove(cur_error)
-        except (BadCredentialsException, RateLimitExceededException) as e:
-            self.log('Error while accessing github: {0}'.format(e), WARNING)
+        except BadCredentialsException as e:
+            submitter_result = 'Please check your Github credentials in Medusa settings. Bad Credentials error'
+            issue_id = None
+        except RateLimitExceededException as e:
+            submitter_result = 'Please wait before submit new issues . Github Rate Limit Exceeded error'
+            issue_id = None
         except Exception:  # pylint: disable=broad-except
             self.log(traceback.format_exc(), ERROR)
             submitter_result = 'Exception generated in issue submitter, please check the log'

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -31,7 +31,6 @@ import pkgutil
 import platform
 import re
 import sys
-import traceback
 
 import tornado
 import subliminal


### PR DESCRIPTION
Seems its fixed.


```
2016-08-09 18:40:25 ERROR    Thread-15 :: [8ae98dd] Failed doing web ui callback: Traceback (most recent call last):
  File "/home/osmc/SickRage/sickbeard/server/web/core/base.py", line 268, in async_call
    result = function(**kwargs)
  File "/home/osmc/SickRage/sickbeard/server/web/core/error_logs.py", line 170, in submit_errors
    submitter_result, issue_id = logger.submit_errors()
  File "/home/osmc/SickRage/sickbeard/logger.py", line 524, in submit_errors
    except (GithubException.BadCredentialsException, GithubException.RateLimitExceededException) as e:
AttributeError: type object 'GithubException' has no attribute 'BadCredentialsException'
Traceback (most recent call last):
  File "/home/osmc/SickRage/sickbeard/server/web/core/base.py", line 268, in async_call
    result = function(**kwargs)
  File "/home/osmc/SickRage/sickbeard/server/web/core/error_logs.py", line 170, in submit_errors
    submitter_result, issue_id = logger.submit_errors()
  File "/home/osmc/SickRage/sickbeard/logger.py", line 524, in submit_errors
    except (GithubException.BadCredentialsException, GithubException.RateLimitExceededException) as e:
AttributeError: type object 'GithubException' has no attribute 'BadCredentialsException'
```