### PR TITLE
Catch all requests exceptions

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1418,16 +1418,15 @@ def getURL(url, post_data=None, params=None, headers=None,  # pylint:disable=too
     hooks, cookies, verify, proxies = request_defaults(kwargs)
     method = u'POST' if post_data else u'GET'
 
-    resp = session.request(method, url, data=post_data, params=params, timeout=timeout, allow_redirects=True,
-                           hooks=hooks, stream=stream, headers=headers, cookies=cookies, proxies=proxies,
-                           verify=verify)
-
-    if not resp.ok:
-        logger.log(u'Requested url {url} returned status code {status}: {desc}'.format
-                   (url=url, status=resp.status_code, desc=http_code_description(resp.status_code)), logger.DEBUG)
-
     try:
-        resp.raise_for_status()
+        resp = session.request(method, url, data=post_data, params=params, timeout=timeout, allow_redirects=True,
+                               hooks=hooks, stream=stream, headers=headers, cookies=cookies, proxies=proxies,
+                               verify=verify)
+    
+        if not resp.ok:
+            logger.log(u'Requested url {url} returned status code {status}: {desc}'.format
+                       (url=url, status=resp.status_code, desc=http_code_description(resp.status_code)), logger.DEBUG)
+    
     except requests.exceptions.RequestException as e:
         logger.log(u'Error requesting url {resp.url}. Error: {msg}'.format(resp=resp, msg=ex(e)), logger.DEBUG)
     except Exception as e:

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1485,17 +1485,9 @@ def download_file(url, filename, session=None, headers=None, **kwargs):  # pylin
             except Exception:
                 logger.log(u"Problem setting permissions or writing file to: %s" % filename, logger.WARNING)
 
-    except (requests.exceptions.HTTPError, requests.exceptions.TooManyRedirects) as e:
+    except requests.exceptions.RequestException as e:
         remove_file_failed(filename)
-        logger.log(u"HTTP error %r while loading download URL %s " % (ex(e), url), logger.WARNING)
-        return False
-    except requests.exceptions.ConnectionError as e:
-        remove_file_failed(filename)
-        logger.log(u"Connection error %r while loading download URL %s " % (ex(e), url), logger.WARNING)
-        return False
-    except requests.exceptions.Timeout as e:
-        remove_file_failed(filename)
-        logger.log(u"Connection timed out %r while loading download URL %s " % (ex(e), url), logger.WARNING)
+        logger.log(u'Error requesting download url: {0}. Error: {1}'.format(url, ex(e)), logger.WARNING)
         return False
     except EnvironmentError as e:
         remove_file_failed(filename)

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1422,11 +1422,11 @@ def getURL(url, post_data=None, params=None, headers=None,  # pylint:disable=too
         resp = session.request(method, url, data=post_data, params=params, timeout=timeout, allow_redirects=True,
                                hooks=hooks, stream=stream, headers=headers, cookies=cookies, proxies=proxies,
                                verify=verify)
-    
+
         if not resp.ok:
             logger.log(u'Requested url {url} returned status code {status}: {desc}'.format
                        (url=url, status=resp.status_code, desc=http_code_description(resp.status_code)), logger.DEBUG)
-    
+
     except requests.exceptions.RequestException as e:
         logger.log(u'Error requesting url {resp.url}. Error: {msg}'.format(resp=resp, msg=ex(e)), logger.DEBUG)
     except Exception as e:


### PR DESCRIPTION
Need to fix https://github.com/pymedusa/SickRage/issues/856

Requests.exceptions.ConnectionError is not being catched. any idea?
looks like an error inside another error

```
2016-08-09 18:14:29 ERROR    DAILYSEARCHER :: [8ae98dd] Exception generated in thread DAILYSEARCHER: error HTTPSConnectionPool(host='cdn.pymedusa.com', port=443): Max retries exceeded with url: /sb_network_timezones/network_timezones.txt (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x69eca530>: Failed to establish a new connection: [Errno -2] Nome ou servi\xc3\xa7o desconhecido',))
Traceback (most recent call last):
  File "/home/osmc/SickRage/sickbeard/scheduler.py", line 106, in run
    self.action.run(self.force)
  File "/home/osmc/SickRage/sickbeard/dailysearcher.py", line 75, in run
    update_network_dict()
  File "/home/osmc/SickRage/sickbeard/network_timezones.py", line 47, in update_network_dict
    url_data = helpers.getURL(url, session=helpers.make_session(), returns='response')
  File "/home/osmc/SickRage/sickbeard/helpers.py", line 1337, in getURL
    verify=verify)
  File "/home/osmc/SickRage/lib/requests/sessions.py", line 475, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/osmc/SickRage/lib/requests/sessions.py", line 585, in send
    r = adapter.send(request, **kwargs)
  File "/home/osmc/SickRage/lib/cachecontrol/adapter.py", line 46, in send
    resp = super(CacheControlAdapter, self).send(request, **kw)
  File "/home/osmc/SickRage/lib/requests/adapters.py", line 467, in send
    raise ConnectionError(e, request=request)
ConnectionError: HTTPSConnectionPool(host='cdn.pymedusa.com', port=443): Max retries exceeded with url: /sb_network_timezones/network_timezones.txt (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x69eca530>: Failed to establish a new connection: [Errno -2] Nome ou servi\xc3\xa7o desconhecido',))
```


@medariox @ratoaq2 