### PR TITLE
Shouldn't format logger message when there's no arguments

### DIFF
--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -557,7 +557,8 @@ class BraceMessage(object):
         :return:
         :rtype: str
         """
-        return str(self.fmt).format(*self.args, **self.kwargs)
+        result = str(self.fmt)
+        return result.format(*self.args, **self.kwargs) if self.args or self.kwargs else result
 
 
 class StyleAdapter(logging.LoggerAdapter):


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

Fix for #876 

An example when the error occurs:
```
logger.error("{'type': 'abc', 'anotherkey': True}")
```

If the message (that might come from an exception or something similar) has set or dict representation, it might lead to an exception when the logger tries create the displayed message.