### PR TITLE
Scene releases: release groups should drop all words after dash

### DIFF
--- a/sickbeard/name_parser/rules/rules.py
+++ b/sickbeard/name_parser/rules/rules.py
@@ -2062,6 +2062,9 @@ class ReleaseGroupPostProcessor(Rule):
                 if not value:
                     break
 
+            if value and matches.tagged('scene') and not matches.next(release_group):
+                value = value.split('-')[0]
+
             if release_group.value != value:
                 to_remove.append(release_group)
                 if value:

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -3016,3 +3016,14 @@
   container: mkv
   mimetype: video/x-matroska
   type: episode
+
+# Scene release groups should drop all words after dash
+? Show.Name.S06E05.720p.HDTV.x264-GROUP-BUYMORE
+: title: Show Name
+  season: 6
+  episode: 5
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  release_group: GROUP
+  type: episode


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

This is a small enhancement for some cases in  #810 
- Removing words in a release group after a dash. e.g.: GROUP-BUYMORE will become GROUP

The scenario above works fine. We need to do regression test on other scenarios to make sure there's no side effect.