### PR TITLE
Fixes pymedusa/SickRage/issues/911

### DIFF
--- a/sickbeard/notifiers/kodi.py
+++ b/sickbeard/notifiers/kodi.py
@@ -406,13 +406,16 @@ class Notifier(object):
 
     def clean_library(self):
         """Handles clean library KODI host via HTTP JSON-RPC."""
+        if not sickbeard.USE_KODI:
+            return True
         clean_library = True
         for host in [x.strip() for x in sickbeard.KODI_HOST.split(',')]:
-            logger.log(u'Cleaning KODI library via JSON method for host: {0}'.format(host), logger.DEBUG)
+            logger.log(u'Cleaning KODI library via JSON method for host: {0}'.format(host), logger.INFO)
             update_command = '{"jsonrpc":"2.0","method":"VideoLibrary.Clean","params": {"showdialogs": false},"id":1}'
             request = self._send_to_kodi_json(update_command, host)
             if not request:
-                logger.log(u'KODI library clean failed for host: {0}'.format(host), logger.WARNING)
+                if sickbeard.KODI_ALWAYS_ON:
+                    logger.log(u'KODI library clean failed for host: {0}'.format(host), logger.WARNING)
                 clean_library = False
                 if sickbeard.KODI_UPDATE_ONLYFIRST:
                     break
@@ -422,7 +425,8 @@ class Notifier(object):
             # catch if there was an error in the returned request
             for r in request:
                 if 'error' in r:
-                    logger.log(u'Error while attempting to clean library for host: {0}'.format(host), logger.WARNING)
+                    if sickbeard.KODI_ALWAYS_ON:
+                        logger.log(u'Error while attempting to clean library for host: {0}'.format(host), logger.WARNING)
                     clean_library = False
             if sickbeard.KODI_UPDATE_ONLYFIRST:
                 break
@@ -449,7 +453,7 @@ class Notifier(object):
             logger.log(u'No KODI host passed, aborting update', logger.WARNING)
             return False
 
-        logger.log(u"Updating KODI library via JSON method for host: " + host, logger.DEBUG)
+        logger.log(u"Updating KODI library via JSON method for host: " + host, logger.INFO)
 
         # if we're doing per-show
         if showName:

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -945,6 +945,12 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
 
         return False
 
+    def flag_kodi_clean_library(self):
+        """Set flag to Clean Kodi's library if Kodi is enabled."""
+        if sickbeard.USE_KODI:
+            self._log(u"Setting to clean Kodi library as we are going to replace file")
+            sickbeard.KODI_LIBRARY_CLEAN_PENDING = True
+
     def process(self):  # pylint: disable=too-many-return-statements, too-many-locals, too-many-branches, too-many-statements
         """
         Post-process a given file
@@ -1021,12 +1027,17 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
                     existing_file_status != PostProcessor.DOESNT_EXIST]):
                 if self.is_proper and new_ep_quality == old_ep_quality:
                     self._log(u'New file is a proper/repack, marking it safe to replace')
+                    self.flag_kodi_clean_library()
                 else:
                     _, preferred_qualities = common.Quality.splitQuality(int(show.quality))
                     if new_ep_quality not in preferred_qualities:
                         self._log(u'File exists and new file quality is not in a preferred quality list, '
                                   u'marking it unsafe to replace')
                         return False
+                    else:
+                        self._log(u'File exists and new file quality is in a preferred quality list, '
+                                  u'marking it safe to replace')
+                        self.flag_kodi_clean_library()
 
             # Check if the processed file season is already in our indexer. If not,
             # the file is most probably mislabled/fake and will be skipped.
@@ -1046,6 +1057,9 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
 
         # if the file is priority then we're going to replace it even if it exists
         else:
+            # Set to clean Kodi if file exists and it is priority_download
+            if existing_file_status != PostProcessor.DOESNT_EXIST:
+                self.flag_kodi_clean_library()
             self._log(u"This download is marked a priority download so I'm going to replace "
                       u"an existing file if I find one")
 
@@ -1061,7 +1075,6 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
         for cur_ep in [ep_obj] + ep_obj.related_episodes:
             try:
                 self._delete(cur_ep.location, associated_files=True)
-                sickbeard.KODI_LIBRARY_CLEAN_PENDING = True
                 # clean up any left over folders
                 if cur_ep.location:
                     helpers.delete_empty_folders(ek(os.path.dirname, cur_ep.location), keep_dir=ep_obj.show._location)  # pylint: disable=protected-access


### PR DESCRIPTION
@medariox @ratoaq2 I improved replace file detection:


Snatched SDTV. No Kodi clean as there is not existing file:
```
Snatch history had a quality in it, using that: SDTV
Medusa snatched this episode and it is not processed before
This episode is a priority download: True
There is no existing file so there's no worries about replacing it
This download is marked a priority download so I'm going to replace an existing file if I find one
Found release name Stranger.Things.S01E03.WEBRip.x264-TURBO
Destination folder for this episode: /media/SAMSUNG/media/series/Stranger Things/Season 1
```

Snatched 1080p WEB-DL: Kodi clean as I snatched SDTV before:
```
Snatch history had a quality in it, using that: 1080p WEB-DL
Medusa snatched this episode and it is not processed before
This episode is a priority download: True
File /media/SAMSUNG/media/series/Stranger Things/Season 1/Stranger.Things.S01E03.WEBRip.x264-TURBO.mkv is smaller than /media/SAMSUNG/media/downloaded/series/Stranger.Things.S01E03.Chapter.Three.Holly.Jolly.1080p.NF.WEBRip.DD5.1.x264-NTb[rarbg]/Stranger.Things.S01E03.Chapter.Three.Holly.Jolly.1080p.NF.WEBRip.DD5.1.x264-NTb.mkv
Setting to clean Kodi library as we are going to replace file
This download is marked a priority download so I'm going to replace an existing file if I find one
```
