### PR TITLE
Fix Third party apps only showing API and TORNADO logs after some calls

### DIFF
--- a/sickbeard/server/api/v1/core.py
+++ b/sickbeard/server/api/v1/core.py
@@ -1212,6 +1212,7 @@ class CMD_Logs(ApiCall):
             with io.open(logger.log_file, 'r', encoding='utf-8') as f:
                 data = f.readlines()
 
+        # TODO: Change this regex to use new ratoaq2 code
         regex = r"^(\d\d\d\d)\-(\d\d)\-(\d\d)\s*(\d\d)\:(\d\d):(\d\d)\s*([A-Z]+)\s*(.+?)\s*\:\:\s*(.*)$"
 
         final_data = []
@@ -1226,6 +1227,13 @@ class CMD_Logs(ApiCall):
 
             if match:
                 level = match.group(7)
+                thread = match.group(8)
+
+                # Don't show API and TORNADO log lines because
+                # it will only show those after some log API calls
+                if thread in ('API', 'TORNADO'):
+                    continue
+
                 if level not in logger.LOGGING_LEVELS:
                     last_line = False
                     continue


### PR DESCRIPTION
Example: 40 lines of FINDSUBTITLES and 10 of API/TORNADO
Next 'log' refresh it will show 30 and 20
Until reaches 50 of API/TORNADO
so user will only see API/TORNADO logs no matter what


@MGaetan89 (ShowsRage app)

@ratoaq2 