### PR TITLE
Remove duplicate log message

### DIFF
--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -429,7 +429,6 @@ def searchForNeededEpisodes():
         # nothing wanted so early out, ie: avoid whatever abritrarily
         # complex thing a provider cache update entails, for example,
         # reading rss feeds
-        logger.log(u"No episodes needed.", logger.INFO)
         return foundResults.values()
 
     original_thread_name = threading.currentThread().name


### PR DESCRIPTION
We already log here: https://github.com/pymedusa/SickRage/blob/develop/sickbeard/search_queue.py#L251

Fix:
```
INFO     SEARCHQUEUE-DAILY-SEARCH :: [9dc5945] No needed episodes found
INFO     SEARCHQUEUE-DAILY-SEARCH :: [9dc5945] No episodes needed.
```
