### PR TITLE
Also trim cache in manual search providers

### DIFF
--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -233,6 +233,8 @@ class TVCache(object):
             logger.log('Error while searching {0}, skipping: {1!r}'.format(self.provider.name, e), logger.DEBUG)
 
     def update_cache_manual_search(self, manual_data=None):
+        # clear cache
+        self._clearCache()
 
         try:
             cl = []


### PR DESCRIPTION
Its was cleaning only daily/backlog search providers

This is when user has only manual search providers enable as fall back providers
Like provider A and B as daily and backlog search only
and
Provider C, D and E as manual search providers only.

So those manual search providers would never be cleaned

@p0psicles 
