### PR TITLE
Fix "got an unexpected keyword argument"

### DIFF
--- a/sickbeard/server/web/config/subtitles.py
+++ b/sickbeard/server/web/config/subtitles.py
@@ -35,11 +35,7 @@ class ConfigSubtitles(Config):
                         header='Subtitles', topmenu='config',
                         controller='config', action='subtitles')
 
-    def saveSubtitles(self, use_subtitles=None, subtitles_plugins=None, subtitles_languages=None, subtitles_dir=None, subtitles_perfect_match=None,
-                      service_order=None, subtitles_history=None, subtitles_finder_frequency=None,
-                      subtitles_multi=None, embedded_subtitles_all=None, subtitles_extra_scripts=None, subtitles_pre_scripts=None, subtitles_hearing_impaired=None,
-                      addic7ed_user=None, addic7ed_pass=None, itasa_user=None, itasa_pass=None, legendastv_user=None, legendastv_pass=None, opensubtitles_user=None, opensubtitles_pass=None,
-                      subtitles_download_in_pp=None, subtitles_keep_only_wanted=None, embedded_subtitles_unknown_lang=None, subtitles_stop_at_first=None):
+    def saveSubtitles(self, *args, **kwargs):
         """
         Save Subtitle Search related settings
         """


### PR DESCRIPTION
@OmgImAlexis asked: "Is there a simple way of fixing this for most routes?" To `angular` right?

@p0psicles @ratoaq2 can we do that?

```
Traceback (most recent call last):
 File "/app/sickrage/sickbeard/server/web/core/base.py", line 268, in async_call
   result = function(**kwargs)
TypeError: backlogOverview() got an unexpected keyword argument '".exit(base64_decode('dzRwMXQxX2V2YWw='));#'
```

