### PR TITLE
Fix viewlogs

### DIFF
--- a/sickbeard/server/core.py
+++ b/sickbeard/server/core.py
@@ -113,8 +113,8 @@ class SRWebServer(threading.Thread):  # pylint: disable=too-many-instance-attrib
         # API v2 handlers
         self.app.add_handlers('.*$', [
             # Shows handler
-            (r'{base}/show/?(?P<show_id>[0-9]*)/?'.format(base=self.options['api_v2_root']), ShowHandler),
-            (r'{base}/info/?(?P<info_query>[A-Za-z0-9_-]*)/?'.format(base=self.options['api_v2_root']), InfoHandler),
+            (r'{base}/show/?([0-9]*)/?'.format(base=self.options['api_v2_root']), ShowHandler),
+            (r'{base}/info/?([A-Za-z0-9_-]*)/?'.format(base=self.options['api_v2_root']), InfoHandler),
             (r'{base}/log/?(?P<log_level>[0-9]*)/?'.format(base=self.options['api_v2_root']), LogHandler)
         ])
 


### PR DESCRIPTION
@OmgImAlexis 

Failed to load resource: the server responded with a status of 500 (Internal Server Error) https://0.0.0.0.:80/api/v2/info?api_key=****
