### PR TITLE
Several fixes in show updater

### DIFF
--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -101,7 +101,7 @@ class ShowUpdater(object):  # pylint: disable=too-few-public-methods
                     if cur_show.indexerid in updated_shows:
                         # If the cur_show is not 'paused' then add to the showQueueSchedular
                         if not cur_show.paused:
-                            pi_list.append(sickbeard.showQueueScheduler.action.updateShow(cur_show, True))
+                            pi_list.append(sickbeard.showQueueScheduler.action.updateShow(cur_show, force))
                         else:
                             logger.info(u'Show update skipped, show: {show} is paused.', show=cur_show.name)
                 else:
@@ -109,7 +109,7 @@ class ShowUpdater(object):  # pylint: disable=too-few-public-methods
 
                     if cur_show.should_update(update_date=update_date):
                         try:
-                            pi_list.append(sickbeard.showQueueScheduler.action.updateShow(cur_show, True))
+                            pi_list.append(sickbeard.showQueueScheduler.action.updateShow(cur_show, force))
                         except CantUpdateShowException as e:
                             logger.debug(u'Unable to update show: {error}', error=e)
                     else:

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -654,7 +654,7 @@ class QueueItemUpdate(ShowQueueItem):
                    (id=self.show.indexerid, indexer=sickbeard.indexerApi(self.show.indexer).name),
                    logger.DEBUG)
         try:
-            self.show.load_from_indexer(cache=not self.force)
+            self.show.load_from_indexer()
         except sickbeard.indexer_error as e:
             logger.log(u'{id}: Unable to contact {indexer}. Aborting: {error_msg}'.format
                        (id=self.show.indexerid, indexer=sickbeard.indexerApi(self.show.indexer).name,
@@ -690,7 +690,7 @@ class QueueItemUpdate(ShowQueueItem):
 
         # get episode list from TVDB
         try:
-            IndexerEpList = self.show.load_episodes_from_indexer(cache=not self.force)
+            IndexerEpList = self.show.load_episodes_from_indexer()
         except sickbeard.indexer_exception as e:
             logger.log(u'{id}: Unable to get info from {indexer}. The show info will not be refreshed. '
                        u'Error: {error_msg}'.format

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -709,18 +709,15 @@ class TVShow(TVObject):
 
         return scanned_eps
 
-    def load_episodes_from_indexer(self, cache=True):
+    def load_episodes_from_indexer(self):
         """Load episodes from indexer.
 
-        :param cache:
-        :type cache: bool
         :return:
         :rtype: dict(int -> dict(int -> bool))
         """
         indexer_api_params = sickbeard.indexerApi(self.indexer).api_params.copy()
 
-        if not cache:
-            indexer_api_params['cache'] = False
+        indexer_api_params['cache'] = False
 
         if self.lang:
             indexer_api_params['language'] = self.lang
@@ -1017,11 +1014,9 @@ class TVShow(TVObject):
         self.reset_dirty()
         return True
 
-    def load_from_indexer(self, cache=True, tvapi=None):
+    def load_from_indexer(self, tvapi=None):
         """Load show from indexer.
 
-        :param cache:
-        :type cache: bool
         :param tvapi:
         """
         if self.indexer == INDEXER_TVRAGE:
@@ -1037,8 +1032,7 @@ class TVShow(TVObject):
         else:
             indexer_api_params = sickbeard.indexerApi(self.indexer).api_params.copy()
 
-            if not cache:
-                indexer_api_params['cache'] = False
+            indexer_api_params['cache'] = False
 
             if self.lang:
                 indexer_api_params['language'] = self.lang
@@ -1939,15 +1933,13 @@ class TVEpisode(TVObject):
             self.reset_dirty()
             return True
 
-    def load_from_indexer(self, season=None, episode=None, cache=True, tvapi=None, cached_season=None):
+    def load_from_indexer(self, season=None, episode=None, tvapi=None, cached_season=None):
         """Load episode information from indexer.
 
         :param season:
         :type season: int
         :param episode:
         :type episode: int
-        :param cache:
-        :type cache: bool
         :param tvapi:
         :param cached_season:
         :return:
@@ -1969,8 +1961,7 @@ class TVEpisode(TVObject):
                 else:
                     indexer_api_params = sickbeard.indexerApi(self.indexer).api_params.copy()
 
-                    if not cache:
-                        indexer_api_params['cache'] = False
+                    indexer_api_params['cache'] = False
 
                     if indexer_lang:
                         indexer_api_params['language'] = indexer_lang

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -697,7 +697,6 @@ class TVShow(TVObject):
                     cur_ep.delete_episode()
 
                 cur_ep.load_from_db(cur_season, cur_episode)
-                cur_ep.load_from_indexer(tvapi=t, cached_season=cached_seasons[cur_season])
                 scanned_eps[cur_season][cur_episode] = True
             except EpisodeDeletedException:
                 logger.log(u'{id}: Tried loading {show} {ep} from the DB that should have been deleted, '
@@ -767,7 +766,6 @@ class TVShow(TVObject):
                         continue
 
                 with ep.lock:
-                    ep.load_from_indexer(season, episode, tvapi=t)
                     sql_l.append(ep.get_sql())
 
                 scanned_eps[season][episode] = True

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1666,6 +1666,7 @@ class TVEpisode(TVObject):
         self.scene_absolute_number = 0
         self.related_episodes = []
         self.wanted_quality = []
+        self.loaded = False
         if show:
             self._specify_episode(self.season, self.episode)
             self.check_for_meta_files()
@@ -1852,6 +1853,8 @@ class TVEpisode(TVObject):
         :return:
         :rtype: bool
         """
+        if self.loaded:
+            return True
         main_db_con = db.DBConnection()
         sql_results = main_db_con.select(
             b'SELECT '
@@ -1931,6 +1934,7 @@ class TVEpisode(TVObject):
                 self.release_group = sql_results[0][b'release_group']
 
             self.reset_dirty()
+            self.loaded = True
             return True
 
     def load_from_indexer(self, season=None, episode=None, tvapi=None, cached_season=None):
@@ -2435,6 +2439,7 @@ class TVEpisode(TVObject):
         # use a custom update/insert method to get the data into the DB
         main_db_con = db.DBConnection()
         main_db_con.upsert('tv_episodes', new_value_dict, control_value_dict)
+        self.loaded = False
 
     def full_path(self):
         """Return episode full path.


### PR DESCRIPTION
A lof ot duplicate line for every show

Flow:
show_queye.py calls:

```python
        # get episode list from DB
        logger.log(u"Loading all episodes from the database", logger.DEBUG)
        DBEpList = self.show.load_episodes_from_db()

        # get episode list from TVDB
        logger.log(u"Loading all episodes from " + sickbeard.indexerApi(self.show.indexer).name + "", logger.DEBUG)
        try:
            IndexerEpList = self.show.load_episodes_from_indexer(cache=not self.force)
```

In `load_episodes_from_db` we were also calling `load_from_indexer` that is called from `load_episodes_from_indexer` later in show_queue. So we were calling twice `load_from_indexer`

```
2016-08-26 03:04:15 INFO     SHOWQUEUE-FORCE-UPDATE :: [555b0cb] This episode The Blacklist - S04E04 has no name on theTVDB. Setting to an empty string
2016-08-26 03:04:15 INFO     SHOWQUEUE-FORCE-UPDATE :: [555b0cb] This episode The Blacklist - S04E03 has no name on theTVDB. Setting to an empty string
2016-08-26 03:04:15 INFO     SHOWQUEUE-FORCE-UPDATE :: [555b0cb] This episode The Blacklist - S04E02 has no name on theTVDB. Setting to an empty string

2016-08-26 03:04:13 INFO     SHOWQUEUE-FORCE-UPDATE :: [555b0cb] This episode The Blacklist - S04E04 has no name on theTVDB. Setting to an empty string
2016-08-26 03:04:13 INFO     SHOWQUEUE-FORCE-UPDATE :: [555b0cb] This episode The Blacklist - S04E03 has no name on theTVDB. Setting to an empty string
2016-08-26 03:04:13 INFO     SHOWQUEUE-FORCE-UPDATE :: [555b0cb] This episode The Blacklist - S04E02 has no name on theTVDB. Setting to an empty string
```