### PR TITLE
Fixes calling show refresh before finishes update thread

### DIFF
--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -739,8 +739,9 @@ class QueueItemUpdate(ShowQueueItem):
 
         logger.log(u'{id}: Finished update of {show}'.format
                    (id=self.show.indexerid, show=self.show.name), logger.DEBUG)
-        sickbeard.showQueueScheduler.action.refreshShow(self.show, self.force)
+
         self.finish()
+        sickbeard.showQueueScheduler.action.refreshShow(self.show, self.force)
 
 
 class QueueItemForceUpdate(QueueItemUpdate):


### PR DESCRIPTION
@pymedusa/developers to test this must wait 3am update to start. Can't test using force update!
or change update start time and restart

Fixes the tons of logs in the 3am update:
 `A refresh was attempted but there is already an update queued or in progress. Since updates do a refresh at the end anyway I'm skipping this request.`

Update thread must be finished before calling refresh show

```python
    def refreshShow(self, show, force=False):

        if self.isBeingRefreshed(show) and not force:
            raise CantRefreshShowException("This show is already being refreshed, not refreshing again.")

        if (self.isBeingUpdated(show) or self.isInUpdateQueue(show)) and not force:
            logger.log(
                u"A refresh was attempted but there is already an update queued or in progress. Since updates do a refresh at the end anyway I'm skipping this request.",
                logger.DEBUG)
return
```