### PR TITLE
Delete non-proper snatch after snatch proper

### DIFF
--- a/gui/slick/views/config_search.mako
+++ b/gui/slick/views/config_search.mako
@@ -59,6 +59,17 @@
                                     </label>
                                 </div>
                             </div><!-- check propers -->
+                            <div id="content_download_propers">
+                                <div class="field-pair">
+                                    <label for="delete_non_propers">
+                                        <span class="component-title">Delete non-propers</span>
+                                        <span class="component-desc">
+                                            <input type="checkbox" name="delete_non_propers" id="delete_non_propers" class="enabler" ${'checked="checked"' if sickbeard.DELETE_NON_PROPERS else ''}/>
+                                            <p>Delete snatched non-proper releases from post-processor folder when snatch a PROPER</p>
+                                        </span>
+                                    </label>
+                                </div>
+                            </div><!-- delete non propers -->
                             <div class="field-pair">
                                 <label>
                                     <span class="component-title">Backlog search day(s)</span>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -254,6 +254,7 @@ TORRENT_METHOD = None
 TORRENT_DIR = None
 DOWNLOAD_PROPERS = False
 CHECK_PROPERS_INTERVAL = None
+DELETE_NON_PROPERS = False
 ALLOW_HIGH_PRIORITY = False
 SAB_FORCED = False
 RANDOMIZE_PROVIDERS = False
@@ -623,7 +624,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
     with INIT_LOCK:
         # pylint: disable=global-statement
         global BRANCH, GIT_RESET, GIT_RESET_BRANCHES, GIT_REMOTE, GIT_REMOTE_URL, CUR_COMMIT_HASH, CUR_COMMIT_BRANCH, ACTUAL_LOG_DIR, LOG_DIR, LOG_NR, LOG_SIZE, WEB_PORT, WEB_LOG, ENCRYPTION_VERSION, ENCRYPTION_SECRET, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, WEB_COOKIE_SECRET, WEB_USE_GZIP, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
-            HANDLE_REVERSE_PROXY, USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, RANDOMIZE_PROVIDERS, CHECK_PROPERS_INTERVAL, ALLOW_HIGH_PRIORITY, SAB_FORCED, TORRENT_METHOD, NOTIFY_ON_LOGIN, SUBLIMINAL_LOG, PRIVACY_LEVEL, \
+            HANDLE_REVERSE_PROXY, USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, DELETE_NON_PROPERS, RANDOMIZE_PROVIDERS, CHECK_PROPERS_INTERVAL, ALLOW_HIGH_PRIORITY, SAB_FORCED, TORRENT_METHOD, NOTIFY_ON_LOGIN, SUBLIMINAL_LOG, PRIVACY_LEVEL, \
             SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_CATEGORY_BACKLOG, SAB_CATEGORY_ANIME, SAB_CATEGORY_ANIME_BACKLOG, SAB_HOST, \
             NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_CATEGORY_BACKLOG, NZBGET_CATEGORY_ANIME, NZBGET_CATEGORY_ANIME_BACKLOG, NZBGET_PRIORITY, NZBGET_HOST, NZBGET_USE_HTTPS, backlogSearchScheduler, \
             TORRENT_USERNAME, TORRENT_PASSWORD, TORRENT_HOST, TORRENT_PATH, TORRENT_SEED_TIME, TORRENT_PAUSED, TORRENT_HIGH_BANDWIDTH, TORRENT_LABEL, TORRENT_LABEL_ANIME, TORRENT_VERIFY_CERT, TORRENT_RPCURL, TORRENT_AUTH_TYPE, \
@@ -916,6 +917,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             TORRENT_METHOD = 'blackhole'
 
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
+        DELETE_NON_PROPERS = bool(check_setting_int(CFG, 'General', 'delete_non_propers', 0))
         CHECK_PROPERS_INTERVAL = check_setting_str(CFG, 'General', 'check_propers_interval', '')
         if CHECK_PROPERS_INTERVAL not in ('15m', '45m', '90m', '4h', 'daily'):
             CHECK_PROPERS_INTERVAL = 'daily'
@@ -1673,6 +1675,7 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
     new_config['General']['update_frequency'] = int(UPDATE_FREQUENCY)
     new_config['General']['showupdate_hour'] = int(SHOWUPDATE_HOUR)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
+    new_config['General']['delete_non_propers'] = int(DELETE_NON_PROPERS)
     new_config['General']['randomize_providers'] = int(RANDOMIZE_PROVIDERS)
     new_config['General']['check_propers_interval'] = CHECK_PROPERS_INTERVAL
     new_config['General']['allow_high_priority'] = int(ALLOW_HIGH_PRIORITY)

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -92,6 +92,7 @@ def _downloadResult(result):
 
     return newResult
 
+
 def _delete_non_propers(result):
     """Delete non-propers from PP folder after snatch a PROPER.
 
@@ -124,6 +125,7 @@ def _delete_non_propers(result):
                                 break
                 except OSError as e:
                     logger.log(u'Unable to delete {resource}. Error: {error}', resource=resource, error=e)
+
 
 def snatchEpisode(result):  # pylint: disable=too-many-branches, too-many-statements
     """

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -26,6 +26,7 @@ import datetime
 import traceback
 import requests
 import sickbeard
+import shutil
 
 from sickbeard.common import SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, Quality, SEASON_RESULT, MULTI_EP_RESULT
 from sickbeard import logger, db, show_name_helpers, helpers
@@ -43,7 +44,7 @@ from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import AuthException, ex
 from sickrage.helper.common import episode_num
 from sickrage.providers.GenericProvider import GenericProvider
-from sickrage.helper.common import enabled_providers
+from sickrage.helper.common import enabled_providers, media_extensions
 
 from socket import timeout as SocketTimeout
 
@@ -158,6 +159,31 @@ def snatchEpisode(result):  # pylint: disable=too-many-branches, too-many-statem
         failed_history.logSnatch(result)
 
     ui.notifications.message('Episode snatched', result.name)
+
+    if is_proper:
+        main_db_con = db.DBConnection()
+        for curEpObj in result.episodes:
+            old_snatches = main_db_con.select("SELECT resource FROM history WHERE action LIKE '%2' AND showid=? AND season=? AND episode=?",
+                                              [curEpObj.show.indexerid, curEpObj.season, curEpObj.episode])
+            for old_snatch in old_snatches:
+                resource = str(old_snatch['resource'])
+                if resource:
+                    logger.log('Found a non-proper snatch in post-processor folder: {0}'.format(resource))
+                    resource = ek(os.path.join, sickbeard.TV_DOWNLOAD_DIR, resource)
+                    try:
+                        if ek(os.path.isdir, resource):
+                            shutil.rmtree(resource)
+                            logger.log('Deleted the non-proper snatch in post-processor folder: {0}'.format(resource))
+                        else:
+                            for media_extension in media_extensions:
+                                # Resource column doesnt store extension
+                                resource_file = resource + '.' + media_extension
+                                if ek(os.path.isfile, resource_file):
+                                    ek(os.remove, resource_file)
+                                    logger.log('Deleted the non-proper snatch in post-processor folder: {0}'.format(resource_file))
+                                    break
+                    except OSError as e:
+                        logger.log(u'Unable to delete {resource}. Error: {error}', resource=resource, error=e)
 
     history.logSnatch(result)
 

--- a/sickbeard/server/web/config/search.py
+++ b/sickbeard/server/web/config/search.py
@@ -43,7 +43,7 @@ class ConfigSearch(Config):
                    nzbget_category_anime_backlog=None, nzbget_priority=None, nzbget_host=None,
                    nzbget_use_https=None, backlog_days=None, backlog_frequency=None, dailysearch_frequency=None,
                    nzb_method=None, torrent_method=None, usenet_retention=None, download_propers=None,
-                   check_propers_interval=None, allow_high_priority=None, sab_forced=None, delete_non_propers = None,
+                   check_propers_interval=None, allow_high_priority=None, sab_forced=None, delete_non_propers=None,
                    randomize_providers=None, use_failed_downloads=None, delete_failed=None,
                    torrent_dir=None, torrent_username=None, torrent_password=None, torrent_host=None,
                    torrent_label=None, torrent_label_anime=None, torrent_path=None, torrent_verify_cert=None,

--- a/sickbeard/server/web/config/search.py
+++ b/sickbeard/server/web/config/search.py
@@ -43,7 +43,7 @@ class ConfigSearch(Config):
                    nzbget_category_anime_backlog=None, nzbget_priority=None, nzbget_host=None,
                    nzbget_use_https=None, backlog_days=None, backlog_frequency=None, dailysearch_frequency=None,
                    nzb_method=None, torrent_method=None, usenet_retention=None, download_propers=None,
-                   check_propers_interval=None, allow_high_priority=None, sab_forced=None,
+                   check_propers_interval=None, allow_high_priority=None, sab_forced=None, delete_non_propers = None,
                    randomize_providers=None, use_failed_downloads=None, delete_failed=None,
                    torrent_dir=None, torrent_username=None, torrent_password=None, torrent_host=None,
                    torrent_label=None, torrent_label_anime=None, torrent_path=None, torrent_verify_cert=None,
@@ -89,6 +89,7 @@ class ConfigSearch(Config):
         sickbeard.RANDOMIZE_PROVIDERS = config.checkbox_to_value(randomize_providers)
 
         config.change_DOWNLOAD_PROPERS(download_propers)
+        sickbeard.DELETE_NON_PROPERS = config.checkbox_to_value(delete_non_propers)
 
         sickbeard.CHECK_PROPERS_INTERVAL = check_propers_interval
 


### PR DESCRIPTION
@duramato what do you think?

I manually deleted file as there is no point seeding something that is non-proper (when proper available)

```
2016-08-31 09:16:31 DEBUG    FINDPROPERS :: [888ac0a] Found proper tags for Major.Crimes.S05E10.PROPER.720p.HDTV.x264-KILLERS[ettv]. Snatching as PROPER
2016-08-31 09:16:31 INFO     FINDPROPERS :: [888ac0a] Found a non-proper snatch in post-processor folder: Major.Crimes.S05E10.720p.HDTV.x264-FLEET
2016-08-31 09:16:31 INFO     FINDPROPERS :: [888ac0a] Deleted the non-proper snatch in post-processor folder: /media/SAMSUNG/media/downloaded/series/Major.Crimes.S05E10.720p.HDTV.x264-FLEET
```

any one see any improvement to this code?