### PR TITLE
Show proper tags using INFO icon

### DIFF
--- a/gui/slick/views/history.mako
+++ b/gui/slick/views/history.mako
@@ -71,8 +71,8 @@
                     <img width="16" height="11" style="vertical-align:middle;" src="images/subtitles/flags/${hItem.resource}.png" onError="this.onerror=null;this.src='images/flags/unknown.png';">
                 % endif
                     <span style="cursor: help; vertical-align:middle;" title="${ek(os.path.basename, hItem.resource)}">${statusStrings[composite.status]}</span>
-		    		% if hItem.proper_tags:
-                    <img src="images/info32.png" width="16" height="16" style="vertical-align:middle;" title="${hItem.proper_tags.replace('|', ', ')}"/>
+                    % if hItem.proper_tags:
+                        <img src="images/info32.png" width="16" height="16" style="vertical-align:middle;" title="${hItem.proper_tags.replace('|', ', ')}"/>
                     % endif
                 </td>
                 <td align="center">
@@ -142,7 +142,7 @@
                             % if provider is not None:
                                 <img src="images/providers/${provider.image_name()}" width="16" height="16" style="vertical-align:middle;" alt="${provider.name}" style="cursor: help;" title="${provider.name}: ${ek(os.path.basename, cur_action.resource)}"/>
                                 % if cur_action.proper_tags:
-                                    <img src="images/info32.png" width="16" height="16" style="vertical-align:middle;" title="${cur_action.proper_tags.replace('|', ', ')}"/> 
+                                    <img src="images/info32.png" width="16" height="16" style="vertical-align:middle;" title="${cur_action.proper_tags.replace('|', ', ')}"/>
                                 % endif
                             % else:
                                 <img src="images/providers/missing.png" width="16" height="16" style="vertical-align:middle;" alt="missing provider" title="missing provider"/>

--- a/gui/slick/views/history.mako
+++ b/gui/slick/views/history.mako
@@ -65,12 +65,15 @@
                     <% isoDate = datetime.strptime(str(hItem.date), History.date_format).isoformat('T') %>
                     <time datetime="${isoDate}" class="date">${airDate}</time>
                 </td>
-                <td class="tvShow"><a href="home/displayShow?show=${hItem.show_id}#S${hItem.season}E${hItem.episode}">${hItem.show_name} - ${"S%02i" % int(hItem.season)}${"E%02i" % int(hItem.episode)} ${'<span class="quality Proper">Proper</span>' if hItem.proper_tags else ''}</a></td>
+                <td class="tvShow"><a href="home/displayShow?show=${hItem.show_id}#S${hItem.season}E${hItem.episode}">${hItem.show_name} - ${"S%02i" % int(hItem.season)}${"E%02i" % int(hItem.episode)} ${'<span class="quality Proper">Proper</span>' if hItem.proper_tags else ''} </a></td>
                 <td align="center" ${'class="subtitles_column"' if composite.status == SUBTITLED else ''}>
                 % if composite.status == SUBTITLED:
                     <img width="16" height="11" style="vertical-align:middle;" src="images/subtitles/flags/${hItem.resource}.png" onError="this.onerror=null;this.src='images/flags/unknown.png';">
                 % endif
                     <span style="cursor: help; vertical-align:middle;" title="${ek(os.path.basename, hItem.resource)}">${statusStrings[composite.status]}</span>
+		    		% if hItem.proper_tags:
+                    <img src="images/info32.png" width="16" height="16" style="vertical-align:middle;" title="${hItem.proper_tags.replace('|', ', ')}"/>
+                    % endif
                 </td>
                 <td align="center">
                 % if composite.status in [DOWNLOADED, ARCHIVED]:
@@ -138,6 +141,9 @@
                             <% provider = providers.getProviderClass(GenericProvider.make_id(cur_action.provider)) %>
                             % if provider is not None:
                                 <img src="images/providers/${provider.image_name()}" width="16" height="16" style="vertical-align:middle;" alt="${provider.name}" style="cursor: help;" title="${provider.name}: ${ek(os.path.basename, cur_action.resource)}"/>
+                                % if cur_action.proper_tags:
+                                    <img src="images/info32.png" width="16" height="16" style="vertical-align:middle;" title="${cur_action.proper_tags.replace('|', ', ')}"/> 
+                                % endif
                             % else:
                                 <img src="images/providers/missing.png" width="16" height="16" style="vertical-align:middle;" alt="missing provider" title="missing provider"/>
                             % endif


### PR DESCRIPTION
@duramato Adds proper tags to history as you always wanted lol

Each snatch_proper has its own proper tags
So if user has a snatch with `PROPER` proper tag and  another `REAL PROPER` proper tag,  it will show two icons because its two snatches

![image](https://cloud.githubusercontent.com/assets/2620870/18413455/eb28ceda-777e-11e6-8e7e-9f45d3b88e2c.png)

![image](https://cloud.githubusercontent.com/assets/2620870/18413468/287bd0ac-777f-11e6-983f-3902aafc1b6f.png)
