### PR TITLE
Only snatch proper if we actually have a download, compare codec befo…

### DIFF
--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -340,7 +340,8 @@ class ParseResult(object):
             self.quality == other.quality,
             self.version == other.version,
             self.proper_tags == other.proper_tags,
-            self.is_episode_special == other.is_episode_special
+            self.is_episode_special == other.is_episode_special,
+            self.video_codec == other.video_codec
         ])
 
     def __str__(self):
@@ -381,6 +382,15 @@ class ParseResult(object):
         :rtype: bool
         """
         return self.guess.get('episode_details') == 'Special'
+
+    @property
+    def video_codec(self):
+        """Return video codec.
+
+        :return:
+        :rtype: str
+        """
+        return self.guess.get('video_codec')
 
 
 class NameParserCache(object):

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -318,7 +318,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                 b'AND episode = ? '
                 b'AND quality = ? '
                 b'AND date >= ? '
-                b"AND (action LIKE '%02' OR action LIKE '%04')",
+                b"AND (action LIKE '%2' OR action LIKE '%4')",
                 [cur_proper.indexerid, cur_proper.season, cur_proper.episode, cur_proper.quality,
                  history_limit.strftime(History.date_format)])
 

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -318,7 +318,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                 b'AND episode = ? '
                 b'AND quality = ? '
                 b'AND date >= ? '
-                b"AND (action LIKE '%2' OR action LIKE '%4')",
+                b"AND (action LIKE '%02' OR action LIKE '%04')",
                 [cur_proper.indexerid, cur_proper.season, cur_proper.episode, cur_proper.quality,
                  history_limit.strftime(History.date_format)])
 

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -240,7 +240,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
             # check if we have the episode as DOWNLOADED
             main_db_con = db.DBConnection()
             sql_results = main_db_con.select(b"SELECT status, release_name FROM tv_episodes WHERE "
-                                             b"status LIKE '%04' AND showid = ? AND season = ? AND episode = ?",
+                                             b"showid = ? AND season = ? AND episode = ? AND status LIKE '%04'",
                                              [best_result.indexerid, best_result.season, best_result.episode])
             if not sql_results:
                 logger.log('Ignoring proper because we dont have this show and/or episode in library: {name}'.format

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -248,18 +248,18 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                 self.processed_propers.append(cur_proper.name)
                 continue
 
-            # only keep the proper if we have already downloaded an epsiode with the same quality
+            # only keep the proper if we have already downloaded an episode with the same quality
             _, old_quality = Quality.splitCompositeStatus(int(sql_results[0][b'status']))
             if old_quality != best_result.quality:
                 logger.log('Ignoring proper because quality is different: {name}'.format(name=best_result.name))
                 self.processed_propers.append(cur_proper.name)
                 continue
 
-            # only keep the proper if we have already downloaded an epsiode with the same codec
+            # only keep the proper if we have already downloaded an episode with the same codec
             release_name = sql_results[0][b'release_name']
             if release_name:
                 current_codec = NameParser()._parse_string(release_name).video_codec
-                # Ignore new proper when different codec from current proper
+                # Ignore proper if codec differs from downloaded release codec
                 if all(current_codec, parse_result.video_codec, parse_result.video_codec != current_codec):
                     logger.log('Ignoring proper because codec is different: {name}'.format(name=best_result.name))
                     self.processed_propers.append(cur_proper.name)

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -318,7 +318,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                 b'AND episode = ? '
                 b'AND quality = ? '
                 b'AND date >= ? '
-                b"AND action LIKE '%04'",
+                b"AND (action LIKE '%02' OR action LIKE '%04')",
                 [cur_proper.indexerid, cur_proper.season, cur_proper.episode, cur_proper.quality,
                  history_limit.strftime(History.date_format)])
 

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -35,7 +35,7 @@ from sickrage.helper.common import enabled_providers
 from sickrage.helper.exceptions import AuthException, ex
 from sickrage.show.History import History
 from . import db, helpers, logger
-from .common import DOWNLOADED, Quality, SNATCHED, cpu_presets
+from .common import Quality, cpu_presets
 from .name_parser.parser import InvalidNameException, InvalidShowException, NameParser
 from .search import pickBestResult, snatchEpisode
 
@@ -237,23 +237,33 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                     self.processed_propers.append(cur_proper.name)
                     continue
 
-            # check if we actually want this proper (if it's the right quality)
+            # check if we have the episode as DOWNLOADED
             main_db_con = db.DBConnection()
-            sql_results = main_db_con.select(b'SELECT status FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?',
+            sql_results = main_db_con.select(b"SELECT status, release_name FROM tv_episodes WHERE "
+                                             b"status LIKE '%04' AND showid = ? AND season = ? AND episode = ?",
                                              [best_result.indexerid, best_result.season, best_result.episode])
             if not sql_results:
-                logger.log('Ignoring proper with incorrect quality: {name}'.format
+                logger.log('Ignoring proper because we dont have this show and/or episode in library: {name}'.format
                            (name=best_result.name))
                 self.processed_propers.append(cur_proper.name)
                 continue
 
-            # only keep the proper if we have already retrieved the same quality ep (don't get better/worse ones)
-            old_status, old_quality = Quality.splitCompositeStatus(int(sql_results[0][b'status']))
-            if old_status not in (DOWNLOADED, SNATCHED) or old_quality != best_result.quality:
-                logger.log('Ignoring proper because quality is different or episode is already archived: {name}'.format
-                           (name=best_result.name))
+            # only keep the proper if we have already downloaded an epsiode with the same quality
+            _, old_quality = Quality.splitCompositeStatus(int(sql_results[0][b'status']))
+            if old_quality != best_result.quality:
+                logger.log('Ignoring proper because quality is different: {name}'.format(name=best_result.name))
                 self.processed_propers.append(cur_proper.name)
                 continue
+
+            # only keep the proper if we have already downloaded an epsiode with the same codec
+            release_name = sql_results[0][b'release_name']
+            if release_name:
+                current_codec = NameParser()._parse_string(release_name).video_codec
+                # Ignore new proper when different codec from current proper
+                if all(current_codec, parse_result.video_codec, parse_result.video_codec != current_codec):
+                    logger.log('Ignoring proper because codec is different: {name}'.format(name=best_result.name))
+                    self.processed_propers.append(cur_proper.name)
+                    continue
 
             # check if we actually want this proper (if it's the right release group and a higher version)
             if best_result.show.is_anime:

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -259,7 +259,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
             if release_name:
                 current_codec = NameParser()._parse_string(release_name).video_codec
                 # Ignore proper if codec differs from downloaded release codec
-                if all(current_codec, parse_result.video_codec, parse_result.video_codec != current_codec):
+                if all([current_codec, parse_result.video_codec, parse_result.video_codec != current_codec]):
                     logger.log('Ignoring proper because codec is different: {name}'.format(name=best_result.name))
                     self.processed_propers.append(cur_proper.name)
                     continue

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -245,7 +245,6 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
             if not sql_results:
                 logger.log('Ignoring proper because we dont have this show and/or episode in library: {name}'.format
                            (name=best_result.name))
-                self.processed_propers.append(cur_proper.name)
                 continue
 
             # only keep the proper if we have already downloaded an episode with the same quality

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -95,15 +95,14 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
         # Get the recently aired (last 2 days) shows from db
         search_date = datetime.datetime.today() - datetime.timedelta(days=2)
         main_db_con = db.DBConnection()
-        search_qualities = list(set(Quality.DOWNLOADED + Quality.SNATCHED + Quality.SNATCHED_BEST))
-        search_q_params = ','.join('?' for _ in search_qualities)
+        search_q_params = ','.join('?' for _ in Quality.DOWNLOADED)
         recently_aired = main_db_con.select(
             b'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate'
             b' FROM tv_episodes AS e'
             b' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)'
             b' WHERE e.airdate >= ?'
             b' AND e.status IN ({0})'.format(search_q_params),
-            [search_date.toordinal()] + search_qualities
+            [search_date.toordinal()] + Quality.DOWNLOADED
         )
 
         if not recently_aired:
@@ -319,7 +318,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                 b'AND episode = ? '
                 b'AND quality = ? '
                 b'AND date >= ? '
-                b"AND (action LIKE '%2' OR action LIKE '%4')",
+                b"AND action LIKE '%04'",
                 [cur_proper.indexerid, cur_proper.season, cur_proper.episode, cur_proper.quality,
                  history_limit.strftime(History.date_format)])
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

…re snatching

This fixes the situations where we have a PROPER downloaded before a non-PROPER and it keeps trying to PP until we manually delete the NON-PROPER.

Current flow:
Snatch (non-proper/proper) -> Found proper? -> Finished download? -> Download proper

Old flow:
Snatch (non-proper/proper) -> Found proper? -> Download proper