### PR TITLE
Anime with numbers in title and no season information causes guessit exception

### DIFF
--- a/sickbeard/name_parser/guessit_parser.py
+++ b/sickbeard/name_parser/guessit_parser.py
@@ -130,7 +130,7 @@ def get_expected_titles(show_list):
                 expected_titles.append(series)
 
             # (?<![^/\\]) means -> it matches nothing but path separators and dot (negative lookbehind)
-            fmt = r're:\b{name}\b' if show.is_anime else r're:(?<![^/\\\.]){name}\b'
+            fmt = r're:(?<=[\W_]){name}(?=[\W_]|$)' if show.is_anime else r're:(?<![^/\\\.]){name}(?=[\W_]|$)'
             expected_titles.append(fmt.format(name=prepare(series)))
 
     return normalize(expected_titles)

--- a/sickbeard/name_parser/rules/rules.py
+++ b/sickbeard/name_parser/rules/rules.py
@@ -1001,6 +1001,9 @@ class AnimeAbsoluteEpisodeNumbers(Rule):
         for filepart in marker_sorted(fileparts, matches):
             season = matches.range(filepart.start, filepart.end, index=0,
                                    predicate=lambda match: match.name == 'season' and match.raw.isdigit())
+            if not season:
+                continue
+
             episode = matches.next(season, index=0,
                                    predicate=lambda match: (match.name == 'episode' and
                                                             match.end <= filepart.end and

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -3034,3 +3034,15 @@
   season: 1
   episode: 2
   type: episode
+
+# Regression test:
+# Anime with numbers in title inside a folder (folder without season info)
+# Anime with numbers and using _ as separators
+? 'C:\folder\[GROUP]_An_Anime_Show_100_-_10_[1080p]_mkv_-_`[GROUP]_An_Anime_Show_100_-_10_[1080p]_vol03+04_par2`'
+: title: An Anime Show 100
+  absolute_episode: 10
+  episode: 10
+  screen_size: 1080p
+  container: MKV
+  release_group: GROUP
+  type: episode

--- a/tests/report_guessit.py
+++ b/tests/report_guessit.py
@@ -9,16 +9,31 @@ sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 from guessit import __version__ as guessit_version
 from rebulk.__version__ import __version__ as rebulk_version
+import sickbeard
 from sickbeard.name_parser.guessit_parser import guessit
 
 
+class MockTvShow(object):
+    def __init__(self, name):
+        self.is_anime = name.startswith('a:')
+        self.name = name[2:] if self.is_anime else name
+        self.exceptions = []
+
+
 def main(argv):
-    if len(argv) != 2:
-        print('Usage: python {} <input>'.format(__file__))
+    if len(argv) < 2:
+        print('Usage: python {} <input> <expected show names>'.format(__file__))
         sys.exit(1)
 
+    show_list = argv[2:]
+    for arg in show_list:
+        sickbeard.showList.append(MockTvShow(arg))
+
     actual = guessit(argv[1])
-    results = ['# guessit: {}  rebulk: {}'.format(guessit_version, rebulk_version), '? {}'.format(argv[1])]
+    results = ['# guessit: {}  rebulk: {}'.format(guessit_version, rebulk_version)]
+    if show_list:
+        results.append('# show list: {}'.format(argv[2:]))
+    results.append('? {}'.format(argv[1]))
     for key, value in actual.items():
         fmt = ': {key}: {value}' if len(results) <= 2 else '  {key}: {value}'
         results.append(fmt.format(key=key, value=value))

--- a/tests/test_guessit.py
+++ b/tests/test_guessit.py
@@ -8,7 +8,7 @@ import os
 import guessit
 import pytest
 import sickbeard.name_parser.guessit_parser as sut
-from six import text_type
+from six import binary_type, text_type
 import yaml
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -36,6 +36,7 @@ def show_list(create_tvshow):
         create_tvshow(indexerid=15, name='The Show (UK)'),
         create_tvshow(indexerid=16, name='3 Show på (abc2)'),  # unicode characters, numbers and parenthesis
         create_tvshow(indexerid=16, name="Show '70s Name"),
+        create_tvshow(indexerid=17, name='An Anime Show 100', anime=1),
     ]
 
 
@@ -58,6 +59,9 @@ def _parameters(files, single_test=None):
 
         for release_names, expected in data.items():
             expected = {k: v for k, v in expected.items()}
+            for k, v in expected.items():
+                if isinstance(v, binary_type):
+                    expected[k] = text_type(v)
 
             if not isinstance(release_names, tuple):
                 release_names = (release_names,)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)
- [x] #1093 Anime with numbers in title and no season information causes guessit exception.
- [x] Improved guessit report.
- [x] Fixed expected_titles regex to consider _ as word boundary