### PR TITLE
Fix not able to get new pin when token expired

### DIFF
--- a/gui/slick/js/config/notifications.js
+++ b/gui/slick/js/config/notifications.js
@@ -403,7 +403,7 @@ MEDUSA.config.notifications = function() { // eslint-disable-line max-lines
                 $('#testTrakt-result').html(data);
                 $('#authTrakt').addClass('hide');
                 $('#trakt_pin').prop('disabled', true);
-                $('#trakt_pin').prop('value','');
+                $('#trakt_pin').val('');
                 $('#TraktGetPin').removeClass('hide');
             });
         }

--- a/gui/slick/js/config/notifications.js
+++ b/gui/slick/js/config/notifications.js
@@ -380,7 +380,7 @@ MEDUSA.config.notifications = function() { // eslint-disable-line max-lines
 
     $('#TraktGetPin').on('click', function () {
         window.open($('#trakt_pin_url').val(), 'popUp', 'toolbar=no, scrollbars=no, resizable=no, top=200, left=200, width=650, height=550');
-        $('#trakt_pin').removeClass('hide');
+        $('#trakt_pin').prop('disabled', false);
     });
 
     $('#trakt_pin').on('keyup change', function() {
@@ -402,8 +402,9 @@ MEDUSA.config.notifications = function() { // eslint-disable-line max-lines
             }).done(function (data) {
                 $('#testTrakt-result').html(data);
                 $('#authTrakt').addClass('hide');
-                $('#trakt_pin').addClass('hide');
-                $('#TraktGetPin').addClass('hide');
+                $('#trakt_pin').prop('disabled', true);
+                $('#trakt_pin').prop('value','');
+                $('#TraktGetPin').removeClass('hide');
             });
         }
     });

--- a/gui/slick/views/config_notifications.mako
+++ b/gui/slick/views/config_notifications.mako
@@ -1536,17 +1536,17 @@
                                     </p>
                                 </div>
                                 <input type="hidden" id="trakt_pin_url" value="${sickbeard.TRAKT_PIN_URL}">
-                                <input type="button" class="btn ${'hide' if sickbeard.TRAKT_ACCESS_TOKEN else ''}" value="Get Trakt PIN" id="TraktGetPin" />
                                 <div class="field-pair">
                                     <label for="trakt_pin">
                                         <span class="component-title">Trakt PIN</span>
-                                        <input type="text" name="trakt_pin" id="trakt_pin" value="" class="form-control input-sm input250"/>
+                                        <input type="text" name="trakt_pin" id="trakt_pin" value="" class="form-control input-sm input250" ${'disabled' if sickbeard.TRAKT_ACCESS_TOKEN else ''} />
+                                        <input type="button" class="btn" value="Get ${'New' if sickbeard.TRAKT_ACCESS_TOKEN else ''} Trakt PIN" id="TraktGetPin" />
+                                        <input type="button" class="btn hide" value="Authorize Medusa" id="authTrakt" />
                                     </label>
                                     <p>
                                         <span class="component-desc">PIN code to authorize Medusa to access Trakt on your behalf.</span>
                                     </p>
                                 </div>
-                                <input type="button" class="btn hide" value="Authorize Medusa" id="authTrakt" />
                                 <div class="field-pair">
                                     <label for="trakt_timeout">
                                         <span class="component-title">API Timeout</span>

--- a/sickbeard/server/web/home/handler.py
+++ b/sickbeard/server/web/home/handler.py
@@ -423,12 +423,18 @@ class Home(WebRoot):
         trakt_api = TraktApi(sickbeard.SSL_VERIFY, sickbeard.TRAKT_TIMEOUT, **trakt_settings)
         try:
             (access_token, refresh_token) = trakt_api.get_token(sickbeard.TRAKT_REFRESH_TOKEN, trakt_pin=trakt_pin)
-        except (MissingTokenException, TokenExpiredException):
-            ui.notifications.error('Wrong PIN. Reload the page to get new token!')
-            return 'Wrong PIN. Reload the page to get new token!'
+        except MissingTokenException:
+            ui.notifications.error('You need to get a PIN and authorize Medusa app')
+            return 'You need to get a PIN and authorize Medusa app'
+        except TokenExpiredException:
+            # Clear existing tokens
+            sickbeard.TRAKT_ACCESS_TOKEN = ''
+            sickbeard.TRAKT_REFRESH_TOKEN = ''
+            ui.notifications.error('TOKEN expired. Reload page, get a new PIN and authorize Medusa app')
+            return 'TOKEN expired. Reload page, get a new PIN and authorize Medusa app'
         except TraktException:
-            ui.notifications.error('Connection error. Reload the page to get new token!')
-            return 'Error while connection to Trakt. Reload the page to get new token!'
+            ui.notifications.error("Connection error. Click 'Authorize Medusa' button again")
+            return "Connection error. Click 'Authorize Medusa' button again"
         if access_token:
             sickbeard.TRAKT_ACCESS_TOKEN = access_token
             sickbeard.TRAKT_REFRESH_TOKEN = refresh_token


### PR DESCRIPTION
If user already have trakt authorized, PIN input will be disabled and button will be "Get new Trakt PIN"
If never setup trakt, button wil be "Get Trakt PIN"

AS soon user clicks the button, the PIN input will be enabled to type pin
when PIN typed, button "Get new Trakt PIN" will be hidden and button "Authorize Medusa" will appear

after trakt authorized, PIN input will be disabled and ""Get new Trakt PIN" will appear
