### PR TITLE
Fixing kodi __init__ method not calling super by mistake

### DIFF
--- a/sickbeard/metadata/kodi.py
+++ b/sickbeard/metadata/kodi.py
@@ -22,7 +22,7 @@ import os
 
 from sickrage.helper.common import replace_extension
 from sickrage.helper.encoding import ek
-from ..metadata import generic, kodi_12plus
+from ..metadata import kodi_12plus
 
 
 class KODIMetadata(kodi_12plus.KODI_12PlusMetadata):

--- a/sickbeard/metadata/kodi.py
+++ b/sickbeard/metadata/kodi.py
@@ -53,19 +53,16 @@ class KODIMetadata(kodi_12plus.KODI_12PlusMetadata):
                  season_banners=False,
                  season_all_poster=False,
                  season_all_banner=False):
-
-        generic.GenericMetadata.__init__(self,
-                                         show_metadata,
-                                         episode_metadata,
-                                         fanart,
-                                         poster,
-                                         banner,
-                                         episode_thumbnails,
-                                         season_posters,
-                                         season_banners,
-                                         season_all_poster,
-                                         season_all_banner)
-
+        super(KODIMetadata, self).__init__(show_metadata,
+                                           episode_metadata,
+                                           fanart,
+                                           poster,
+                                           banner,
+                                           episode_thumbnails,
+                                           season_posters,
+                                           season_banners,
+                                           season_all_poster,
+                                           season_all_banner)
         self.name = 'KODI'
 
         self.poster_name = self.banner_name = "folder.jpg"


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)
- [x] super constructor was not called by mistake
