### PR TITLE
Remove "Failed Downloads" release sorting. Use database order

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -2376,10 +2376,7 @@ option.flag {
 }
 
 #Anime div.component-group-desc p {
-    margin-bottom: 0.4em;
-    margin-left: 0;
-    margin-right: 0;
-    margin-top: 0.4em;
+    margin: 0.4em 0 0.4em 0;
     width: 95%;
 }
 

--- a/gui/slick/js/manage/failed-downloads.js
+++ b/gui/slick/js/manage/failed-downloads.js
@@ -1,7 +1,7 @@
 MEDUSA.manage.failedDownloads = function() {
     $('#failedTable:has(tbody tr)').tablesorter({
         widgets: ['zebra'],
-        sortList: [[0, 0]],
+        sortList: [],
         headers: {3: {sorter: false}}
     });
     $('#limit').on('change', function() {

--- a/medusa/helpers.py
+++ b/medusa/helpers.py
@@ -859,26 +859,23 @@ def anon_url(*url):
     """Return a URL string consisting of the Anonymous redirect URL and an arbitrary number of values appended."""
     return '' if None in url else '%s%s' % (app.ANON_REDIRECT, ''.join(str(s) for s in url))
 
-
-"""
-Encryption
-==========
-By Pedro Jose Pereira Vieito <pvieito@gmail.com> (@pvieito)
-
-* If encryption_version==0 then return data without encryption
-* The keys should be unique for each device
-
-To add a new encryption_version:
-  1) Code your new encryption_version
-  2) Update the last encryption_version available in sickbeard/server/web/config/general.py
-  3) Remember to maintain old encryption versions and key generators for retro-compatibility
-"""
+# Encryption
+# ==========
+# By Pedro Jose Pereira Vieito <pvieito@gmail.com> (@pvieito)
+# 
+# * If encryption_version==0 then return data without encryption
+# * The keys should be unique for each device
+# 
+# To add a new encryption_version:
+#   1) Code your new encryption_version
+#   2) Update the last encryption_version available in sickbeard/server/web/config/general.py
+#   3) Remember to maintain old encryption versions and key generators for retro-compatibility
 
 # Key Generators
 unique_key1 = hex(uuid.getnode() ** 2)  # Used in encryption v1
 
-
 # Encryption Functions
+
 def encrypt(data, encryption_version=0, _decrypt=False):
     # Version 1: Simple XOR encryption (this is not very secure, but works)
     if encryption_version == 1:

--- a/medusa/helpers.py
+++ b/medusa/helpers.py
@@ -862,10 +862,10 @@ def anon_url(*url):
 # Encryption
 # ==========
 # By Pedro Jose Pereira Vieito <pvieito@gmail.com> (@pvieito)
-# 
+#
 # * If encryption_version==0 then return data without encryption
 # * The keys should be unique for each device
-# 
+#
 # To add a new encryption_version:
 #   1) Code your new encryption_version
 #   2) Update the last encryption_version available in sickbeard/server/web/config/general.py
@@ -875,6 +875,7 @@ def anon_url(*url):
 unique_key1 = hex(uuid.getnode() ** 2)  # Used in encryption v1
 
 # Encryption Functions
+
 
 def encrypt(data, encryption_version=0, _decrypt=False):
     # Version 1: Simple XOR encryption (this is not very secure, but works)


### PR DESCRIPTION
As database failed.db, table failed has no date, when we default sorting to release, we lose the chronological order of failed (database order)