### PR TITLE
Fix for #1155: Expected titles should not contain number-only items.

### DIFF
--- a/medusa/name_parser/guessit_parser.py
+++ b/medusa/name_parser/guessit_parser.py
@@ -106,6 +106,10 @@ def get_expected_titles(show_list):
     for show in show_list:
         names = [show.name] + show.exceptions
         for name in names:
+            if name.isdigit():
+                # do not add numbers to expected titles.
+                continue
+
             match = series_re.match(name)
             if not match:
                 continue

--- a/tests/datasets/tvshows.yml
+++ b/tests/datasets/tvshows.yml
@@ -3057,3 +3057,14 @@
   video_codec: h264
   release_group: GROUP
   type: episode
+
+
+# Regression test for #1155
+# Expected titles shouldn't contain number-only items.
+? Show Name\Season 01\S01E24 A Touch of Glass.m4v
+: title: Show Name
+  season: 1
+  episode: 24
+  episode_title: A Touch of Glass
+  container: m4v
+  type: episode

--- a/tests/test_guessit.py
+++ b/tests/test_guessit.py
@@ -37,6 +37,7 @@ def show_list(create_tvshow):
         create_tvshow(indexerid=16, name='3 Show på (abc2)'),  # unicode characters, numbers and parenthesis
         create_tvshow(indexerid=16, name="Show '70s Name"),
         create_tvshow(indexerid=17, name='An Anime Show 100', anime=1),
+        create_tvshow(indexerid=18, name='24'),  # expected titles shouldn't contain numbers
     ]
 
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)
- [x] Fix for #1155: Expected titles should not contain number-only items.

@wimpyrbx Can you test this?
