### PR TITLE
Adds manual subtitle search in displayShow and re-download subtitle (clicking in the existing flag)

### DIFF
--- a/medusa/__init__.py
+++ b/medusa/__init__.py
@@ -630,6 +630,8 @@ RECENTLY_DELETED = set()
 
 RELEASES_IN_PP = []
 
+SUBTITLES_LIST = []
+
 PRIVACY_LEVEL = 'normal'
 
 
@@ -686,7 +688,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             ANIME_DEFAULT, NAMING_ANIME, ANIMESUPPORT, USE_ANIDB, ANIDB_USERNAME, ANIDB_PASSWORD, ANIDB_USE_MYLIST, \
             ANIME_SPLIT_HOME, SCENE_DEFAULT, DOWNLOAD_URL, BACKLOG_DAYS, GIT_USERNAME, GIT_PASSWORD, \
             DEVELOPER, DISPLAY_ALL_SEASONS, SSL_VERIFY, NEWS_LAST_READ, NEWS_LATEST, BROKEN_PROVIDERS, SOCKET_TIMEOUT, RECENTLY_DELETED, \
-            FANART_BACKGROUND, FANART_BACKGROUND_OPACITY, GIT_REMOTE_BRANCHES, RELEASES_IN_PP
+            FANART_BACKGROUND, FANART_BACKGROUND_OPACITY, GIT_REMOTE_BRANCHES, RELEASES_IN_PP, SUBTITLES_LIST
 
         if __INITIALIZED__:
             return False
@@ -1265,6 +1267,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         DISPLAY_ALL_SEASONS = bool(check_setting_int(CFG, 'General', 'display_all_seasons', 1))
         RECENTLY_DELETED = set()
         RELEASES_IN_PP = []
+        SUBTITLES_LIST = []
         GIT_REMOTE_BRANCHES = []
         KODI_LIBRARY_CLEAN_PENDING = False
 

--- a/medusa/__init__.py
+++ b/medusa/__init__.py
@@ -628,6 +628,8 @@ NEWZNAB_DATA = None
 
 RECENTLY_DELETED = set()
 
+RELEASES_IN_PP = []
+
 PRIVACY_LEVEL = 'normal'
 
 
@@ -684,7 +686,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             ANIME_DEFAULT, NAMING_ANIME, ANIMESUPPORT, USE_ANIDB, ANIDB_USERNAME, ANIDB_PASSWORD, ANIDB_USE_MYLIST, \
             ANIME_SPLIT_HOME, SCENE_DEFAULT, DOWNLOAD_URL, BACKLOG_DAYS, GIT_USERNAME, GIT_PASSWORD, \
             DEVELOPER, DISPLAY_ALL_SEASONS, SSL_VERIFY, NEWS_LAST_READ, NEWS_LATEST, BROKEN_PROVIDERS, SOCKET_TIMEOUT, RECENTLY_DELETED, \
-            FANART_BACKGROUND, FANART_BACKGROUND_OPACITY, GIT_REMOTE_BRANCHES
+            FANART_BACKGROUND, FANART_BACKGROUND_OPACITY, GIT_REMOTE_BRANCHES, RELEASES_IN_PP
 
         if __INITIALIZED__:
             return False
@@ -1262,6 +1264,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         POSTER_SORTDIR = check_setting_int(CFG, 'GUI', 'poster_sortdir', 1)
         DISPLAY_ALL_SEASONS = bool(check_setting_int(CFG, 'General', 'display_all_seasons', 1))
         RECENTLY_DELETED = set()
+        RELEASES_IN_PP = []
         GIT_REMOTE_BRANCHES = []
         KODI_LIBRARY_CLEAN_PENDING = False
 

--- a/medusa/__init__.py
+++ b/medusa/__init__.py
@@ -630,8 +630,6 @@ RECENTLY_DELETED = set()
 
 RELEASES_IN_PP = []
 
-SUBTITLES_LIST = []
-
 PRIVACY_LEVEL = 'normal'
 
 
@@ -688,7 +686,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             ANIME_DEFAULT, NAMING_ANIME, ANIMESUPPORT, USE_ANIDB, ANIDB_USERNAME, ANIDB_PASSWORD, ANIDB_USE_MYLIST, \
             ANIME_SPLIT_HOME, SCENE_DEFAULT, DOWNLOAD_URL, BACKLOG_DAYS, GIT_USERNAME, GIT_PASSWORD, \
             DEVELOPER, DISPLAY_ALL_SEASONS, SSL_VERIFY, NEWS_LAST_READ, NEWS_LATEST, BROKEN_PROVIDERS, SOCKET_TIMEOUT, RECENTLY_DELETED, \
-            FANART_BACKGROUND, FANART_BACKGROUND_OPACITY, GIT_REMOTE_BRANCHES, RELEASES_IN_PP, SUBTITLES_LIST
+            FANART_BACKGROUND, FANART_BACKGROUND_OPACITY, GIT_REMOTE_BRANCHES, RELEASES_IN_PP
 
         if __INITIALIZED__:
             return False
@@ -1267,7 +1265,6 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         DISPLAY_ALL_SEASONS = bool(check_setting_int(CFG, 'General', 'display_all_seasons', 1))
         RECENTLY_DELETED = set()
         RELEASES_IN_PP = []
-        SUBTITLES_LIST = []
         GIT_REMOTE_BRANCHES = []
         KODI_LIBRARY_CLEAN_PENDING = False
 

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import ast
 import json
-import operator
 import os
 import time
 from datetime import date
@@ -1960,18 +1959,8 @@ class Home(WebRoot):
             })
 
         try:
-            found_subtitles = []
-            video = subtitles.get_video(ep_obj, ep_obj.location)
-            if video:
-                pool = subtitles.get_provider_pool()
-                languages = subtitles.get_needed_languages('')
-                subtitles_list = pool.list_subtitles(video, languages)
-                min_score = subtitles.get_min_score()
-                scored_subtitles = sorted([(s, subtitles.compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED))
-                                          for s in subtitles_list], key=operator.itemgetter(1), reverse=True)
-                for subtitle, score in scored_subtitles:
-                    found_subtitles.append({'provider': subtitle.provider_name, 'lang': subtitle.language.opensubtitles, 'score': score, 'min_score': min_score, 'filename': subtitles.get_subtitle_description(subtitle)})
-
+            found_subtitles = subtitles.download_subtitles(tv_episode=ep_obj, video_path=ep_obj.location, subtitles=False,
+                                                           embedded_subtitles=False, lang='all', search_only=True)
         except Exception as e:
             return json.dumps({
                 'result': 'failure',

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -2031,6 +2031,7 @@ class Home(WebRoot):
             ui.notifications.message(ep_obj.show.name, 'Subtitle downloaded')
             return json.dumps({
                 'result': 'success',
+                'release_id': release_id
             })
         else:
             ui.notifications.message(ep_obj.show.name, 'No subtitle downloaded')

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1970,23 +1970,24 @@ class Home(WebRoot):
                 'result': 'failure',
             })
 
-        ep_obj = show_obj.get_episode(season, episode, filepath)
-        release_location = os.path.basename(ep_obj.location)
+        ep_obj = show_obj.get_episode(season, episode)
+        video_path = filepath or ep_obj.location
+        release_name = os.path.basename(video_path)
 
         try:
-            found_subtitles = subtitles.download_subtitles(tv_episode=ep_obj, video_path=ep_obj.location, subtitles=False,
+            found_subtitles = subtitles.download_subtitles(tv_episode=ep_obj, video_path=video_path, subtitles=False,
                                                            embedded_subtitles=False, lang='all', search_only=True)
         except Exception as e:
             return json.dumps({
                 'result': 'failure',
-                'release': release_location,
+                'release': release_name,
                 'subtitles': [],
-                'error': e,
+                'error': str(e),
             })
 
         return json.dumps({
             'result': 'success',
-            'release': release_location,
+            'release': release_name,
             'subtitles': found_subtitles,
             'error': None,
         })
@@ -2010,19 +2011,20 @@ class Home(WebRoot):
                 'result': 'failure',
             })
 
-        ep_obj = show_obj.get_episode(season, episode, filepath)
-        release_location = os.path.basename(ep_obj.location)
+        ep_obj = show_obj.get_episode(season, episode)
+        video_path = filepath or ep_obj.location
+        release_name = os.path.basename(video_path)
 
         try:
             # new_manual_subtitle = FUNCTION(subtitle_id=subtitle_id)
             new_manual_subtitle = None
-            logger.log("Download subtitles for: {0}".format(release_location))
+            logger.log("Downloading subtitles for: {0}".format(release_name))
             raise Exception
         except Exception as e:
             ui.notifications.message(ep_obj.show.name, 'Failed to downloaded subtitles')
             return json.dumps({
                 'result': 'failure',
-                'release': release_location,
+                'release': release_name,
                 'subtitles': [],
                 'error': str(e),
             })

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1992,7 +1992,6 @@ class Home(WebRoot):
                 'message': "Video file no longer exists. Can't search for subtitles"
             })
 
-        found_subtitles = new_manual_subtitle = None
         try:
             if mode == 'searching':
                 logger.log("Manual searching subtitles for: {0}".format(release_name))
@@ -2009,9 +2008,18 @@ class Home(WebRoot):
                 if new_manual_subtitle:
                     ui.notifications.message(ep_obj.show.name, 'Subtitle downloaded: {0}'.format(','.join(new_manual_subtitle)))
                 else:
-                    ui.notifications.message(ep_obj.show.name, 'Failed to download subtitle: {0}'.format(','.join(new_manual_subtitle)))
+                    ui.notifications.message(ep_obj.show.name, 'Failed to download subtitle for {0}'.format(release_name))
                 result = 'success' if new_manual_subtitle else 'failure'
                 subtitles_result = new_manual_subtitle
+            else:
+                raise ValueError
+
+            return json.dumps({
+                'result': result,
+                'release': release_name,
+                'subtitles': subtitles_result,
+                'release_id': release_id
+            })
         except Exception as e:
             ui.notifications.message(ep_obj.show.name, 'Failed to manual {0} subtitles'.format(mode))
             logger.log('Error while manual {mode} subtitles. Error: {error_msg}'.format
@@ -2020,13 +2028,6 @@ class Home(WebRoot):
                 'result': 'failure',
                 'error': str(e)
             })
-
-        return json.dumps({
-            'result': result,
-            'release': release_name,
-            'subtitles': subtitles_result,
-            'release_id': release_id
-        })
 
     def setSceneNumbering(self, show, indexer, forSeason=None, forEpisode=None, forAbsolute=None, sceneSeason=None,
                           sceneEpisode=None, sceneAbsolute=None):

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1981,21 +1981,31 @@ class Home(WebRoot):
             'error': None,
         })
 
-    def pick_manual_search_subtitle(self, show=None, season=None, episode=None, subtitle_id=None):
+    def pick_manual_subtitle(self, show=None, season=None, episode=None, filepath=None, subtitle_id=None):
         # retrieve the episode object and fail if we can't get one
-        ep_obj = getEpisode(show, season, episode)
-        if isinstance(ep_obj, str):
+        try:
+            show = int(show)
+            show_obj = Show.find(app.showList, show)
+        except (ValueError, TypeError):
             return json.dumps({
                 'result': 'failure',
             })
 
+        ep_obj = show_obj.get_episode(season, episode, filepath)
+        release_location = os.path.basename(ep_obj.location)
+
         try:
-            new_manual_subtitle = ep_obj.download_manual_search_subtitle(subtitle_id=subtitle_id)
+            # new_manual_subtitle = FUNCTION(subtitle_id=subtitle_id)
+            new_manual_subtitle = None
+            logger.log("Download subtitles for: {0}".format(release_location))
+            raise Exception
         except Exception as e:
             ui.notifications.message(ep_obj.show.name, 'Failed to downloaded subtitles')
             return json.dumps({
                 'result': 'failure',
-                'error': e,
+                'release': release_location,
+                'subtitles': [],
+                'error': str(e),
             })
 
         if new_manual_subtitle:

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -2017,8 +2017,7 @@ class Home(WebRoot):
             return json.dumps({
                 'result': result,
                 'release': release_name,
-                'subtitles': subtitles_result,
-                'release_id': release_id
+                'subtitles': subtitles_result
             })
         except Exception as e:
             ui.notifications.message(ep_obj.show.name, 'Failed to manual {0} subtitles'.format(mode))

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1967,7 +1967,7 @@ class Home(WebRoot):
                 filepath = None
             show = int(show)
             show_obj = Show.find(app.showList, show)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, IndexError):
             return json.dumps({
                 'result': 'failure',
             })

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1932,6 +1932,9 @@ class Home(WebRoot):
             })
 
         try:
+            if lang:
+                logger.log("Manual re-downloading subtitles for {show} with language {lang}".format
+                           (show=ep_obj.show.name, lang=lang))
             new_subtitles = ep_obj.download_subtitles(lang=lang)
         except Exception:
             return json.dumps({
@@ -1941,13 +1944,15 @@ class Home(WebRoot):
         if new_subtitles:
             new_languages = [subtitles.name_from_code(code) for code in new_subtitles]
             status = 'New subtitles downloaded: {languages}'.format(languages=', '.join(new_languages))
+            result = 'success'
         else:
             new_languages = []
             status = 'No subtitles downloaded'
+            result = 'failure'
 
         ui.notifications.message(ep_obj.show.name, status)
         return json.dumps({
-            'result': status,
+            'result': result,
             'subtitles': ','.join(ep_obj.subtitles),
             'new_subtitles': ','.join(new_languages),
         })

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1950,9 +1950,19 @@ class Home(WebRoot):
             'subtitles': ','.join(ep_obj.subtitles),
         })
 
-    def manual_search_subtitles(self, show=None, season=None, episode=None, filepath=None):
+    def manual_search_subtitles(self, show=None, season=None, episode=None, release_id=None):
         # retrieve the episode object and fail if we can't get one
+
         try:
+            if release_id:
+                # Release ID is sent when using postpone
+                release = app.RELEASES_IN_PP[int(release_id)]
+                show = release['show']
+                season = release['season']
+                episode = release['episode']
+                filepath = release['release']
+            else:
+                filepath = None
             show = int(show)
             show_obj = Show.find(app.showList, show)
         except (ValueError, TypeError):
@@ -1981,9 +1991,18 @@ class Home(WebRoot):
             'error': None,
         })
 
-    def pick_manual_subtitle(self, show=None, season=None, episode=None, filepath=None, subtitle_id=None):
+    def pick_manual_subtitle(self, show=None, season=None, episode=None, release_id=None, subtitle_id=None):
         # retrieve the episode object and fail if we can't get one
         try:
+            if release_id:
+                # Release ID is sent when using postpone
+                release = app.RELEASES_IN_PP[int(release_id)]
+                show = release['show']
+                season = release['season']
+                episode = release['episode']
+                filepath = release['release']
+            else:
+                filepath = None
             show = int(show)
             show_obj = Show.find(app.showList, show)
         except (ValueError, TypeError):

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1976,6 +1976,13 @@ class Home(WebRoot):
         video_path = filepath or ep_obj.location
         release_name = os.path.basename(video_path)
 
+        if not ek(os.path.isfile, video_path):
+            logger.log('Video file no longer exists: {video_file}'.format(video_file=video_path), logger.DEBUG)
+            ui.notifications.message(ep_obj.show.name, "Video file no longer exists. Can't search for subtitles")
+            return json.dumps({
+                'result': 'failure',
+            })
+
         try:
             found_subtitles = subtitles.download_subtitles(tv_episode=ep_obj, video_path=video_path, subtitles=False,
                                                            embedded_subtitles=False, lang='all', search_only=True)

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -2018,24 +2018,24 @@ class Home(WebRoot):
         release_name = os.path.basename(video_path)
 
         try:
-            # new_manual_subtitle = FUNCTION(subtitle_id=subtitle_id)
-            new_manual_subtitle = None
             logger.log("Downloading subtitles for: {0}".format(release_name))
-            raise Exception
-        except Exception as e:
+            new_manual_subtitle = subtitles.download_subtitles(tv_episode=ep_obj, video_path=video_path, subtitles=False,
+                                                           embedded_subtitles=False, lang='all', search_only=False, picked_id=subtitle_id)
+        except Exception:
             ui.notifications.message(ep_obj.show.name, 'Failed to downloaded subtitles')
             return json.dumps({
                 'result': 'failure',
-                'release': release_name,
-                'subtitles': [],
-                'error': str(e),
             })
 
         if new_manual_subtitle:
             ui.notifications.message(ep_obj.show.name, 'Subtitle downloaded')
             return json.dumps({
                 'result': 'success',
-                'error': '',
+            })
+        else:
+            ui.notifications.message(ep_obj.show.name, 'No subtitle downloaded')
+            return json.dumps({
+                'result': 'failure',
             })
 
     def setSceneNumbering(self, show, indexer, forSeason=None, forEpisode=None, forAbsolute=None, sceneSeason=None,

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1990,13 +1990,10 @@ class Home(WebRoot):
         try:
             if not picked_id:
                 logger.log("Manual searching subtitles for: {0}".format(release_name))
-                found_subtitles = subtitles.download_subtitles(tv_episode=ep_obj, video_path=video_path, subtitles=False,
-                                                               embedded_subtitles=False, lang='all', search_only=True)
+                found_subtitles = subtitles.list_subtitles(tv_episode=ep_obj, video_path=video_path)
             else:
                 logger.log("Manual downloading subtitles for: {0}".format(release_name))
-                new_manual_subtitle = subtitles.download_subtitles(tv_episode=ep_obj, video_path=video_path, subtitles=False,
-                                                                   embedded_subtitles=False, lang='all', search_only=False,
-                                                                   picked_id=picked_id)
+                new_manual_subtitle = subtitles.save_subtitle(tv_episode=ep_obj, subtitle_id=picked_id, video_path=video_path)
         except Exception as e:
             ui.notifications.message(ep_obj.show.name, 'Failed to manual {0} subtitles'.format('download' if picked_id else 'search'))
             logger.log('Error while manual {search_type} subtitles. Error: {error_msg}'.format

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1923,7 +1923,7 @@ class Home(WebRoot):
             'episodes': episodes,
         })
 
-    def searchEpisodeSubtitles(self, show=None, season=None, episode=None):
+    def searchEpisodeSubtitles(self, show=None, season=None, episode=None, lang=None):
         # retrieve the episode object and fail if we can't get one
         ep_obj = getEpisode(show, season, episode)
         if isinstance(ep_obj, str):
@@ -1932,7 +1932,7 @@ class Home(WebRoot):
             })
 
         try:
-            new_subtitles = ep_obj.download_subtitles()
+            new_subtitles = ep_obj.download_subtitles(lang=lang)
         except Exception:
             return json.dumps({
                 'result': 'failure',
@@ -1942,12 +1942,14 @@ class Home(WebRoot):
             new_languages = [subtitles.name_from_code(code) for code in new_subtitles]
             status = 'New subtitles downloaded: {languages}'.format(languages=', '.join(new_languages))
         else:
+            new_languages = []
             status = 'No subtitles downloaded'
 
         ui.notifications.message(ep_obj.show.name, status)
         return json.dumps({
             'result': status,
             'subtitles': ','.join(ep_obj.subtitles),
+            'new_subtitles': ','.join(new_languages),
         })
 
     def manual_search_subtitles(self, show=None, season=None, episode=None, release_id=None):

--- a/medusa/server/web/manage/handler.py
+++ b/medusa/server/web/manage/handler.py
@@ -293,7 +293,8 @@ class Manage(Home, WebRoot):
                 if not tv_episode.show.subtitles:
                     continue
 
-                app.RELEASES_IN_PP.append({'release': video_path, 'show': tv_episode.show.indexerid, 'season': tv_episode.season, 'episode': tv_episode.episode})
+                app.RELEASES_IN_PP.append({'release': video_path, 'show': tv_episode.show.indexerid, 'show_name': tv_episode.show.name,
+                                           'season': tv_episode.season, 'episode': tv_episode.episode})
 
         return t.render(releases_in_pp=app.RELEASES_IN_PP, title='Missing Subtitles in Post-Process folder',
                         header='Missing Subtitles in Post Process folder', topmenu='manage',

--- a/medusa/server/web/manage/handler.py
+++ b/medusa/server/web/manage/handler.py
@@ -11,8 +11,8 @@ from tornado.routes import route
 from ..core import PageTemplate, WebRoot
 from ..home import Home
 from .... import (
-    db, helpers, logger,
-    subtitles, ui,
+    db, helpers, logger, postProcessor,
+    subtitles, ui
 )
 from ....common import (
     Overview, Quality, SNATCHED,
@@ -291,6 +291,10 @@ class Manage(Home, WebRoot):
                     continue
 
                 if not tv_episode.show.subtitles:
+                    continue
+
+                related_files = postProcessor.PostProcessor(video_path).list_associated_files(video_path, base_name_only=True, subfolders=False)
+                if related_files:
                     continue
 
                 app.RELEASES_IN_PP.append({'release': video_path, 'show': tv_episode.show.indexerid, 'show_name': tv_episode.show.name,

--- a/medusa/server/web/manage/handler.py
+++ b/medusa/server/web/manage/handler.py
@@ -277,7 +277,7 @@ class Manage(Home, WebRoot):
 
     def subtitleMissedPP(self):
         t = PageTemplate(rh=self, filename='manage_subtitleMissedPP.mako')
-        releases_in_pp = []
+        app.RELEASES_IN_PP = []
         for root, _, files in os.walk(app.TV_DOWNLOAD_DIR, topdown=False):
             for filename in sorted(files):
                 if not isMediaFile(filename):
@@ -293,9 +293,9 @@ class Manage(Home, WebRoot):
                 if not tv_episode.show.subtitles:
                     continue
 
-                releases_in_pp.append({'release': video_path, 'indexer_id': tv_episode.show.indexerid, 'season': tv_episode.season, 'episode': tv_episode.episode})
+                app.RELEASES_IN_PP.append({'release': video_path, 'show': tv_episode.show.indexerid, 'season': tv_episode.season, 'episode': tv_episode.episode})
 
-        return t.render(releases_in_pp=releases_in_pp, title='Missing Subtitles in Post-Process folder',
+        return t.render(releases_in_pp=app.RELEASES_IN_PP, title='Missing Subtitles in Post-Process folder',
                         header='Missing Subtitles in Post Process folder', topmenu='manage',
                         controller='manage', action='subtitleMissedPP')
 

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -504,6 +504,8 @@ def get_subtitle_description(subtitle):
     """
     desc = None
     sub_id = text_type(subtitle.id)
+    if hasattr(subtitle, 'hash') and subtitle.hash:
+        desc = text_type(subtitle.hash).lower()
     if hasattr(subtitle, 'filename') and subtitle.filename:
         desc = subtitle.filename.lower()
     elif hasattr(subtitle, 'name') and subtitle.name:
@@ -513,10 +515,7 @@ def get_subtitle_description(subtitle):
     if hasattr(subtitle, 'releases') and subtitle.releases:
         desc = text_type(subtitle.releases).lower()
 
-    if not desc:
-        desc = sub_id
-
-    return sub_id + '-' + desc if desc not in sub_id else desc
+    return sub_id if not desc else desc
 
 
 def invalidate_video_cache(video_path):

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -290,7 +290,7 @@ def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_sub
             return []
 
         min_score = get_min_score()
-        scored_subtitles = sorted([(s, compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED), s.get_matches(video), s.id())
+        scored_subtitles = sorted([(s, compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED), s.get_matches(video), s.id)
                                   for s in subtitles_list], key=operator.itemgetter(1), reverse=True)
         logger.debug("Scores computed for release: {release}".format(release=os.path.basename(video_path)))
         for subtitle, score, subtitle_matches, _ in scored_subtitles:

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -440,7 +440,8 @@ def save_subs(tv_episode, video, found_subtitles, video_path=None):
             history.logSubtitle(show_indexerid, season, episode, status, subtitle)
 
     # Refresh the subtitles property
-    tv_episode.refresh_subtitles()
+    if tv_episode.location:
+        tv_episode.refresh_subtitles()
 
     return sorted({subtitle.language.opensubtitles for subtitle in saved_subtitles})
 

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -261,7 +261,6 @@ def list_subtitles(tv_episode, video_path=None, limit=40):
     subtitles_dir = get_subtitles_dir(video_path)
     release_name = tv_episode.release_name
 
-    logger.debug(u'Manual searching with all wanted languages')
     languages = {from_code(language) for language in wanted_languages()}
 
     video = get_video(tv_episode, video_path, subtitles_dir=subtitles_dir, subtitles=False,
@@ -322,7 +321,7 @@ def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_sub
     Checks whether subtitles are needed or not
 
     :param tv_episode: the episode to download subtitles
-    :type tv_episode: sickbeard.tv.TVEpisode
+    :type tv_episode: medusa.tv.TVEpisode
     :param video_path: the video path. If none, the episode location will be used
     :type video_path: str
     :param subtitles: True if existing external subtitles should be taken into account

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -227,7 +227,7 @@ def code_from_code(code):
     return from_code(code).opensubtitles
 
 
-def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_subtitles=True, lang=None, search_only=False):
+def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_subtitles=True, lang=None, search_only=False, picked_id=None):
     """Download missing subtitles for the given episode.
 
     Checks whether subtitles are needed or not
@@ -290,16 +290,17 @@ def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_sub
             return []
 
         min_score = get_min_score()
-        scored_subtitles = sorted([(s, compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED), s.get_matches(video), s.id)
+        # TODO: store scored_subtitles using dogpile so we can use ID picked by user to save subtitle
+        scored_subtitles = sorted([(s, compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED), s.get_matches(video))
                                   for s in subtitles_list], key=operator.itemgetter(1), reverse=True)
         logger.debug("Scores computed for release: {release}".format(release=os.path.basename(video_path)))
-        for subtitle, score, subtitle_matches, _ in scored_subtitles:
+        for subtitle, score, subtitle_matches in scored_subtitles:
             logger.debug(u'[{0:>13s}:{1:<5s}] score = {2:3d}/{3:3d} for {4}. Matches: {5}'.format(
                 subtitle.provider_name, subtitle.language, score, min_score, get_subtitle_description(subtitle), list(subtitle_matches)))
 
         if search_only:
             found_subtitles = []
-            for subtitle, score, subtitle_matches, subtitle_id in scored_subtitles:
+            for subtitle, score, subtitle_matches in scored_subtitles:
                 needed_guess = set(['format', 'series', 'year', 'episode', 'season', 'video_codec', 'release_group'])
                 missing_guess = list(needed_guess - subtitle_matches)
                 found_subtitles.append({'provider': subtitle.provider_name,
@@ -307,7 +308,6 @@ def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_sub
                                         'score': score,
                                         'min_score': min_score,
                                         'missing_guess': missing_guess,
-                                        'subtitle_id': subtitle_id,
                                         'filename': get_subtitle_description(subtitle)})
             return found_subtitles
 

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -290,16 +290,16 @@ def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_sub
             return []
 
         min_score = get_min_score()
-        scored_subtitles = sorted([(s, compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED), s.get_matches(video))
+        scored_subtitles = sorted([(s, compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED), s.get_matches(video), s.id())
                                   for s in subtitles_list], key=operator.itemgetter(1), reverse=True)
         logger.debug("Scores computed for release: {release}".format(release=os.path.basename(video_path)))
-        for subtitle, score, subtitle_matches in scored_subtitles:
+        for subtitle, score, subtitle_matches, _ in scored_subtitles:
             logger.debug(u'[{0:>13s}:{1:<5s}] score = {2:3d}/{3:3d} for {4}. Matches: {5}'.format(
                 subtitle.provider_name, subtitle.language, score, min_score, get_subtitle_description(subtitle), list(subtitle_matches)))
 
         if search_only:
             found_subtitles = []
-            for subtitle, score, subtitle_matches in scored_subtitles:
+            for subtitle, score, subtitle_matches, subtitle_id in scored_subtitles:
                 needed_guess = set(['format', 'series', 'year', 'episode', 'season', 'video_codec', 'release_group'])
                 missing_guess = list(needed_guess - subtitle_matches)
                 found_subtitles.append({'provider': subtitle.provider_name,
@@ -307,6 +307,7 @@ def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_sub
                                         'score': score,
                                         'min_score': min_score,
                                         'missing_guess': missing_guess,
+                                        'subtitle_id': subtitle_id,
                                         'filename': get_subtitle_description(subtitle)})
             return found_subtitles
 

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -244,7 +244,7 @@ def score_subtitles(subtitles_list, video):
     """
     providers_order = {d['name']: i for i, d in enumerate(sorted_service_list())}
     result = sorted([(s, compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED),
-                    -1 * providers_order.get(s.provider_name))
+                    -1 * providers_order.get(s.provider_name, 1000))
                      for s in subtitles_list], key=operator.itemgetter(1, 2), reverse=True)
     return [(s, score) for (s, score, provider_order) in result]
 

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -292,6 +292,7 @@ def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_sub
         min_score = get_min_score()
         scored_subtitles = sorted([(s, compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED))
                                   for s in subtitles_list], key=operator.itemgetter(1), reverse=True)
+        logger.debug("Scores computed for release: {release}".format(release=os.path.basename(video_path)))
         for subtitle, score in scored_subtitles:
             logger.debug(u'[{0:>13s}:{1:<5s}] score = {2:3d}/{3:3d} for {4}'.format(
                 subtitle.provider_name, subtitle.language, score, min_score, get_subtitle_description(subtitle)))

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -315,7 +315,7 @@ def save_subtitle(tv_episode, subtitle_id, video_path=None):
         return save_subs(tv_episode, video, [subtitle], video_path=video_path)
 
 
-def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_subtitles=True):
+def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_subtitles=True, lang=None):
     """Download missing subtitles for the given episode.
 
     Checks whether subtitles are needed or not
@@ -338,7 +338,12 @@ def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_sub
     release_name = tv_episode.release_name
     ep_num = episode_num(season, episode) or episode_num(season, episode, numbering='absolute')
     subtitles_dir = get_subtitles_dir(video_path)
-    languages = get_needed_languages(tv_episode.subtitles)
+
+    if lang:
+        logger.debug(u'Force re-downloading subtitle language: %s', lang)
+        languages = {from_code(lang)}
+    else:
+        languages = get_needed_languages(tv_episode.subtitles)
 
     if not languages:
         logger.debug(u'Episode already has all needed subtitles, skipping %s %s', show_name, ep_num)

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -439,6 +439,9 @@ def save_subs(tv_episode, video, found_subtitles, video_path=None):
             logger.debug(u'history.logSubtitle %s, %s', subtitle.provider_name, subtitle.language.opensubtitles)
             history.logSubtitle(show_indexerid, season, episode, status, subtitle)
 
+    # Refresh the subtitles property
+    tv_episode.refresh_subtitles()
+
     return sorted({subtitle.language.opensubtitles for subtitle in saved_subtitles})
 
 

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -290,20 +290,23 @@ def download_subtitles(tv_episode, video_path=None, subtitles=True, embedded_sub
             return []
 
         min_score = get_min_score()
-        scored_subtitles = sorted([(s, compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED))
+        scored_subtitles = sorted([(s, compute_score(s, video, hearing_impaired=app.SUBTITLES_HEARING_IMPAIRED), s.get_matches(video))
                                   for s in subtitles_list], key=operator.itemgetter(1), reverse=True)
         logger.debug("Scores computed for release: {release}".format(release=os.path.basename(video_path)))
-        for subtitle, score in scored_subtitles:
-            logger.debug(u'[{0:>13s}:{1:<5s}] score = {2:3d}/{3:3d} for {4}'.format(
-                subtitle.provider_name, subtitle.language, score, min_score, get_subtitle_description(subtitle)))
+        for subtitle, score, subtitle_matches in scored_subtitles:
+            logger.debug(u'[{0:>13s}:{1:<5s}] score = {2:3d}/{3:3d} for {4}. Matches: {5}'.format(
+                subtitle.provider_name, subtitle.language, score, min_score, get_subtitle_description(subtitle), list(subtitle_matches)))
 
         if search_only:
             found_subtitles = []
-            for subtitle, score in scored_subtitles:
+            for subtitle, score, subtitle_matches in scored_subtitles:
+                needed_guess = set(['format', 'series', 'year', 'episode', 'season', 'video_codec', 'release_group'])
+                missing_guess = list(needed_guess - subtitle_matches)
                 found_subtitles.append({'provider': subtitle.provider_name,
                                         'lang': subtitle.language.opensubtitles,
                                         'score': score,
                                         'min_score': min_score,
+                                        'missing_guess': missing_guess,
                                         'filename': get_subtitle_description(subtitle)})
             return found_subtitles
 

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -273,13 +273,11 @@ def list_subtitles(tv_episode, video_path=None, limit=40):
 
     logger.debug("Scores computed for release: {release}".format(release=os.path.basename(video_path)))
 
-    needed_guess = {'format', 'series', 'year', 'episode', 'season', 'video_codec', 'release_group'}
-
     max_score = episode_scores['hash']
     factor = max_score / 9
     return [{'id': subtitle.id,
              'provider': subtitle.provider_name,
-             'missing_guess': list(needed_guess - subtitle.get_matches(video)),
+             'missing_guess': list(set(episode_scores) - subtitle.get_matches(video) - {'hearing_impaired', 'hash'}),
              'lang': subtitle.language.opensubtitles,
              'score': round(10 * (factor / (float(factor - 1 - score + max_score)))),
              'sub_score': score,

--- a/medusa/tv.py
+++ b/medusa/tv.py
@@ -1765,11 +1765,13 @@ class TVEpisode(TVObject):
             logger.log(u'{id}: Saving subtitles changes to database'.format(id=self.show.indexerid), logger.DEBUG)
             self.save_to_db()
 
-    def download_subtitles(self, force=False):
+    def download_subtitles(self, force=False, lang=None):
         """Download subtitles.
 
         :param force:
         :type force: bool
+        :pram lang:
+        :type param: string
         """
         if not self.is_location_valid():
             logger.log(u"{id}: {show} {ep} file doesn't exist, can't download subtitles".format
@@ -1778,7 +1780,7 @@ class TVEpisode(TVObject):
                        logger.DEBUG)
             return
 
-        new_subtitles = subtitles.download_subtitles(self)
+        new_subtitles = subtitles.download_subtitles(self, lang=lang)
         if new_subtitles:
             self.subtitles = subtitles.merge_subtitles(self.subtitles, new_subtitles)
 

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -972,11 +972,9 @@ new #confirmBox
 @TODO THIS NEEDS TO BE FIXED!
 ========================================================================== */
 .modal-dialog {
-    width: 460px;
-    position: fixed;
-    left: 50%;
-    top: 50%;
-    margin: -130px 0 0 -230px;
+    min-width: 50%;
+    position: relative;
+    margin: 30px auto;
     border: 1px solid rgb(17, 17, 17);
     box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.175);
     border-radius: 0;

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -1009,10 +1009,6 @@ new #confirmBox
     text-align: center;
 }
 
-.modal-header .close {
-    display: none;
-}
-
 .modal-footer button {
     margin-right: 15px;
     padding: 2px 15px;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -972,7 +972,7 @@ displayShow.mako
 ========================================================================== */
 
 .modal-wide .modal-dialog {
-  width: 90%;
+  width: 100%;
 }
 
 .modal-dialog{

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -972,7 +972,7 @@ displayShow.mako
 ========================================================================== */
 
 .modal-wide .modal-dialog {
-  width: 100%;
+  width: 90%;
 }
 
 .modal-dialog{

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -975,6 +975,13 @@ displayShow.mako
   width: 90%;
 }
 
+.modal-dialog{
+    overflow-y: initial !important
+}
+.modal-body{
+    overflow-y: auto;
+}
+
 #posterCol {
     float: left;
     margin-right: 10px;

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -20,7 +20,7 @@
 
     function changeImage(imageTR, srcData, altData, titleData, heightData, emptyLink) {
         if (emptyLink === true) {
-            imageTR.empty();
+            imageTR.find('img').remove()
         }
         imageTR.append($('<img/>').prop({
             src: srcData,
@@ -72,7 +72,7 @@
                     subtitlesResultModal.modal('show');
                 }
                 if (data.result == 'success') {
-                    changeImage(subtitlePicked, 'images/save.png', 'subtitle saved', 'subtitle saved', 16, true);
+                    changeImage(subtitlePicked, 'images/yes16.png', 'subtitle saved', 'subtitle saved', 16, true);
                     if ( $('table#releasesPP').length > 0 ){
                         // Removes the release as we downloaded the subtitle
                         // Need to add 1 because of the row header
@@ -140,24 +140,23 @@
                                 missingGuess = '';
                             }
                             // If perfect match, add a checkmark next to subtitle filename
+                            var checkmark = '';
                             if (subtitle.sub_score >= subtitle.min_score) {
-                                subtitleName += ' <img src="images/save.png" width="16" height="16"/>';
+                                checkmark = '<img src="images/save.png" width="16" height="16"/>';
                             }
+                            var subtitle_link = '<a href="#" id="pickSub" title="Download subtitle" subtitleID="subtitleid-' + subtitle.id + '">' + subtitleName + checkmark + '</a>';
                             // Make subtitle score always between 0 and 10
                             if (subtitle_score > 10) {
                                 subtitle_score = 10;
                             } else if (subtitle_score < 0) {
                                 subtitle_score = 0;
                             }
-                            var pickButton = '<a href="#" id="pickSub" title="Download subtitle" subtitleID="subtitleid-' + subtitle.id + '">' +
-                                                  '<img src="images/download.png" width="16" height="16"/></a>';
                             var row = '<tr style="font-size: 95%;">' +
                                       '<td style="white-space:nowrap;">' + provider + ' ' + subtitle.provider + '</td>' +
                                       '<td>' + flag + '</td>' +
                                       '<td title="' + subtitle.sub_score + '/' + subtitle.min_score + '"> ' + subtitle_score + '</td>' +
-                                      '<td title="' + subtitle.filename + '"> ' + subtitleName + '</td>' +
+                                      '<td class="tvShow"> ' + subtitle_link + '</td>' +
                                       '<td>' + missingGuess + '</td>' +
-                                      '<td>' + pickButton + '</td>' +
                                       '</tr>';
                             $('#subtitle_results').append(row);
                             // Allow the modal to be resizable

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -163,4 +163,32 @@
             return false;
         });
     };
+
+    $.ajaxEpRedownloadSubtitle = function() {
+        $('.epRedownloadSubtitle').on('click', function(e) {
+            e.preventDefault();
+            selectedEpisode = $(this);
+            $("#confirmSubtitleReDownloadModal").modal('show');
+        });
+ 
+        $('#confirmSubtitleReDownloadModal .btn.btn-success').on('click', function(){
+            redownloadSubtitles();
+        });
+
+        function redownloadSubtitles() {
+            changeImage(selectedEpisode, 'images/loading16.gif', downloading, downloading, 16, true);
+            var url = selectedEpisode.prop('href');
+            var downloading = 'Re-downloading subtitle'
+            var failed = 'Re-downloaded subtitle failed'
+            var downloaded = 'Re-downloaded subtitle succeeded'
+            $.getJSON(url, function(data) {
+                if (data.result.toLowerCase() === 'success' && data.new_subtitles.length > 0) {
+                    changeImage(selectedEpisode, 'images/save.png', downloaded, downloaded, 16, true);
+                } else {
+                    changeImage(selectedEpisode, 'images/no16.png', failed, failed, 16, true);
+                }
+              });
+            return false;
+        }
+    };
 })();

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -19,6 +19,7 @@
                 title: 'loading'
             }));
 
+            $("h4.modal-title").text('Subtitle search');
             $('#askmanualSubtitleSearchModal').modal('show');
         });
 
@@ -111,7 +112,7 @@
                             }
                             var download_button = ' <a id="pickSub" title=subtitleid-' + index + '><img src="images/download.png" width="16" height="16"/></a>'
                             //var stars_obj = '<span class="imdbstars" qtip-content="' + stars + '">' + stars + '</span>'
-                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + ' ' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + missing_guess + '</td><td>' + download_button + '</td></tr>';
+                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td title="' + subtitle.filename + '">' + subtitle.filename.substring(0, 99) + matched + '</td><td>' + missing_guess + '</td><td>' + download_button + '</td></tr>';
                             $('#subtitle_results').append(row);
                         });
                     }

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -26,8 +26,19 @@
             var manual_subtitle = '';
             manual_subtitle = ($(this).text().toLowerCase() === 'manual');
             if (manual_subtitle == true) {
-                // Call manual subtitle search URL
-                $('#manualSubtitleSearchModal').modal('show');
+                // Uses the manual subtitle search handler by changing url
+                url = subtitlesSearchLink.prop('href');
+                url = url.replace('searchEpisodeSubtitles', 'manual_search_subtitles');
+                console.log(url)
+                $.getJSON(url, function(data) {
+                    if (data.result.toLowerCase() !== 'failure') {
+                        // Don't show modal if failure or no results
+                    }
+                    else {
+                        // Populates the modal with the results
+                        $('#manualSubtitleSearchModal').modal('show');
+                    }
+                });
             }
             else {
                 forcedSearch();
@@ -35,7 +46,7 @@
         });
     
         function forcedSearch() {
-            $.getJSON(subtitlesSearchLink.attr('href'), function(data) {
+            $.getJSON(subtitlesSearchLink.prop('href'), function(data) {
                 if (data.result.toLowerCase() !== 'failure' && data.result.toLowerCase() !== 'no subtitles downloaded') {
                     // clear and update the subtitles column with new informations
                     var subtitles = data.subtitles.split(',');

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -151,7 +151,7 @@
                             }
                             var pickButton = '<a href="#" id="pickSub" title="Download subtitle" subtitleID="subtitleid-' + subtitle.id + '">' +
                                                   '<img src="images/download.png" width="16" height="16"/></a>';
-                            var row = '<tr>' +
+                            var row = '<tr style="font-size: 95%;">' +
                                       '<td style="white-space:nowrap;">' + provider + ' ' + subtitle.provider + '</td>' +
                                       '<td>' + flag + '</td>' +
                                       '<td title="' + subtitle.sub_score + '/' + subtitle.min_score + '"> ' + subtitle_score + '</td>' +

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -80,12 +80,16 @@
                                 matched = ' <img src="images/save.png" width="16" height="16"/>';
                             }
                             var missing_guess = subtitle.missing_guess
-                            var download_button = ' <input class="btn btn-inline" type="button" id="pickSub" title=subtitleid-' + subtitle.subtitle_id + ' value="pick"/> '
+                            var download_button = ' <a id="pickSub" title=subtitleid-' + subtitle.subtitle_id + '><img src="images/download.png" width="16" height="16"/></a>'
                             //var stars_obj = '<span class="imdbstars" qtip-content="' + stars + '">' + stars + '</span>'
-                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + missing_guess + '</td><td>' + download_button + '</td></tr>';
+                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + ' ' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + missing_guess + '</td><td>' + download_button + '</td></tr>';
                             $('#subtitle_results').append(row);
                         });
                     }
+                    $('.modal-content').resizable({
+                        alsoResize: ".modal-body"
+                    });
+                    $('.modal-dialog').draggable();
                     $('#manualSubtitleSearchModal').modal('show');
                     // Add back the CC icon
                     subtitlesSearchLink.empty();

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -2,6 +2,19 @@
     var subtitlesTd;
     var selectedEpisode;
 
+    function changeImage(imageTR, srcData, altData, titleData, heightData, emptyLink) {
+        if (emptyLink === true) {
+            imageTR.empty();
+        }
+        imageTR.append($('<img/>').prop({
+            src: srcData,
+            alt: altData,
+            title: titleData,
+            width: 16,
+            height: heightData
+        }));
+    }
+
     $.ajaxEpSubtitlesSearch = function() {
         $('.epSubtitlesSearch').on('click', function(e) {
             // This is for the page 'displayShow.mako'
@@ -32,29 +45,14 @@
             // Append the ID param that 'pick_manual_subtitle' expect
             url = url + '&subtitle_id=' + subtitleID;
             subtitlePicked = $(this);
-            subtitlePicked.empty();
-            subtitlePicked.append($('<img/>').prop({
-                src: 'images/loading16.gif',
-                alt: '',
-                title: 'loading'
-            }));
+            changeImage(subtitlePicked, 'images/loading16.gif', 'loading', 'loading', 16, true);
             alert('Picked subtitle ID: ' + subtitleID);
             $.getJSON(url, function(data) {
                 if (data.result == 'success') {
-                    subtitlePicked.empty();
-                    subtitlePicked.append($('<img/>').prop({
-                        src: 'images/save.png',
-                        alt: '',
-                        title: 'subtitle saved'
-                    }));
+                    changeImage(subtitlePicked, 'images/save.png', 'subtitle saved', 'subtitle saved', 16, true);
                 }
                 else {
-                    subtitlePicked.empty();
-                    subtitlePicked.append($('<img/>').prop({
-                        src: 'images/no16.png',
-                        alt: '',
-                        title: 'subtitle not saved'
-                    }));
+                    changeImage(subtitlePicked, 'images/no16.png', 'subtitle not saved', 'subtitle not saved', 16, true);
                 }
             });
         });
@@ -71,13 +69,7 @@
         });
     
         function searchSubtitles() {
-                // fill with the ajax loading gif
-                selectedEpisode.empty();
-                selectedEpisode.append($('<img/>').prop({
-                    src: 'images/loading16.gif',
-                    alt: '',
-                    title: 'loading'
-                }));
+                changeImage(selectedEpisode, 'images/loading16.gif', 'loading', 'loading', 16, true);
                 var url = selectedEpisode.prop('href');
                 // if manual search, replace handler
                 url = url.replace('searchEpisodeSubtitles', 'manual_search_subtitles');
@@ -127,16 +119,13 @@
                     // After all rows are added, show the modal with results found
                     $('#manualSubtitleSearchModal').modal('show');
                     // Add back the CC icon as we are not searching anymore
-                    selectedEpisode.empty();
-                    selectedEpisode.append($('<img/>').prop({
-                        src: 'images/closed_captioning.png',
-                        height: '16',
-                    }));
+                    changeImage(selectedEpisode, 'images/closed_captioning.png', 'Search subtitles', 'Search subtitles', 16, true);
                 });
                 return false;
         }
 
         function forcedSearch() {
+            changeImage(selectedEpisode, 'images/loading16.gif', 'loading', 'loading', 16, true);
             var url = selectedEpisode.prop('href');
             $.getJSON(url, function(data) {
                 if (data.result.toLowerCase() !== 'failure' && data.result.toLowerCase() !== 'no subtitles downloaded') {
@@ -146,23 +135,15 @@
                     $.each(subtitles, function(index, language) {
                         if (language !== '') {
                             if (index !== subtitles.length - 1) { // eslint-disable-line no-negated-condition
-                                subtitlesTd.append($('<img/>').prop({
-                                    src: 'images/subtitles/flags/' + language + '.png',
-                                    alt: language,
-                                    width: 16,
-                                    height: 11
-                                }));
+                                changeImage(subtitlesTd, '', language, language, 11, true);
                             } else {
-                                subtitlesTd.append($('<img/>').prop({
-                                    src: 'images/subtitles/flags/' + language + '.png',
-                                    alt: language,
-                                    width: 16,
-                                    height: 11
-                                }));
+                                changeImage(subtitlesTd, 'images/subtitles/flags/' + language + '.png', language, language, 11, true);
                             }
                         }
                     });
                 }
+                // Add back the CC icon as we are not searching anymore
+                changeImage(selectedEpisode, 'images/closed_captioning.png', 'Search subtitles', 'Search subtitles', 16, true);
             });
             return false;
         }
@@ -171,13 +152,7 @@
     $.fn.ajaxEpMergeSubtitles = function() {
         $('.epMergeSubtitles').on('click', function() {
             var subtitlesMergeLink = $(this);
-            // fill with the ajax loading gif
-            subtitlesMergeLink.empty();
-            subtitlesMergeLink.append($('<img/>').prop({
-                src: 'images/loading16.gif',
-                alt: '',
-                title: 'loading'
-            }));
+            changeImage(subtitlesMergeLink, 'images/loading16.gif', 'loading', 'loading', 16, true);
             $.getJSON($(this).attr('href'), function() {
                 // don't allow other merges
                 subtitlesMergeLink.remove();

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -1,6 +1,19 @@
 (function() {
     var subtitlesTd;
     var selectedEpisode;
+    var subtitleTypeList = ['.epSubtitlesSearch', '.epSubtitlesSearchPP', '.epRedownloadSubtitle', '.epSearch', '.epRetry', '.epManualSearch'];
+    
+    function disableAllSearches() {
+        $.each(subtitleTypeList, function (index, subtitleType) {
+            $(subtitleType).css({'pointer-events' : 'none'});
+        });
+    }
+
+    function enableAllSearches() {
+        $.each(subtitleTypeList, function (index, subtitleType) {
+            $(subtitleType).css({'pointer-events' : 'auto'});
+        });
+    }
 
     function changeImage(imageTR, srcData, altData, titleData, heightData, emptyLink) {
         if (emptyLink === true) {
@@ -14,6 +27,11 @@
             height: heightData
         }));
     }
+
+    $('#manualSubtitleSearchModal').on('hidden.bs.modal', function () {
+        // If user close manual subtitle search modal, enable again all searches
+        enableAllSearches();
+    });
 
     $.ajaxEpSubtitlesSearch = function() {
         $('.epSubtitlesSearch').on('click', function(e) {
@@ -49,6 +67,10 @@
             // Append the ID param that 'pick_manual_subtitle' expect
             url += '&subtitle_id=' + subtitleID;
             $.getJSON(url, function(data) {
+                // If user click to close the window before subtitle download finishes, show again the modal
+                if (($('#manualSubtitleSearchModal').is(':visible')) === false) {
+                    $('#manualSubtitleSearchModal').modal('show');
+                }
                 if (data.result == 'success') {
                     changeImage(subtitlePicked, 'images/save.png', 'subtitle saved', 'subtitle saved', 16, true);
                 }
@@ -70,6 +92,7 @@
         });
     
         function searchSubtitles() {
+                disableAllSearches();
                 changeImage(selectedEpisode, 'images/loading16.gif', 'loading', 'loading', 16, true);
                 var url = selectedEpisode.prop('href');
                 // if manual search, replace handler
@@ -121,11 +144,13 @@
                     $('#manualSubtitleSearchModal').modal('show');
                     // Add back the CC icon as we are not searching anymore
                     changeImage(selectedEpisode, 'images/closed_captioning.png', 'Search subtitles', 'Search subtitles', 16, true);
+                    enableAllSearches();
                 });
                 return false;
         }
 
         function forcedSearch() {
+            disableAllSearches();
             changeImage(selectedEpisode, 'images/loading16.gif', 'loading', 'loading', 16, true);
             var url = selectedEpisode.prop('href');
             $.getJSON(url, function(data) {
@@ -145,6 +170,7 @@
                 }
                 // Add back the CC icon as we are not searching anymore
                 changeImage(selectedEpisode, 'images/closed_captioning.png', 'Search subtitles', 'Search subtitles', 16, true);
+                enableAllSearches();
             });
             return false;
         }
@@ -175,18 +201,20 @@
         });
 
         function redownloadSubtitles() {
+            disableAllSearches();
             changeImage(selectedEpisode, 'images/loading16.gif', downloading, downloading, 16, true);
             var url = selectedEpisode.prop('href');
-            var downloading = 'Re-downloading subtitle'
-            var failed = 'Re-downloaded subtitle failed'
-            var downloaded = 'Re-downloaded subtitle succeeded'
+            var downloading = 'Re-downloading subtitle';
+            var failed = 'Re-downloaded subtitle failed';
+            var downloaded = 'Re-downloaded subtitle succeeded';
             $.getJSON(url, function(data) {
                 if (data.result.toLowerCase() === 'success' && data.new_subtitles.length > 0) {
                     changeImage(selectedEpisode, 'images/save.png', downloaded, downloaded, 16, true);
                 } else {
                     changeImage(selectedEpisode, 'images/no16.png', failed, failed, 16, true);
                 }
-              });
+            });
+            enableAllSearches();
             return false;
         }
     };

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -73,6 +73,11 @@
                 }
                 if (data.result == 'success') {
                     changeImage(subtitlePicked, 'images/save.png', 'subtitle saved', 'subtitle saved', 16, true);
+                    // Need to add 1 because of the row header
+                    var removeRow = parseInt(data.release_id) + 1
+                    if (document.getElementById('releasesPP') !== null) {
+                        document.getElementById('releasesPP').deleteRow(removeRow);
+                    }
                 }
                 else {
                     changeImage(subtitlePicked, 'images/no16.png', 'subtitle not saved', 'subtitle not saved', 16, true);

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -3,7 +3,7 @@
     var selectedEpisode;
     var searchTypesList = ['.epSubtitlesSearch', '.epSubtitlesSearchPP', '.epRedownloadSubtitle', '.epSearch', '.epRetry', '.epManualSearch'];
     var subtitlesResultModal = $('#manualSubtitleSearchModal');
-    
+
     function disableAllSearches() {
         // Disables all other searches while manual searching for subtitles
         $.each(searchTypesList, function (index, searchTypes) {
@@ -93,7 +93,7 @@
                 forcedSearch();
             }
         });
-    
+
         function searchSubtitles() {
                 disableAllSearches();
                 changeImage(selectedEpisode, 'images/loading16.gif', 'loading', 'loading', 16, true);
@@ -115,25 +115,23 @@
                             // For each subtitle found create the row string and append to the modal
                             var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';
                             var flag = '<img src="images/subtitles/flags/' + subtitle.lang + '.png" width="16" height="11"/>';
-                            // Convert score in a scale of 10
-                            var subtitle_score =  Math.trunc((10*(subtitle.score-330)/22), 0);
                             var missingGuess = subtitle.missing_guess;
+                            var subtitle_score =  subtitle.score;
                             var subtitleName = subtitle.filename.substring(0, 99);
                             if (subtitle_score >= 10) {
                                 // If match, don't show missing guess and add a checkmark next to subtitle filename
                                 subtitleName += ' <img src="images/save.png" width="16" height="16"/>';
-                                missingGuess = '';
                                 subtitle_score = 10
                             }
                             if (subtitle_score < 0) {
                                 subtitle_score = 0;
                             }
-                            var pickButton = '<a href="#" id="pickSub" title="Download subtitle" subtitleID=subtitleid-' + subtitle.id + '>' +
+                            var pickButton = '<a href="#" id="pickSub" title="Download subtitle" subtitleID="subtitleid-' + subtitle.id + '">' +
                                                   '<img src="images/download.png" width="16" height="16"/></a>';
                             var row = '<tr>' +
                                       '<td>' + provider + ' ' + subtitle.provider + '</td>' +
                                       '<td>' + flag + '</td>' +
-                                      '<td title="' + subtitle.score + '/' + subtitle.min_score + '"> ' + subtitle_score + '</td>' +
+                                      '<td title="' + subtitle.sub_score + '/' + subtitle.min_score + '"> ' + subtitle_score + '</td>' +
                                       '<td title="' + subtitle.filename + '"> ' + subtitleName + '</td>' +
                                       '<td>' + missingGuess + '</td>' +
                                       '<td>' + pickButton + '</td>' +
@@ -202,7 +200,7 @@
             selectedEpisode = $(this);
             $("#confirmSubtitleReDownloadModal").modal('show');
         });
- 
+
         $('#confirmSubtitleReDownloadModal .btn.btn-success').on('click', function(){
             redownloadSubtitles();
         });

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -58,14 +58,9 @@
             // Remove 'subtitleid-' so we know the actual ID
             subtitleID = subtitleID.replace('subtitleid-', '');
             url = selectedEpisode.prop('href');
-            // Replace handler if we are in 'displayShow.mako' or in 'manage_subtitleMissedPP.mako'
-            if (url.indexOf('searchEpisodeSubtitles') > -1) {
-                url = url.replace('searchEpisodeSubtitles', 'pick_manual_subtitle');
-            } else {
-                url = url.replace('manual_search_subtitles', 'pick_manual_subtitle');
-            }
-            // Append the ID param that 'pick_manual_subtitle' expect
-            url += '&subtitle_id=' + subtitleID;
+            url = url.replace('searchEpisodeSubtitles', 'manual_search_subtitles');
+            // Append the ID param that 'manual_search_subtitles' expect when picking subtitles
+            url += '&picked_id=' + subtitleID;
             $.getJSON(url, function(data) {
                 // If user click to close the window before subtitle download finishes, show again the modal
                 if (($('#manualSubtitleSearchModal').is(':visible')) === false) {
@@ -141,16 +136,16 @@
                                       '<td>' + pickButton + '</td>' +
                                       '</tr>';
                             $('#subtitle_results').append(row);
+                            // Allow the modal to be resizable
+                            $('.modal-content').resizable({
+                                alsoResize: '.modal-body'
+                            });
+                            // Allow the modal to be draggable
+                            $('.modal-dialog').draggable();
+                            // After all rows are added, show the modal with results found
+                            $('#manualSubtitleSearchModal').modal('show');
                         });
                     }
-                    // Allow the modal to be resizable
-                    $('.modal-content').resizable({
-                        alsoResize: '.modal-body'
-                    });
-                    // Allow the modal to be draggable
-                    $('.modal-dialog').draggable();
-                    // After all rows are added, show the modal with results found
-                    $('#manualSubtitleSearchModal').modal('show');
                     // Add back the CC icon as we are not searching anymore
                     changeImage(selectedEpisode, 'images/closed_captioning.png', 'Search subtitles', 'Search subtitles', 16, true);
                     enableAllSearches();

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -37,8 +37,12 @@
                             var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';
                             var flag = '<img src="images/subtitles/flags/' + subtitle.lang + '.png" width="16" height="11"/>';
                             var stars =  Math.trunc((subtitle.score / subtitle.min_score) * 10)
+                            var matched = ''
+                            if (stars == 10) {
+                                matched = ' <img src="images/save.png" width="16" height="16"/>';
+                            }
                             //var stars_obj = '<span class="imdbstars" qtip-content="' + stars + '">' + stars + '</span>'
-                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + '</td></tr>';
+                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td></tr>';
                             $('#subtitle_results').append(row);
                         });
                         $('#manualSubtitleSearchModal').modal('show');

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -113,20 +113,24 @@
                             var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';
                             var flag = '<img src="images/subtitles/flags/' + subtitle.lang + '.png" width="16" height="11"/>';
                             // Convert score in a scale of 10
-                            var stars =  Math.trunc((subtitle.score / subtitle.min_score) * 10);
+                            var subtitle_score =  Math.trunc((10*(subtitle.score-330)/22), 0);
                             var missingGuess = subtitle.missing_guess;
                             var subtitleName = subtitle.filename.substring(0, 99);
-                            if (stars == 10) {
+                            if (subtitle_score >= 10) {
                                 // If match, don't show missing guess and add a checkmark next to subtitle filename
                                 subtitleName += ' <img src="images/save.png" width="16" height="16"/>';
                                 missingGuess = '';
+                                subtitle_score = 10
+                            }
+                            if (subtitle_score < 0) {
+                                subtitle_score = 0;
                             }
                             var pickButton = '<a id="pickSub" title="Download subtitle" subtitleID=subtitleid-' + subtitle.id + '>' +
                                                   '<img src="images/download.png" width="16" height="16"/></a>';
                             var row = '<tr>' +
                                       '<td>' + provider + ' ' + subtitle.provider + '</td>' +
                                       '<td>' + flag + '</td>' +
-                                      '<td>' + stars + '</td>' +
+                                      '<td title="' + subtitle.score + '/' + subtitle.min_score + '"> ' + subtitle_score + '</td>' +
                                       '<td title="' + subtitle.filename + '"> ' + subtitleName + '</td>' +
                                       '<td>' + missingGuess + '</td>' +
                                       '<td>' + pickButton + '</td>' +

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -5,8 +5,8 @@
     var subtitlesSearchLink
 
     $.ajaxEpSubtitlesSearch = function() {
-        $('.epSubtitlesSearch').on('click', function(evt) {
-            evt.preventDefault();
+        $('.epSubtitlesSearch').on('click', function(e) {
+            e.preventDefault();
 
             subtitlesTd = $(this).parent().siblings('.col-subtitles');
             subtitlesSearchLink = $(this);
@@ -20,6 +20,24 @@
             }));
 
             $('#askmanualSubtitleSearchModal').modal('show');
+        });
+
+        $('.epSubtitlesSearchPP').on('click', function(e) {
+            e.preventDefault();
+
+            subtitlesTd = $(this).parent().siblings('.col-search');
+            subtitlesSearchLink = $(this);
+
+            // fill with the ajax loading gif
+            subtitlesSearchLink.empty();
+            subtitlesSearchLink.append($('<img/>').prop({
+                src: 'images/loading16.gif',
+                alt: '',
+                title: 'loading'
+            }));
+
+            url = subtitlesSearchLink.prop('href');
+            searchSubtitles(url);
         });
 
         $(document).on("click", "#pickSub", function(event){
@@ -36,10 +54,23 @@
                 // Uses the manual subtitle search handler by changing url
                 url = subtitlesSearchLink.prop('href');
                 url = url.replace('searchEpisodeSubtitles', 'manual_search_subtitles');
+                searchSubtitles(url);
+            }
+            else {
+                forcedSearch();
+            }
+        });
+    
+        function searchSubtitles(url) {
                 $.getJSON(url, function(data) {
+                    var existing_rows = $('#subtitle_results tr').length;
+                    if (existing_rows > 1) {
+                        for (var x=existing_rows-1; x>0; x--) {
+                            document.getElementById("subtitle_results").deleteRow(x);
+                        }
+                    }
+                    $("h4.modal-title").text(data.release);
                     if (data.result == 'success') {
-
-                        $("h4.modal-title").text(data.release);
                         $.each(data.subtitles, function (index, subtitle) {
                             var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';
                             var flag = '<img src="images/subtitles/flags/' + subtitle.lang + '.png" width="16" height="11"/>';
@@ -54,8 +85,8 @@
                             var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + missing_guess + '</td><td>' + download_button + '</td></tr>';
                             $('#subtitle_results').append(row);
                         });
-                        $('#manualSubtitleSearchModal').modal('show');
                     }
+                    $('#manualSubtitleSearchModal').modal('show');
                     // Add back the CC icon
                     subtitlesSearchLink.empty();
                     subtitlesSearchLink.append($('<img/>').prop({
@@ -63,12 +94,9 @@
                         height: '16',
                     }));
                 });
-            }
-            else {
-                forcedSearch();
-            }
-        });
-    
+                return false;
+        };
+
         function forcedSearch() {
             $.getJSON(subtitlesSearchLink.prop('href'), function(data) {
                 if (data.result.toLowerCase() !== 'failure' && data.result.toLowerCase() !== 'no subtitles downloaded') {

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -132,7 +132,7 @@
                             // For each subtitle found create the row string and append to the modal
                             var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';
                             var flag = '<img src="images/subtitles/flags/' + subtitle.lang + '.png" width="16" height="11"/>';
-                            var missingGuess = subtitle.missing_guess;
+                            var missingGuess = subtitle.missing_guess.join(', ');
                             var subtitle_score =  subtitle.score;
                             var subtitleName = subtitle.filename.substring(0, 99);
                             // if hash match, don't show missingGuess
@@ -152,7 +152,7 @@
                             var pickButton = '<a href="#" id="pickSub" title="Download subtitle" subtitleID="subtitleid-' + subtitle.id + '">' +
                                                   '<img src="images/download.png" width="16" height="16"/></a>';
                             var row = '<tr>' +
-                                      '<td>' + provider + ' ' + subtitle.provider + '</td>' +
+                                      '<td style="white-space:nowrap;">' + provider + ' ' + subtitle.provider + '</td>' +
                                       '<td>' + flag + '</td>' +
                                       '<td title="' + subtitle.sub_score + '/' + subtitle.min_score + '"> ' + subtitle_score + '</td>' +
                                       '<td title="' + subtitle.filename + '"> ' + subtitleName + '</td>' +

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -43,8 +43,36 @@
         $(document).on("click", "#pickSub", function(event){
             var subtitle_id = $(this).attr("title");
             subtitle_id = subtitle_id.replace('subtitleid-', '');
-            $('#manualSubtitleSearchModal').modal('hide');
+            url = subtitlesSearchLink.prop('href');
+            url = url.replace('searchEpisodeSubtitles', 'pick_manual_subtitle');
+            url = url.replace('manual_search_subtitles', 'pick_manual_subtitle');
+            url = url + '&subtitle_id=' + subtitle_id;
+            subtitle_picked = $(this);
+            subtitle_picked.empty();
+            subtitle_picked.append($('<img/>').prop({
+                src: 'images/loading16.gif',
+                alt: '',
+                title: 'loading'
+            }));
             alert('Picked subtitle ID: ' + subtitle_id);
+            $.getJSON(url, function(data) {
+                if (data.result == 'success') {
+                    subtitle_picked.empty();
+                    subtitle_picked.append($('<img/>').prop({
+                        src: 'images/save.png',
+                        alt: '',
+                        title: 'subtitle saved'
+                    }));
+                }
+                else {
+                    subtitle_picked.empty();
+                    subtitle_picked.append($('<img/>').prop({
+                        src: 'images/no16.png',
+                        alt: '',
+                        title: 'subtitle not saved'
+                    }));
+                }
+            });
         });
 
         $('#askmanualSubtitleSearchModal .btn').on('click', function() {

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -159,7 +159,7 @@
             changeImage(selectedEpisode, 'images/loading16.gif', 'loading', 'loading', 16, true);
             var url = selectedEpisode.prop('href');
             $.getJSON(url, function(data) {
-                if (data.result.toLowerCase() !== 'failure' && data.result.toLowerCase() !== 'no subtitles downloaded') {
+                if (data.result.toLowerCase() == 'success') {
                     // clear and update the subtitles column with new informations
                     var subtitles = data.subtitles.split(',');
                     subtitlesTd.empty();

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -77,7 +77,7 @@
                         // Removes the release as we downloaded the subtitle
                         // Need to add 1 because of the row header
                         // Only applied to manage_subtitleMissedPP.mako
-                        var removeRow = parseInt(data.release_id) + 1
+                        var removeRow = $('#releasesPP tr[release_id=' + data.release_id + ']').index() + 1;
                         $('#releasesPP tr').eq(removeRow).remove();
                     } else {
                         // update the subtitles column with new informations

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -30,10 +30,17 @@
                 url = subtitlesSearchLink.prop('href');
                 url = url.replace('searchEpisodeSubtitles', 'manual_search_subtitles');
                 $.getJSON(url, function(data) {
-                    console.log(data.result);
-                    console.log(data.release);
-                    console.log(data.subtitles);
                     if (data.result == 'success') {
+                        console.log(data.subtitles);
+                        $("h4.modal-title").text("Manual subtitle search for release: " + data.release);
+                        $.each(data.subtitles, function (index, subtitle) {
+                            var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';
+                            var flag = '<img src="images/subtitles/flags/' + subtitle.lang + '.png" width="16" height="11"/>';
+                            var stars =  Math.trunc((subtitle.score / subtitle.min_score) * 10)
+                            //var stars_obj = '<span class="imdbstars" qtip-content="' + stars + '">' + stars + '</span>'
+                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + '</td></tr>';
+                            $('#subtitle_results').append(row);
+                        });
                         $('#manualSubtitleSearchModal').modal('show');
                     }
                     // Add back the CC icon

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -9,7 +9,6 @@
             e.preventDefault();
             subtitlesTd = $(this).parent().siblings('.col-subtitles');
             subtitlesSearchLink = $(this);
-            $("h4.modal-title").text('Subtitle search');
             $('#askmanualSubtitleSearchModal').modal('show');
         });
 
@@ -85,7 +84,7 @@
                             document.getElementById("subtitle_results").deleteRow(x);
                         }
                     }
-                    $("h4.modal-title").text(data.release);
+                    $("h4#manualSubtitleSearchModalTitle.modal-title").text(data.release);
                     if (data.result == 'success') {
                         $.each(data.subtitles, function (index, subtitle) {
                             var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -75,10 +75,8 @@
                     changeImage(subtitlePicked, 'images/yes16.png', 'subtitle saved', 'subtitle saved', 16, true);
                     if ( $('table#releasesPP').length > 0 ){
                         // Removes the release as we downloaded the subtitle
-                        // Need to add 1 because of the row header
                         // Only applied to manage_subtitleMissedPP.mako
-                        var removeRow = $('#releasesPP tr[release_id=' + data.release_id + ']').index() + 1;
-                        $('#releasesPP tr').eq(removeRow).remove();
+                        selectedEpisode.parent().parent().remove();
                     } else {
                         // update the subtitles column with new informations
                         var language = data.subtitles;

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -23,9 +23,10 @@
         });
 
         $(document).on("click", "#pickSub", function(event){
-            var filename = $(this).attr("title");
+            var subtitle_id = $(this).attr("title");
+            subtitle_id = subtitle_id.replace('subtitleid-', '');
             $('#manualSubtitleSearchModal').modal('hide');
-            alert('Picked: ' + filename);
+            alert('Picked subtitle ID: ' + subtitle_id);
         });
 
         $('#askmanualSubtitleSearchModal .btn').on('click', function() {
@@ -38,7 +39,7 @@
                 $.getJSON(url, function(data) {
                     if (data.result == 'success') {
 
-                        $("h4.modal-title").text("Manual subtitle search for release: " + data.release);
+                        $("h4.modal-title").text(data.release);
                         $.each(data.subtitles, function (index, subtitle) {
                             var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';
                             var flag = '<img src="images/subtitles/flags/' + subtitle.lang + '.png" width="16" height="11"/>';
@@ -48,9 +49,9 @@
                                 matched = ' <img src="images/save.png" width="16" height="16"/>';
                             }
                             var missing_guess = subtitle.missing_guess
-                            var download_button = ' <input class="btn btn-inline" type="button" id="pickSub" title=subtitle-' + subtitle.filename + ' value="pick"/> '
+                            var download_button = ' <input class="btn btn-inline" type="button" id="pickSub" title=subtitleid-' + subtitle.subtitle_id + ' value="pick"/> '
                             //var stars_obj = '<span class="imdbstars" qtip-content="' + stars + '">' + stars + '</span>'
-                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + missing_guess + '</td></tr>';
+                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + missing_guess + '</td><td>' + download_button + '</td></tr>';
                             $('#subtitle_results').append(row);
                         });
                         $('#manualSubtitleSearchModal').modal('show');

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -75,11 +75,12 @@
                             var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';
                             var flag = '<img src="images/subtitles/flags/' + subtitle.lang + '.png" width="16" height="11"/>';
                             var stars =  Math.trunc((subtitle.score / subtitle.min_score) * 10)
+                            var missing_guess = subtitle.missing_guess
                             var matched = ''
                             if (stars == 10) {
                                 matched = ' <img src="images/save.png" width="16" height="16"/>';
+                                missing_guess = ''
                             }
-                            var missing_guess = subtitle.missing_guess
                             var download_button = ' <a id="pickSub" title=subtitleid-' + subtitle.subtitle_id + '><img src="images/download.png" width="16" height="16"/></a>'
                             //var stars_obj = '<span class="imdbstars" qtip-content="' + stars + '">' + stars + '</span>'
                             var row = '<tr><td>' + provider + ' ' + subtitle.provider + ' ' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + missing_guess + '</td><td>' + download_button + '</td></tr>';

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -29,15 +29,19 @@
                 // Uses the manual subtitle search handler by changing url
                 url = subtitlesSearchLink.prop('href');
                 url = url.replace('searchEpisodeSubtitles', 'manual_search_subtitles');
-                console.log(url)
                 $.getJSON(url, function(data) {
-                    if (data.result.toLowerCase() !== 'failure') {
-                        // Don't show modal if failure or no results
-                    }
-                    else {
-                        // Populates the modal with the results
+                    console.log(data.result);
+                    console.log(data.release);
+                    console.log(data.subtitles);
+                    if (data.result == 'success') {
                         $('#manualSubtitleSearchModal').modal('show');
                     }
+                    // Add back the CC icon
+                    subtitlesSearchLink.empty();
+                    subtitlesSearchLink.append($('<img/>').prop({
+                        src: 'images/closed_captioning.png',
+                        height: '16',
+                    }));
                 });
             }
             else {

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -73,11 +73,17 @@
                 }
                 if (data.result == 'success') {
                     changeImage(subtitlePicked, 'images/save.png', 'subtitle saved', 'subtitle saved', 16, true);
-                    // Removes the release as we downloaded the subtitle
-                    // Need to add 1 because of the row header
-                    // Only applied to manage_subtitleMissedPP.mako
-                    var removeRow = parseInt(data.release_id) + 1
-                    $('#releasesPP tr').eq(removeRow).remove();
+                    if ( $('table#releasesPP').length > 0 ){
+                        // Removes the release as we downloaded the subtitle
+                        // Need to add 1 because of the row header
+                        // Only applied to manage_subtitleMissedPP.mako
+                        var removeRow = parseInt(data.release_id) + 1
+                        $('#releasesPP tr').eq(removeRow).remove();
+                    } else {
+                        // update the subtitles column with new informations
+                        language = data.subtitles;
+                        changeImage(subtitlesTd, 'images/subtitles/flags/' + language + '.png', language, language, 11, false);
+                    }
                 } else {
                     changeImage(subtitlePicked, 'images/no16.png', 'subtitle not saved', 'subtitle not saved', 16, true);
                 }

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -109,7 +109,7 @@
                                 matched = ' <img src="images/save.png" width="16" height="16"/>';
                                 missing_guess = ''
                             }
-                            var download_button = ' <a id="pickSub" title=subtitleid-' + subtitle.subtitle_id + '><img src="images/download.png" width="16" height="16"/></a>'
+                            var download_button = ' <a id="pickSub" title=subtitleid-' + index + '><img src="images/download.png" width="16" height="16"/></a>'
                             //var stars_obj = '<span class="imdbstars" qtip-content="' + stars + '">' + stars + '</span>'
                             var row = '<tr><td>' + provider + ' ' + subtitle.provider + ' ' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + missing_guess + '</td><td>' + download_button + '</td></tr>';
                             $('#subtitle_results').append(row);

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -7,37 +7,17 @@
     $.ajaxEpSubtitlesSearch = function() {
         $('.epSubtitlesSearch').on('click', function(e) {
             e.preventDefault();
-
             subtitlesTd = $(this).parent().siblings('.col-subtitles');
             subtitlesSearchLink = $(this);
-
-            // fill with the ajax loading gif
-            subtitlesSearchLink.empty();
-            subtitlesSearchLink.append($('<img/>').prop({
-                src: 'images/loading16.gif',
-                alt: '',
-                title: 'loading'
-            }));
-
             $("h4.modal-title").text('Subtitle search');
             $('#askmanualSubtitleSearchModal').modal('show');
         });
 
         $('.epSubtitlesSearchPP').on('click', function(e) {
             e.preventDefault();
-
             subtitlesTd = $(this).parent().siblings('.col-search');
             subtitlesSearchLink = $(this);
-
-            // fill with the ajax loading gif
-            subtitlesSearchLink.empty();
-            subtitlesSearchLink.append($('<img/>').prop({
-                src: 'images/loading16.gif',
-                alt: '',
-                title: 'loading'
-            }));
-
-            url = subtitlesSearchLink.prop('href');
+            url = subtitlesSearchLink.prop('href');            
             searchSubtitles(url);
         });
 
@@ -91,6 +71,13 @@
         });
     
         function searchSubtitles(url) {
+                // fill with the ajax loading gif
+                subtitlesSearchLink.empty();
+                subtitlesSearchLink.append($('<img/>').prop({
+                    src: 'images/loading16.gif',
+                    alt: '',
+                    title: 'loading'
+                }));
                 $.getJSON(url, function(data) {
                     var existing_rows = $('#subtitle_results tr').length;
                     if (existing_rows > 1) {

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -47,9 +47,10 @@
                             if (stars == 10) {
                                 matched = ' <img src="images/save.png" width="16" height="16"/>';
                             }
+                            var missing_guess = subtitle.missing_guess
                             var download_button = ' <input class="btn btn-inline" type="button" id="pickSub" title=subtitle-' + subtitle.filename + ' value="pick"/> '
                             //var stars_obj = '<span class="imdbstars" qtip-content="' + stars + '">' + stars + '</span>'
-                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + download_button + '</td></tr>';
+                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + missing_guess + '</td></tr>';
                             $('#subtitle_results').append(row);
                         });
                         $('#manualSubtitleSearchModal').modal('show');

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -42,7 +42,7 @@
         });
 
         $(document).on("click", "#pickSub", function(event){
-            var subtitle_id = $(this).attr("title");
+            var subtitle_id = $(this).attr("subtitle_id");
             subtitle_id = subtitle_id.replace('subtitleid-', '');
             url = subtitlesSearchLink.prop('href');
             url = url.replace('searchEpisodeSubtitles', 'pick_manual_subtitle');
@@ -110,7 +110,7 @@
                                 matched = ' <img src="images/save.png" width="16" height="16"/>';
                                 missing_guess = ''
                             }
-                            var download_button = ' <a id="pickSub" title=subtitleid-' + index + '><img src="images/download.png" width="16" height="16"/></a>'
+                            var download_button = ' <a id="pickSub" title="Download subtitle" subtitle_id=subtitleid-' + index + '><img src="images/download.png" width="16" height="16"/></a>'
                             //var stars_obj = '<span class="imdbstars" qtip-content="' + stars + '">' + stars + '</span>'
                             var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td title="' + subtitle.filename + '">' + subtitle.filename.substring(0, 99) + matched + '</td><td>' + missing_guess + '</td><td>' + download_button + '</td></tr>';
                             $('#subtitle_results').append(row);

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -144,7 +144,7 @@
                             if (subtitle.sub_score >= subtitle.min_score) {
                                 checkmark = '<img src="images/save.png" width="16" height="16"/>';
                             }
-                            var subtitle_link = '<a href="#" id="pickSub" title="Download subtitle" subtitleID="subtitleid-' + subtitle.id + '">' + subtitleName + checkmark + '</a>';
+                            var subtitle_link = '<a href="#" id="pickSub" title="Download subtitle: ' + subtitle.filename + '" subtitleID="subtitleid-' + subtitle.id + '">' + subtitleName + checkmark + '</a>';
                             // Make subtitle score always between 0 and 10
                             if (subtitle_score > 10) {
                                 subtitle_score = 10;

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -19,8 +19,8 @@
         $('.epSubtitlesSearch').on('click', function(e) {
             // This is for the page 'displayShow.mako'
             e.preventDefault();
-            subtitlesTd = $(this).parent().siblings('.col-subtitles');
             selectedEpisode = $(this);
+            subtitlesTd = selectedEpisode.parent().siblings('.col-subtitles');
             // Ask user if he want to manual search subs or automatic search
             $('#askmanualSubtitleSearchModal').modal('show');
         });
@@ -28,24 +28,26 @@
         $('.epSubtitlesSearchPP').on('click', function(e) {
             // This is for the page 'manage_subtitleMissedPP.mako'
             e.preventDefault();
-            subtitlesTd = $(this).parent().siblings('.col-search');
             selectedEpisode = $(this);
+            subtitlesTd = selectedEpisode.parent().siblings('.col-search');
             searchSubtitles();
         });
 
-        $(document).on("click", "#pickSub", function(event){
-            var subtitleID = $(this).attr("subtitleID");
+        $(document).on('click', '#pickSub', function(event){
+            subtitlePicked = $(this);
+            changeImage(subtitlePicked, 'images/loading16.gif', 'loading', 'loading', 16, true);
+            var subtitleID = subtitlePicked.attr('subtitleID');
             // Remove 'subtitleid-' so we know the actual ID
             subtitleID = subtitleID.replace('subtitleid-', '');
             url = selectedEpisode.prop('href');
-            // Replace if it was clicked in 'displayShow.mako'
-            url = url.replace('searchEpisodeSubtitles', 'pick_manual_subtitle');
-            // Replace if it was clicked in 'manage_subtitleMissedPP.mako'
-            url = url.replace('manual_search_subtitles', 'pick_manual_subtitle');
+            // Replace handler if we are in 'displayShow.mako' or in 'manage_subtitleMissedPP.mako'
+            if (url.indexOf('searchEpisodeSubtitles') > -1) {
+                url = url.replace('searchEpisodeSubtitles', 'pick_manual_subtitle');
+            } else {
+                url = url.replace('manual_search_subtitles', 'pick_manual_subtitle');
+            }
             // Append the ID param that 'pick_manual_subtitle' expect
-            url = url + '&subtitle_id=' + subtitleID;
-            subtitlePicked = $(this);
-            changeImage(subtitlePicked, 'images/loading16.gif', 'loading', 'loading', 16, true);
+            url += '&subtitle_id=' + subtitleID;
             alert('Picked subtitle ID: ' + subtitleID);
             $.getJSON(url, function(data) {
                 if (data.result == 'success') {
@@ -78,11 +80,11 @@
                     var existing_rows = $('#subtitle_results tr').length;
                     if (existing_rows > 1) {
                         for (var x=existing_rows-1; x>0; x--) {
-                            document.getElementById("subtitle_results").deleteRow(x);
+                            document.getElementById('subtitle_results').deleteRow(x);
                         }
                     }
                     // Add the release to the modal title
-                    $("h4#manualSubtitleSearchModalTitle.modal-title").text(data.release);
+                    $('h4#manualSubtitleSearchModalTitle.modal-title').text(data.release);
                     if (data.result == 'success') {
                         $.each(data.subtitles, function (index, subtitle) {
                             // For each subtitle found create the row string and append to the modal
@@ -112,7 +114,7 @@
                     }
                     // Allow the modal to be resizable
                     $('.modal-content').resizable({
-                        alsoResize: ".modal-body"
+                        alsoResize: '.modal-body'
                     });
                     // Allow the modal to be draggable
                     $('.modal-dialog').draggable();

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -81,8 +81,19 @@
                         $('#releasesPP tr').eq(removeRow).remove();
                     } else {
                         // update the subtitles column with new informations
-                        language = data.subtitles;
-                        changeImage(subtitlesTd, 'images/subtitles/flags/' + language + '.png', language, language, 11, false);
+                        var language = data.subtitles;
+                        var hasLang = false;
+                        var lang = language;
+                        subtitlesTd.children().children().each(function(){
+                            // Check if user already have this subtitle language
+                            if ($(this).attr('alt').indexOf(lang) !== -1){
+                                hasLang = true;
+                            }
+                        });
+                        // Only add language flag if user doesn't have this subtitle language
+                        if (hasLang === false) {
+                            changeImage(subtitlesTd, 'images/subtitles/flags/' + language + '.png', language, language, 11, false);
+                        }
                     }
                 } else {
                     changeImage(subtitlePicked, 'images/no16.png', 'subtitle not saved', 'subtitle not saved', 16, true);

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -148,7 +148,7 @@
                                 alsoResize: '.modal-body'
                             });
                             // Allow the modal to be draggable
-                            $('.modal-dialog').draggable();
+                            $('.modal-dialog').draggable({ cancel: '.text' });
                             // After all rows are added, show the modal with results found
                             subtitlesResultModal.modal('show');
                         });

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -22,6 +22,12 @@
             $('#askmanualSubtitleSearchModal').modal('show');
         });
 
+        $(document).on("click", "#pickSub", function(event){
+            var filename = $(this).attr("title");
+            $('#manualSubtitleSearchModal').modal('hide');
+            alert('Picked: ' + filename);
+        });
+
         $('#askmanualSubtitleSearchModal .btn').on('click', function() {
             var manual_subtitle = '';
             manual_subtitle = ($(this).text().toLowerCase() === 'manual');
@@ -31,7 +37,7 @@
                 url = url.replace('searchEpisodeSubtitles', 'manual_search_subtitles');
                 $.getJSON(url, function(data) {
                     if (data.result == 'success') {
-                        console.log(data.subtitles);
+
                         $("h4.modal-title").text("Manual subtitle search for release: " + data.release);
                         $.each(data.subtitles, function (index, subtitle) {
                             var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';
@@ -41,8 +47,9 @@
                             if (stars == 10) {
                                 matched = ' <img src="images/save.png" width="16" height="16"/>';
                             }
+                            var download_button = ' <input class="btn btn-inline" type="button" id="pickSub" title=subtitle-' + subtitle.filename + ' value="pick"/> '
                             //var stars_obj = '<span class="imdbstars" qtip-content="' + stars + '">' + stars + '</span>'
-                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td></tr>';
+                            var row = '<tr><td>' + provider + ' ' + subtitle.provider + '</td><td>' + flag + '</td><td>' + stars + '</td><td>' + subtitle.filename + matched + '</td><td>' + download_button + '</td></tr>';
                             $('#subtitle_results').append(row);
                         });
                         $('#manualSubtitleSearchModal').modal('show');

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -132,7 +132,15 @@
                             // For each subtitle found create the row string and append to the modal
                             var provider = '<img src="images/subtitles/' + subtitle.provider + '.png" width="16" height="16" style="vertical-align:middle;"/>';
                             var flag = '<img src="images/subtitles/flags/' + subtitle.lang + '.png" width="16" height="11"/>';
-                            var missingGuess = subtitle.missing_guess.join(', ');
+                            var missingGuess = '';
+                            for (var i = 0; i < subtitle.missing_guess.length; i++) {
+                                var value = subtitle.missing_guess[i];
+                                if (missingGuess) {
+                                    missingGuess += ', ';
+                                }
+                                value = value.charAt(0).toUpperCase() + value.slice(1);
+                                missingGuess += value.replace(/(\_[a-z])/g, function($1){return $1.toUpperCase().replace('_',' ');});
+                            }
                             var subtitle_score =  subtitle.score;
                             var subtitleName = subtitle.filename.substring(0, 99);
                             // if hash match, don't show missingGuess

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -48,7 +48,6 @@
             }
             // Append the ID param that 'pick_manual_subtitle' expect
             url += '&subtitle_id=' + subtitleID;
-            alert('Picked subtitle ID: ' + subtitleID);
             $.getJSON(url, function(data) {
                 if (data.result == 'success') {
                     changeImage(subtitlePicked, 'images/save.png', 'subtitle saved', 'subtitle saved', 16, true);
@@ -99,7 +98,7 @@
                                 subtitleName += ' <img src="images/save.png" width="16" height="16"/>';
                                 missingGuess = '';
                             }
-                            var pickButton = '<a id="pickSub" title="Download subtitle" subtitleID=subtitleid-' + index + '>' +
+                            var pickButton = '<a id="pickSub" title="Download subtitle" subtitleID=subtitleid-' + subtitle.id + '>' +
                                                   '<img src="images/download.png" width="16" height="16"/></a>';
                             var row = '<tr>' +
                                       '<td>' + provider + ' ' + subtitle.provider + '</td>' +

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -118,12 +118,18 @@
                             var missingGuess = subtitle.missing_guess;
                             var subtitle_score =  subtitle.score;
                             var subtitleName = subtitle.filename.substring(0, 99);
-                            if (subtitle_score >= 10) {
-                                // If match, don't show missing guess and add a checkmark next to subtitle filename
-                                subtitleName += ' <img src="images/save.png" width="16" height="16"/>';
-                                subtitle_score = 10
+                            // if hash match, don't show missingGuess
+                            if (subtitle.sub_score >= subtitle.max_score){
+                                missingGuess = '';
                             }
-                            if (subtitle_score < 0) {
+                            // If perfect match, add a checkmark next to subtitle filename
+                            if (subtitle.sub_score >= subtitle.min_score) {
+                                subtitleName += ' <img src="images/save.png" width="16" height="16"/>';
+                            }
+                            // Make subtitle score always between 0 and 10
+                            if (subtitle_score > 10) {
+                                subtitle_score = 10;
+                            } else if (subtitle_score < 0) {
                                 subtitle_score = 0;
                             }
                             var pickButton = '<a href="#" id="pickSub" title="Download subtitle" subtitleID="subtitleid-' + subtitle.id + '">' +

--- a/static/js/home/display-show.js
+++ b/static/js/home/display-show.js
@@ -9,6 +9,7 @@ MEDUSA.home.displayShow = function() { // eslint-disable-line max-lines
     });
 
     $.ajaxEpSubtitlesSearch();
+    $.ajaxEpRedownloadSubtitle();
 
     $('#seasonJump').on('change', function() {
         var id = $('#seasonJump option:selected').val();

--- a/static/js/manage/subtitle-missedPP.js
+++ b/static/js/manage/subtitle-missedPP.js
@@ -1,0 +1,3 @@
+MEDUSA.manage.subtitleMissedPP = function() {
+    $.ajaxEpSubtitlesSearch();
+};

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -572,7 +572,8 @@
                 <h4 class="modal-title">Manual subtitle search for release: </h4>
             </div>
             <div class="modal-body">
-                <table style="width:100%">
+                <table id=subtitle_results style="width:100%">
+                <tbody>
                 <tr>
                     <th>Provider</th>
                     <th>Flag</th>
@@ -580,6 +581,7 @@
                     <th>Subtitle</th>
                     <th>Missing/wrong</th>
                 </tr>
+                </tbody>
                 </table> 
             </div>
         </div>

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -564,30 +564,6 @@
         </div>
     </div>
 </div>
-<div id="manualSubtitleSearchModal" class="modal fade modal-wide" >
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title"></h4>
-            </div>
-            <div class="modal-body">
-                <table id=subtitle_results style="width:100%">
-                <tbody>
-                <tr>
-                    <th>Provider/Flag</th>
-                    <th></th>
-                    <th>Score</th>
-                    <th>Subtitle</th>
-                    <th>Missing/wrong</th>
-                    <th></th>
-                </tr>
-                </tbody>
-                </table> 
-            </div>
-        </div>
-    </div>
-</div>
 <div id="askmanualSubtitleSearchModal" class="modal fade">
     <div class="modal-dialog">
         <div class="modal-content">
@@ -605,5 +581,6 @@
         </div>
     </div>
 </div>
+<%include file="subtitle_modal.mako"/>
 <!--End - Bootstrap Modal-->
 </%block>

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -575,7 +575,7 @@
                 <p>Do you want to manually pick subtitles or let us choose it for you?</p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-danger" data-dismiss="modal">Auto</button>
+                <button type="button" class="btn btn-info" data-dismiss="modal">Auto</button>
                 <button type="button" class="btn btn-success" data-dismiss="modal">Manual</button>
             </div>
         </div>

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -576,6 +576,7 @@
                 <tbody>
                 <tr>
                     <th>Provider/Flag</th>
+                    <th></th>
                     <th>Score</th>
                     <th>Subtitle</th>
                     <th>Missing/wrong</th>

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -495,7 +495,12 @@
             <td class="col-subtitles" align="center">
             % for flag in (epResult["subtitles"] or '').split(','):
                 % if flag.strip() and Quality.splitCompositeStatus(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
-                    <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${subtitles.name_from_code(flag)}" onError="this.onerror=null;this.src='images/flags/unknown.png';" />
+                    % if flag != 'und':
+                        <a class=epRedownloadSubtitle href="home/searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}&amp;lang=${flag}">
+                        <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${flag}" onError="this.onerror=null;this.src='images/flags/unknown.png';" />
+                    % else:
+                        <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${subtitles.name_from_code(flag)}" onError="this.onerror=null;this.src='images/flags/unknown.png';" />
+                    % endif
                 % endif
             % endfor
             </td>
@@ -556,6 +561,24 @@
             <div class="modal-body">
                 <p>Do you want to include the current episode quality in the search?</p>
                 <p class="text-warning"><small>Choosing No will ignore any releases with the same episode quality as the one currently downloaded/snatched.</small></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-danger" data-dismiss="modal">No</button>
+                <button type="button" class="btn btn-success" data-dismiss="modal">Yes</button>
+            </div>
+        </div>
+    </div>
+</div>
+<div id="confirmSubtitleReDownloadModal" class="modal fade">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">Re-download subtitle</h4>
+            </div>
+            <div class="modal-body">
+                <p>Do you want to re-download the subtitle for this language?</p>
+                <p class="text-warning"><small>It will overwrite your current subtitle</small></p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-danger" data-dismiss="modal">No</button>

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -516,7 +516,7 @@
                 % else:
                     <a class="epManualSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}&amp;manual_search_type=episode"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
                 % endif
-                % if int(epResult["status"]) not in Quality.SNATCHED + Quality.SNATCHED_PROPER and app.USE_SUBTITLES and show.subtitles and epResult["location"] and subtitles.needs_subtitles(epResult['subtitles']):
+                % if int(epResult["status"]) not in Quality.SNATCHED + Quality.SNATCHED_PROPER and app.USE_SUBTITLES and show.subtitles and epResult["location"]:
                     <a class="epSubtitlesSearch" href="home/searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img src="images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
                 % endif
             </td>

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -569,7 +569,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title">Manual subtitle search for release: </h4>
+                <h4 class="modal-title"></h4>
             </div>
             <div class="modal-body">
                 <table id=subtitle_results style="width:100%">
@@ -580,6 +580,7 @@
                     <th>Score</th>
                     <th>Subtitle</th>
                     <th>Missing/wrong</th>
+                    <th>Download</th>
                 </tr>
                 </tbody>
                 </table> 

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -575,12 +575,11 @@
                 <table id=subtitle_results style="width:100%">
                 <tbody>
                 <tr>
-                    <th>Provider</th>
-                    <th>Flag</th>
+                    <th>Provider/Flag</th>
                     <th>Score</th>
                     <th>Subtitle</th>
                     <th>Missing/wrong</th>
-                    <th>Download</th>
+                    <th></th>
                 </tr>
                 </tbody>
                 </table> 

--- a/views/manage_subtitleMissedPP.mako
+++ b/views/manage_subtitleMissedPP.mako
@@ -28,7 +28,7 @@
         </thead>
         <tbody aria-live="polite" aria-relevant="all">
         % for index, epResult in enumerate(releases_in_pp):
-            <tr class="snatched" role="row">
+            <tr class="snatched" role="row" release_id=${index}>
                 <td class="tvShow" align="left">
                         ${epResult['show_name']}
                 </td>

--- a/views/manage_subtitleMissedPP.mako
+++ b/views/manage_subtitleMissedPP.mako
@@ -48,5 +48,19 @@
         </tbody>
     </table>
 <%include file="subtitle_modal.mako"/>
+</br>
+<form name="processForm" method="post" action="home/postprocess/processEpisode" align="right">
+<table>
+    <input type="hidden" id="type" name="type" value="manual">
+    <input type="hidden" id="process_method" name="process_method" value=${app.PROCESS_METHOD}>
+    <input type="hidden" id="episodeDir" type="text" name="proc_dir" value=${app.TV_DOWNLOAD_DIR}>
+    <input type="hidden" id="force" name="force" value="0">
+    <input type="hidden" id="is_priority" name="is_priority" value="0"> 
+    <input type="hidden" id="delete_on" name="delete_on" value=${not app.NO_DELETE}>
+    <input type="hidden" id="failed" name="failed" value="0">
+    <input type="hidden" id="ignore_subs" name="ignore_subs" value="0">
+</table>
+    <input id="submit" class="btn" type="submit" value="Run Manual Post-Process" />
+</form>
 </div>
 </%block>

--- a/views/manage_subtitleMissedPP.mako
+++ b/views/manage_subtitleMissedPP.mako
@@ -2,6 +2,7 @@
 <%!
     import medusa as app
     import os
+    from medusa.helper.common import episode_num
 %>
 <%block name="scripts">
 <script type="text/javascript" src="js/lib/jquery.bookmarkscroll.js?${sbPID}"></script>
@@ -19,6 +20,8 @@
     <table id="showListTable" class="defaultTable" cellspacing="1" border="0" cellpadding="0">
         <thead aria-live="polite" aria-relevant="all">
             <tr>
+                <th>Show</th>
+                <th>Episode</th>
                 <th>Release</th>
                 <th class="col-search">Search</th>
             </tr>
@@ -26,6 +29,12 @@
         <tbody aria-live="polite" aria-relevant="all">
         % for index, epResult in enumerate(releases_in_pp):
             <tr class="snatched" role="row">
+                <td class="tvShow" align="left">
+                        ${epResult['show_name']}
+                </td>
+                <td class="tvShow" align="center">
+                        ${episode_num(epResult['season'], epResult['episode'])}
+                </td>
                 <td class="tvShow" align="left">
                     <span class="break-word">
                         ${os.path.relpath(epResult['release'], app.TV_DOWNLOAD_DIR)}

--- a/views/manage_subtitleMissedPP.mako
+++ b/views/manage_subtitleMissedPP.mako
@@ -38,29 +38,6 @@
         % endfor
         </tbody>
     </table>
-<div id="manualSubtitleSearchModal" class="modal fade modal-wide" >
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title"></h4>
-            </div>
-            <div class="modal-body">
-                <table id=subtitle_results style="width:100%">
-                <tbody>
-                <tr>
-                    <th>Provider/Lang</th>
-                    <th></th>
-                    <th>Score</th>
-                    <th>Subtitle</th>
-                    <th>Missing/wrong</th>
-                    <th></th>
-                </tr>
-                </tbody>
-                </table> 
-            </div>
-        </div>
-    </div>
-</div>
+<%include file="subtitle_modal.mako"/>
 </div>
 </%block>

--- a/views/manage_subtitleMissedPP.mako
+++ b/views/manage_subtitleMissedPP.mako
@@ -24,7 +24,7 @@
             </tr>
         </thead>
         <tbody aria-live="polite" aria-relevant="all">
-        % for epResult in releases_in_pp:
+        % for index, epResult in enumerate(releases_in_pp):
             <tr class="snatched" role="row">
                 <td class="tvShow" align="left">
                     <span class="break-word">
@@ -32,7 +32,7 @@
                     </span>
                 </td>
                 <td class="col-search">
-                    <a class="epSubtitlesSearchPP" href="home/manual_search_subtitles?show=${epResult["indexer_id"]}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}&amp;filepath=${epResult["release"]}"><img src="images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
+                    <a class="epSubtitlesSearchPP" release_id=${index} href="home/manual_search_subtitles?release_id=${index}"><img src="images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
                 </td>
             </tr>
         % endfor

--- a/views/manage_subtitleMissedPP.mako
+++ b/views/manage_subtitleMissedPP.mako
@@ -1,0 +1,62 @@
+<%inherit file="/layouts/main.mako"/>
+<%block name="scripts">
+<script type="text/javascript" src="js/lib/jquery.bookmarkscroll.js?${sbPID}"></script>
+<script type="text/javascript" src="js/ajax-episode-subtitles.js?${sbPID}"></script>
+</%block>
+<%block name="content">
+    <div>
+    % if not header is UNDEFINED:
+        <h1 class="header">${header}</h1>
+    % else:
+        <h1 class="title">${title}</h1>
+    % endif
+    </div>
+<div id="container">
+    <table id="showListTable" class="defaultTable" cellspacing="1" border="0" cellpadding="0">
+        <thead aria-live="polite" aria-relevant="all">
+            <tr>
+                <th>Release</th>
+                <th class="col-search">Search</th>
+            </tr>
+        </thead>
+        <tbody aria-live="polite" aria-relevant="all">
+        % for epResult in releases_in_pp:
+            <tr class="skipped" role="row">
+                <td class="tvShow">
+                    <span class="break-word">
+                        ${epResult['release']}
+                    </span>
+                </td>
+                <td class="col-search">
+                    <a class="epSubtitlesSearchPP" href="home/manual_search_subtitles?show=${epResult["indexer_id"]}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}&amp;filepath=${epResult["release"]}"><img src="images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
+                </td>
+            </tr>
+        % endfor
+        </tbody>
+    </table>
+<div id="manualSubtitleSearchModal" class="modal fade modal-wide" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title"></h4>
+            </div>
+            <div class="modal-body">
+                <table id=subtitle_results style="width:100%">
+                <tbody>
+                <tr>
+                    <th>Provider</th>
+                    <th>Flag</th>
+                    <th>Score</th>
+                    <th>Subtitle</th>
+                    <th>Missing/wrong</th>
+                    <th>Download</th>
+                </tr>
+                </tbody>
+                </table> 
+            </div>
+        </div>
+    </div>
+</div>
+</div>
+</%block>

--- a/views/manage_subtitleMissedPP.mako
+++ b/views/manage_subtitleMissedPP.mako
@@ -49,7 +49,7 @@
     </table>
 <%include file="subtitle_modal.mako"/>
 </br>
-<form name="processForm" method="post" action="home/postprocess/processEpisode" align="right">
+<form name="processForm" method="post" action="home/postprocess/processEpisode" style="float: right;">
 <table>
     <input type="hidden" id="type" name="type" value="manual">
     <input type="hidden" id="process_method" name="process_method" value=${app.PROCESS_METHOD}>

--- a/views/manage_subtitleMissedPP.mako
+++ b/views/manage_subtitleMissedPP.mako
@@ -17,7 +17,7 @@
     % endif
     </div>
 <div id="container">
-    <table id="showListTable" class="defaultTable" cellspacing="1" border="0" cellpadding="0">
+    <table id="releasesPP" class="defaultTable" cellspacing="1" border="0" cellpadding="0">
         <thead aria-live="polite" aria-relevant="all">
             <tr>
                 <th>Show</th>

--- a/views/manage_subtitleMissedPP.mako
+++ b/views/manage_subtitleMissedPP.mako
@@ -50,6 +50,7 @@
                 <tbody>
                 <tr>
                     <th>Provider/Lang</th>
+                    <th></th>
                     <th>Score</th>
                     <th>Subtitle</th>
                     <th>Missing/wrong</th>

--- a/views/manage_subtitleMissedPP.mako
+++ b/views/manage_subtitleMissedPP.mako
@@ -1,4 +1,8 @@
 <%inherit file="/layouts/main.mako"/>
+<%!
+    import medusa as app
+    import os
+%>
 <%block name="scripts">
 <script type="text/javascript" src="js/lib/jquery.bookmarkscroll.js?${sbPID}"></script>
 <script type="text/javascript" src="js/ajax-episode-subtitles.js?${sbPID}"></script>
@@ -21,10 +25,10 @@
         </thead>
         <tbody aria-live="polite" aria-relevant="all">
         % for epResult in releases_in_pp:
-            <tr class="skipped" role="row">
-                <td class="tvShow">
+            <tr class="snatched" role="row">
+                <td class="tvShow" align="left">
                     <span class="break-word">
-                        ${epResult['release']}
+                        ${os.path.relpath(epResult['release'], app.TV_DOWNLOAD_DIR)}
                     </span>
                 </td>
                 <td class="col-search">
@@ -45,12 +49,11 @@
                 <table id=subtitle_results style="width:100%">
                 <tbody>
                 <tr>
-                    <th>Provider</th>
-                    <th>Flag</th>
+                    <th>Provider/Lang</th>
                     <th>Score</th>
                     <th>Subtitle</th>
                     <th>Missing/wrong</th>
-                    <th>Download</th>
+                    <th></th>
                 </tr>
                 </tbody>
                 </table> 

--- a/views/partials/footer.mako
+++ b/views/partials/footer.mako
@@ -102,7 +102,7 @@
     <script type="text/javascript" src="js/manage/init.js?${sbPID}"></script>
     <script type="text/javascript" src="js/manage/mass-edit.js?${sbPID}"></script>
     <script type="text/javascript" src="js/manage/subtitle-missed.js?${sbPID}"></script>
-
+    <script type="text/javascript" src="js/manage/subtitle-missedPP.js?${sbPID}"></script>
     <script type="text/javascript" src="js/history/index.js?${sbPID}"></script>
 
     <script type="text/javascript" src="js/errorlogs/viewlogs.js?${sbPID}"></script>

--- a/views/partials/header.mako
+++ b/views/partials/header.mako
@@ -72,6 +72,9 @@
                     % if app.USE_SUBTITLES:
                         <li><a href="manage/subtitleMissed/"><i class="menu-icon-backlog"></i>&nbsp;Missed Subtitle Management</a></li>
                     % endif
+                    % if app.POSTPONE_IF_NO_SUBS:
+                        <li><a href="manage/subtitleMissedPP/"><i class="menu-icon-backlog"></i>&nbsp;Missed Subtitle in Post-Process folder</a></li>
+                    % endif
                     </ul>
                     <div style="clear:both;"></div>
                 </li>

--- a/views/subtitle_modal.mako
+++ b/views/subtitle_modal.mako
@@ -13,10 +13,10 @@
                     <th>Lang</th>
                     <th>Score</th>
                     <th>Subtitle</th>
-                    <th>Missing/wrong</th>
+                    <th>Missing Matches</th>
                 </tr>
                 </tbody>
-                </table> 
+                </table>
             </div>
         </div>
     </div>

--- a/views/subtitle_modal.mako
+++ b/views/subtitle_modal.mako
@@ -3,7 +3,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title"></h4>
+                <h4 id="manualSubtitleSearchModalTitle" class="modal-title"></h4>
             </div>
             <div class="modal-body">
                 <table id=subtitle_results style="width:100%">

--- a/views/subtitle_modal.mako
+++ b/views/subtitle_modal.mako
@@ -3,7 +3,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 id="manualSubtitleSearchModalTitle" class="modal-title"></h4>
+                <h4 id="manualSubtitleSearchModalTitle" class="modal-title text" style="display: inline;"></h4>
             </div>
             <div class="modal-body text">
                 <table id=subtitle_results style="width:100%">

--- a/views/subtitle_modal.mako
+++ b/views/subtitle_modal.mako
@@ -1,0 +1,24 @@
+<div id="manualSubtitleSearchModal" class="modal fade modal-wide" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title"></h4>
+            </div>
+            <div class="modal-body">
+                <table id=subtitle_results style="width:100%">
+                <tbody>
+                <tr>
+                    <th>Provider</th>
+                    <th>Lang</th>
+                    <th>Score</th>
+                    <th>Subtitle</th>
+                    <th>Missing/wrong</th>
+                    <th></th>
+                </tr>
+                </tbody>
+                </table> 
+            </div>
+        </div>
+    </div>
+</div>

--- a/views/subtitle_modal.mako
+++ b/views/subtitle_modal.mako
@@ -8,7 +8,7 @@
             <div class="modal-body text">
                 <table id=subtitle_results style="width:100%">
                 <tbody>
-                <tr>
+                <tr style="font-size: 95%;">
                     <th>Provider</th>
                     <th>Lang</th>
                     <th>Score</th>

--- a/views/subtitle_modal.mako
+++ b/views/subtitle_modal.mako
@@ -5,7 +5,7 @@
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                 <h4 id="manualSubtitleSearchModalTitle" class="modal-title"></h4>
             </div>
-            <div class="modal-body">
+            <div class="modal-body text">
                 <table id=subtitle_results style="width:100%">
                 <tbody>
                 <tr>

--- a/views/subtitle_modal.mako
+++ b/views/subtitle_modal.mako
@@ -14,7 +14,6 @@
                     <th>Score</th>
                     <th>Subtitle</th>
                     <th>Missing/wrong</th>
-                    <th></th>
                 </tr>
                 </tbody>
                 </table> 


### PR DESCRIPTION
## SQUASH PLEASE 
### How it works:

If show has no subtitles, user clicks the `CC` image, and we ask if he wants to `auto` search subs or `manual` download subs

### TODO:
- [ ] Test Test test

### Done:
- [x] Modal close button not showing in black theme
- [x] When downloading a subtitle, only add the flag to the table if user didn't had that language 
- [x] Update TVEpisode object with new subtitle downloaded
- [x] Add JS code that calls function `manual_search_subtitles` in handler
- [x] Add subliminal code that search for subtitles
- [x] Add JS that read results from `manual_search_subtitles` and populate the empty modal `manualSubtitleSearchModal` in displayShow.mako
- [x] Add some kind of button in the modal so user can pick subtitles
- [x] Some how would be nice to manual search subtitles in PP folder too (when postpone enabled)
- [x] Clear modal rows when searching for different episode
- [x] Add spinning wheel to download button
- [x] Download button should call `pick_manual_search_subtitle` with the current subtitle unique ID
- [x] The most important thing: download the picked subtitle using ID

### POC

![manual_subs_poc4](https://cloud.githubusercontent.com/assets/2620870/18749519/9b6ceef2-80ad-11e6-939a-6596cd3e01f3.png)

### THIS PR:

![ask](https://cloud.githubusercontent.com/assets/2620870/18761751/960d87e4-80dc-11e6-8059-c9067d88ccbf.png)

![ag](https://cloud.githubusercontent.com/assets/2620870/18914940/8170ce30-8565-11e6-8604-23e0b1a68a32.png)


