### PR TITLE
Fix release names being cut off for Limetorrents

### DIFF
--- a/medusa/providers/torrent/html/limetorrents.py
+++ b/medusa/providers/torrent/html/limetorrents.py
@@ -135,7 +135,7 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                     title = title_info[1].get_text(strip=True)
                     title2 = id_regex.search(info).group(1)
                     if len(title) < len(title2):
-                        title = title2.replace("-", " ")
+                        title = title2.replace('-', ' ')
                     torrent_id = id_regex.search(info).group(2)
                     torrent_hash = hash_regex.search(url['href']).group(2)
                     if not all([title, torrent_id, torrent_hash]):

--- a/medusa/providers/torrent/html/limetorrents.py
+++ b/medusa/providers/torrent/html/limetorrents.py
@@ -135,7 +135,7 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                     title = title_info[1].get_text(strip=True)
                     title2 = id_regex.search(info).group(1)
                     if len(title) < len(title2):
-                        title = title2
+                        title = title2.replace("-", " ")
                     torrent_id = id_regex.search(info).group(2)
                     torrent_hash = hash_regex.search(url['href']).group(2)
                     if not all([title, torrent_id, torrent_hash]):

--- a/medusa/providers/torrent/html/limetorrents.py
+++ b/medusa/providers/torrent/html/limetorrents.py
@@ -133,7 +133,7 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                         continue
 
                     title = id_regex.search(info).group(1)
-                    torrent_id = id_regex.search(info).group(1)
+                    torrent_id = id_regex.search(info).group(2)
                     torrent_hash = hash_regex.search(url['href']).group(2)
                     if not all([title, torrent_id, torrent_hash]):
                         continue

--- a/medusa/providers/torrent/html/limetorrents.py
+++ b/medusa/providers/torrent/html/limetorrents.py
@@ -132,7 +132,10 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                     if not all([url, title_info, info]):
                         continue
 
-                    title = id_regex.search(info).group(1)
+                    title = title_info[1].get_text(strip=True)
+                    title2 = id_regex.search(info).group(1)
+                    if len(title) < len(title2):
+                        title = title2
                     torrent_id = id_regex.search(info).group(2)
                     torrent_hash = hash_regex.search(url['href']).group(2)
                     if not all([title, torrent_id, torrent_hash]):

--- a/medusa/providers/torrent/html/limetorrents.py
+++ b/medusa/providers/torrent/html/limetorrents.py
@@ -29,7 +29,7 @@ from .... import logger, tvcache
 from ....bs4_parser import BS4Parser
 from ....helper.common import convert_size, try_int
 
-id_regex = re.compile(r'(?:torrent-([0-9]*).html)', re.I)
+id_regex = re.compile(r'(?:\/)(.*)(?:-torrent-([0-9]*).html)', re.I)
 hash_regex = re.compile(r'(.*)([0-9a-f]{40})(.*)', re.I)
 
 
@@ -132,7 +132,7 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                     if not all([url, title_info, info]):
                         continue
 
-                    title = title_info[1].get_text(strip=True)
+                    title = id_regex.search(info).group(1)
                     torrent_id = id_regex.search(info).group(1)
                     torrent_hash = hash_regex.search(url['href']).group(2)
                     if not all([title, torrent_id, torrent_hash]):


### PR DESCRIPTION
Fixes release name beeing cut off

**Previously:**
`F-ck Thats Delicious S02E02 The Other City By The Sea 720p HDTV x264-[eSc] - [SR..`
**Now:**
`F-ck-Thats-Delicious-S02E02-The-Other-City-By-The-Sea-720p-HDTV-x264-[eSc]--[SRIGGA]`

**Down side:** string now has dashes `-`
**Prevention of the "downside":** only take the "longer" release name if it's actually longer than the previous to avoid the dashes