### PR TITLE
Fix TypeError: 'NoneType' object is not iterable

### DIFF
--- a/medusa/tvcache.py
+++ b/medusa/tvcache.py
@@ -26,6 +26,7 @@ import traceback
 import medusa as app
 from six import text_type
 from . import db, logger, show_name_helpers
+from .helper.common import episode_num
 from .helper.exceptions import AuthException
 from .name_parser.parser import InvalidNameException, InvalidShowException, NameParser
 from .rssfeeds import getFeed
@@ -438,8 +439,15 @@ class TVCache(object):
                     format(self.provider_id, ','.join([str(x) for x in ep_obj.wanted_quality])),
                     [ep_obj.show.indexerid, ep_obj.season, b'%|{0}|%'.format(ep_obj.episode)]])
 
-            sql_results = cache_db_con.mass_action(cl, fetchall=True)
-            sql_results = list(itertools.chain(*sql_results))
+            if cl:
+                # Only execute the query if we have results
+                sql_results = cache_db_con.mass_action(cl, fetchall=True)
+                sql_results = list(itertools.chain(*sql_results))
+            else:
+                sql_results = []
+                logger.log("No cached results in {provider} for show id '{show_id}' episode '{ep}'".format
+                           (provider=self.provider_id, show_id=ep_obj.show.indexerid,
+                            ep=episode_num(ep_obj.season, ep_obj.episode)), logger.DEBUG)
 
         # for each cache entry
         for cur_result in sql_results:

--- a/medusa/tvcache.py
+++ b/medusa/tvcache.py
@@ -445,8 +445,8 @@ class TVCache(object):
                 sql_results = list(itertools.chain(*sql_results))
             else:
                 sql_results = []
-                logger.log("No cached results in {provider} for show id '{show_id}' episode '{ep}'".format
-                           (provider=self.provider_id, show_id=ep_obj.show.indexerid,
+                logger.log("No cached results in {provider} for show '{show_name}' episode '{ep}'".format
+                           (provider=self.provider_id, show_name=ep_obj.show.name,
                             ep=episode_num(ep_obj.season, ep_obj.episode)), logger.DEBUG)
 
         # for each cache entry


### PR DESCRIPTION
just guessing what is wrong because i can't reproduce and I can't get more info in the issue

```
2016-09-25 05:17:32 ERROR    SEARCHQUEUE-DAILY-SEARCH :: [Nutech] :: [baa22c5] Error while searching Nutech, skipping: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/home/home/SickRage/medusa/search/core.py", line 445, in searchForNeededEpisodes
    curFoundResults = cur_provider.search_rss(episodes)
  File "/home/home/SickRage/medusa/providers/GenericProvider.py", line 408, in search_rss
    return self.cache.findNeededEpisodes(episodes)
  File "/home/home/SickRage/medusa/tvcache.py", line 442, in findNeededEpisodes
    sql_results = list(itertools.chain(*sql_results))
TypeError: 'NoneType' object is not iterable
```

