### PR TITLE
custom guessit function should be loaded before subliminal and other modules that depends on it

### DIFF
--- a/medusa/__init__.py
+++ b/medusa/__init__.py
@@ -32,7 +32,7 @@ from configobj import ConfigObj
 import requests
 import shutil_custom
 from . import (
-    auto_postprocessor, db, helpers, logger, metadata, naming, providers,
+    app, auto_postprocessor, db, helpers, logger, metadata, naming, providers,
     scheduler, showUpdater, show_queue, subtitles, traktChecker, versionChecker
 )
 from .common import SD, SKIPPED, WANTED

--- a/medusa/app.py
+++ b/medusa/app.py
@@ -1,0 +1,10 @@
+# coding=utf-8
+"""First module to initialize."""
+import guessit
+
+from .name_parser.guessit_parser import guessit as pre_configured_guessit
+
+# Replace standard modules/functions by our custom ones
+
+# Replace guessit function with a pre-configured one, so guessit.guessit() could be called directly in any place.
+guessit.guessit = pre_configured_guessit

--- a/medusa/name_parser/__init__.py
+++ b/medusa/name_parser/__init__.py
@@ -1,10 +1,2 @@
 # coding=utf-8
-"""Name Parser module.
-
-Replace guessit function with a pre-configured one, so guessit.guessit() could be called directly in any place.
-"""
-import guessit
-
-from guessit_parser import guessit as pre_configured_guessit
-
-guessit.guessit = pre_configured_guessit
+"""Name Parser module."""

--- a/medusa/name_parser/guessit_parser.py
+++ b/medusa/name_parser/guessit_parser.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 
 from dogpile.cache.region import make_region
 from guessit.rules.common.date import valid_year
-import medusa as app
 from .rules import default_api
 
 
@@ -81,10 +80,11 @@ def guessit(name, options=None):
     :return: the guessed properties
     :rtype: dict
     """
+    from .. import showList
     final_options = dict(options) if options else dict()
     final_options.update(dict(type='episode', implicit=True,
                               episode_prefer_number=final_options.get('show_type') == 'anime',
-                              expected_title=get_expected_titles(app.showList),
+                              expected_title=get_expected_titles(showList),
                               expected_group=expected_groups,
                               allowed_languages=allowed_languages,
                               allowed_countries=allowed_countries))


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)
- [x] Fix: custom guessit function should be loaded before subliminal and other modules that depends on guessit